### PR TITLE
Improved messaging for error responses

### DIFF
--- a/index.html
+++ b/index.html
@@ -730,6 +730,42 @@
 
         function processAIErrorResponse (jqXHR, textStatus, errorThrown) {
             console.warn('error', jqXHR, textStatus, errorThrown)
+            if (jqXHR.status === 429) {
+                // get x- rate limit reset header
+                const reset = jqXHR.getResponseHeader('x-ratelimit-reset')
+                if (reset) {
+                    const resetTime = new Date(reset * 1000)
+                    const now = new Date()
+                    const diff = resetTime - now
+                    const seconds = Math.floor(diff / 1000)
+                    const minutes = Math.floor(seconds / 60)
+                    const remainingSeconds = seconds % 60
+                    if (minutes > 0) {
+                        RED.notify(`Sorry, the FlowFuse Assistant is busy. Please try again in ${minutes} minute${minutes > 1 ? 's' : ''}.`, 'warning')
+                    } else {
+                        RED.notify(`Sorry, the FlowFuse Assistant is busy. Please try again in ${remainingSeconds} second${remainingSeconds > 1 ? 's' : ''}.`, 'warning')
+                    }
+                    return
+                }
+                RED.notify('Sorry, the FlowFuse Assistant is busy. Please try again later.', 'warning')
+                return
+            }
+            if (jqXHR.status === 404) {
+                RED.notify('Sorry, the FlowFuse Assistant is not available at the moment', 'warning')
+                return
+            }
+            if (jqXHR.status === 401) {
+                RED.notify('Sorry, you are not authorised to use the FlowFuse Assistant', 'warning')
+                return
+            }
+            if (jqXHR.status >= 400 && jqXHR.status < 500) {
+                let message = 'Sorry, the FlowFuse Assistant cannot help with this request'
+                if (jqXHR.responseJSON?.body?.code === 'assistant_service_denied' && jqXHR.responseJSON?.body?.error) {
+                    message = jqXHR.responseJSON.body.error
+                }
+                RED.notify(message, 'warning')
+                return
+            }
             RED.notify('Sorry, something went wrong, please try again', 'error')
         }
 

--- a/index.js
+++ b/index.js
@@ -63,11 +63,23 @@ module.exports = (RED) => {
                         data
                     })
                 }).catch((error) => {
-                    const errorData = { status: 'error', message: 'Request to FlowFuse Assistant was unsuccessful', body: error.response?.body }
+                    let body = error.response?.body
+                    if (typeof body === 'string') {
+                        try {
+                            body = JSON.parse(body)
+                        } catch (e) {
+                            // ignore
+                        }
+                    }
+                    let message = 'FlowFuse Assistant request was unsuccessful'
+                    const errorData = { status: 'error', message, body }
                     const errorCode = error.response?.statusCode || 500
-                    res.status(errorCode).json({ status: 'error', message: errorData })
-                    console.warn('nr-assistant error:', error)
-                    RED.log.warn('FlowFuse Assistant request was unsuccessful')
+                    res.status(errorCode).json(errorData)
+                    RED.log.trace('nr-assistant error:', error)
+                    if (body && typeof body === 'object' && body.error) {
+                        message = `${message}: ${body.error}`
+                    }
+                    RED.log.warn(message)
                 })
             })
         }


### PR DESCRIPTION
closes #23

## Description
Improve messaging and notifications for 4xx errors
Permit custom notification text for 403 errors when the body code is "assistant_service_denied" - for feeding back info like "Trial expired"



## Related Issue(s)

#23
https://github.com/FlowFuse/security/issues/92

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

