### PR TITLE
ci: Add build and publish nightly package workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,52 @@
+name: Build and push packages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/build_node_package.yml@v0.19.0'
+    with:
+      node: '[
+              {"version": "14", "tests": true, "lint": false},
+              {"version": "16", "tests": true, "lint": false},
+              {"version": "18", "tests": true, "lint": true},
+              {"version": "20", "tests": true, "lint": true},
+            ]'
+
+  publish:
+    needs: build
+    if: |
+      ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
+      ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.19.0'
+    with:
+      package_name: nr-assistant
+      publish_package: true
+    secrets:
+      npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+  dispatch_nr_launcher:
+    name: Dispatch nr-launcher package build
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_APP_KEY }}
+      - name: Trigger nr-launcher package build
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: publish.yml
+          repo: flowfuse/nr-launcher
+          ref: main
+          token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
## Description

This pull request introduces the "Build and push package" responsible for building and pushing `nr-assistant` package to node registry tagged as `nightly`.

## Related Issue(s)

https://github.com/FlowFuse/nr-assistant/issues/6

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

