### PR TITLE
Add codelens for CSS and DB2 ui-template

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,8 @@
 
             const funcCommandId = 'nr-assistant-fn-inline'
             const jsonCommandId = 'nr-assistant-json-inline'
+            const cssCommandId = 'nr-assistant-css-inline'
+            const db2uiTemplateCommandId = 'nr-assistant-html-dashboard2-template-inline'
 
             debug('registering code lens providers...')
 
@@ -169,6 +171,87 @@
                         id: codeLens.id,
                         title: 'Ask the FlowFuse Assistant 🪄',
                         tooltip: 'Click to ask FlowFuse Assistant for help with JSON',
+                        arguments: [model, codeLens, token]
+                    }
+                    return codeLens
+                }
+            })
+
+            monaco.languages.registerCodeLensProvider('css', {
+                provideCodeLenses: function (model, token) {
+                    debug('CSS CodeLens provider called', model, token)
+                    const thisEditor = getMonacoEditorForModel(model)
+                    const node = RED.view.selection()?.nodes?.[0]
+                    if (!thisEditor || !node) {
+                        return
+                    }
+
+                    return {
+                        lenses: [
+                            {
+                                range: {
+                                    startLineNumber: 1,
+                                    startColumn: 1,
+                                    endLineNumber: 2,
+                                    endColumn: 1
+                                },
+                                id: cssCommandId
+                            }
+                        ],
+                        dispose: () => { }
+                    }
+                },
+                resolveCodeLens: function (model, codeLens, token) {
+                    debug('CSS CodeLens resolve called', model, codeLens, token)
+                    if (codeLens.id !== cssCommandId) {
+                        return codeLens
+                    }
+                    codeLens.command = {
+                        id: codeLens.id,
+                        title: 'Ask the FlowFuse Assistant 🪄',
+                        tooltip: 'Click to ask FlowFuse Assistant for help with CSS',
+                        arguments: [model, codeLens, token]
+                    }
+                    return codeLens
+                }
+            })
+
+            monaco.languages.registerCodeLensProvider('html', {
+                provideCodeLenses: function (model, token) {
+                    debug('HTML CodeLens provider called', model, token)
+                    const thisEditor = getMonacoEditorForModel(model)
+                    if (!thisEditor) {
+                        return
+                    }
+                    const node = RED.view.selection()?.nodes?.[0]
+                    // only support dashboard2 ui-template nodes for now
+                    if (!node || node.type !== 'ui-template' || node._def?.set?.id !== '@flowfuse/node-red-dashboard/ui-template') {
+                        return
+                    }
+                    return {
+                        lenses: [
+                            {
+                                range: {
+                                    startLineNumber: 1,
+                                    startColumn: 1,
+                                    endLineNumber: 2,
+                                    endColumn: 1
+                                },
+                                id: db2uiTemplateCommandId
+                            }
+                        ],
+                        dispose: () => { }
+                    }
+                },
+                resolveCodeLens: function (model, codeLens, token) {
+                    debug('HTML CodeLens resolve called', model, codeLens, token)
+                    if (codeLens.id !== db2uiTemplateCommandId) {
+                        return codeLens
+                    }
+                    codeLens.command = {
+                        id: codeLens.id,
+                        title: 'Ask the FlowFuse Assistant 🪄',
+                        tooltip: 'Click to ask FlowFuse Assistant for help with VUE or HTML',
                         arguments: [model, codeLens, token]
                     }
                     return codeLens
@@ -359,6 +442,130 @@
                                 {
                                     range: new monaco.Range(currentSelection.startLineNumber, currentSelection.startColumn, currentSelection.endLineNumber, currentSelection.endColumn),
                                     text: responseData.json
+                                }
+                            ])
+                        }
+                    })
+                } else {
+                    console.warn('Could not find editor for model', model.uri.toString())
+                }
+            })
+
+            monaco.editor.registerCommand(cssCommandId, function (accessor, model, codeLens, token) {
+                debug('running command', cssCommandId)
+                const node = RED.view.selection()?.nodes?.[0]
+                if (!node) {
+                    console.warn('No node selected') // should not happen
+                    return
+                }
+                if (!assistantOptions.enabled) {
+                    RED.notify(plugin._('errors.assistant-not-enabled'), 'warning')
+                    return
+                }
+                const thisEditor = getMonacoEditorForModel(model)
+                if (thisEditor) {
+                    if (!document.body.contains(thisEditor.getDomNode())) {
+                        console.warn('Editor is no longer in the DOM, cannot proceed.')
+                        return
+                    }
+
+                    // FUTURE: for including selected text in the context for features like "fix my code", "refactor this", "what is this?" etc
+                    // const userSelection = triggeredEditor.getSelection()
+                    // const selectedText = model.getValueInRange(userSelection)
+                    /** @type {PromptOptions} */
+                    const promptOptions = {
+                        method: 'css',
+                        lang: 'css',
+                        type: node.type
+                        // selectedText: model.getValueInRange(userSelection)
+                    }
+                    /** @type {PromptUIOptions} */
+                    const uiOptions = {
+                        title: 'FlowFuse Assistant : CSS',
+                        explanation: 'The FlowFuse Assistant can help you write CSS.',
+                        description: 'Enter a short description of what you want it to do.'
+                    }
+                    doPrompt(node, thisEditor, promptOptions, uiOptions, (error, response) => {
+                        if (error) {
+                            console.warn('Error processing request', error)
+                            return
+                        }
+                        debug('css response', response)
+                        const responseData = response?.data
+                        if (responseData && responseData.css) {
+                            // ensure the editor is still present in the DOM
+                            if (!document.body.contains(thisEditor.getDomNode())) {
+                                console.warn('Editor is no longer in the DOM')
+                                return
+                            }
+                            thisEditor.focus()
+                            const currentSelection = thisEditor.getSelection()
+                            thisEditor.executeEdits('', [
+                                {
+                                    range: new monaco.Range(currentSelection.startLineNumber, currentSelection.startColumn, currentSelection.endLineNumber, currentSelection.endColumn),
+                                    text: responseData.css
+                                }
+                            ])
+                        }
+                    })
+                } else {
+                    console.warn('Could not find editor for model', model.uri.toString())
+                }
+            })
+
+            monaco.editor.registerCommand(db2uiTemplateCommandId, function (accessor, model, codeLens, token) {
+                debug('running command', db2uiTemplateCommandId)
+                const node = RED.view.selection()?.nodes?.[0]
+                if (!node) {
+                    console.warn('No node selected') // should not happen
+                    return
+                }
+                if (!assistantOptions.enabled) {
+                    RED.notify(plugin._('errors.assistant-not-enabled'), 'warning')
+                    return
+                }
+                const thisEditor = getMonacoEditorForModel(model)
+                if (thisEditor) {
+                    if (!document.body.contains(thisEditor.getDomNode())) {
+                        console.warn('Editor is no longer in the DOM, cannot proceed.')
+                        return
+                    }
+
+                    // FUTURE: for including selected text in the context for features like "fix my code", "refactor this", "what is this?" etc
+                    // const userSelection = triggeredEditor.getSelection()
+                    // const selectedText = model.getValueInRange(userSelection)
+                    /** @type {PromptOptions} */
+                    const promptOptions = {
+                        method: 'dashboard2-template',
+                        lang: 'html',
+                        type: node.type
+                        // selectedText: model.getValueInRange(userSelection)
+                    }
+                    /** @type {PromptUIOptions} */
+                    const uiOptions = {
+                        title: 'FlowFuse Assistant : Dashboard 2 UI Template',
+                        explanation: 'The FlowFuse Assistant can help you write HTML, VUE and JavaScript.',
+                        description: 'Enter a short description of what you want it to do.'
+                    }
+                    doPrompt(node, thisEditor, promptOptions, uiOptions, (error, response) => {
+                        if (error) {
+                            console.warn('Error processing request', error)
+                            return
+                        }
+                        debug('html response', response)
+                        const responseData = response?.data
+                        if (responseData && responseData.html) {
+                            // ensure the editor is still present in the DOM
+                            if (!document.body.contains(thisEditor.getDomNode())) {
+                                console.warn('Editor is no longer in the DOM')
+                                return
+                            }
+                            thisEditor.focus()
+                            const currentSelection = thisEditor.getSelection()
+                            thisEditor.executeEdits('', [
+                                {
+                                    range: new monaco.Range(currentSelection.startLineNumber, currentSelection.startColumn, currentSelection.endLineNumber, currentSelection.endColumn),
+                                    text: responseData.html
                                 }
                             ])
                         }

--- a/index.html
+++ b/index.html
@@ -832,45 +832,89 @@
         }
 
         /**
-         * Show a dialog with the given title and content
+         * Show a dialog with the given title and content.
+         * * NOTE: Only basic sanitization is performed. Call RED.utils.renderMarkdown or RED.utils.sanitize before passing it in.
          * @param {string} title - The title of the dialog
          * @param {string} content - The content of the dialog, can be HTML
-         * @param {object} [options] - Options for the dialog
+         * @param {'text'|'html'} [renderMode='text'] - Whether the content is HTML or plain text.
+         * @param {object} [options] - jQuery UI Options for the dialog
          */
-        function showMessage (title, content, options) {
-            options = options || {}
-            const className = options.dialogClass || 'ff-nr-ai-dialog-message'
-            const dialog = $('<div></div>').css({ overflow: 'auto' }).html(content)
-            let height = options.height || 380
-            let width = options.width || $('#red-ui-notifications').width() || 500
-            // ensure the dialog is not more than 90% of the viewport height and width
-            if (height > $(window).height() * 0.9) {
-                height = $(window).height() * 0.9
+        function showMessage (title, content, renderMode = 'text', options = {}) {
+            const window70vw = $(window).width() * 0.70 // 70% of viewport width
+            const window70vh = $(window).height() * 0.70 // 70% of viewport height
+
+            // super basic sanitisation for xss in content
+            if (typeof content !== 'string' || content.length === 0) {
+                console.warn('Content must be a string')
+                return
+            } else if (renderMode === 'html' && (content.includes('<script>') || content.includes('<' + '/script>'))) {
+                content = content.replace(/<script>/g, '```\n').replace(/<\/script>/g, '```') // basic sanitization
             }
-            if (width > $(window).width() * 0.9) {
-                width = $(window).width() * 0.9
+
+            // First some basic sizing calculations to ensure the dialog is not too small/large
+            let initialMaxWidth = $('#red-ui-notifications').width() || 500 // start off with 500px as the initial maxWidth
+            if (content.length > 3000) {
+                initialMaxWidth = 1000
+            } else if (content.length > 2000) {
+                initialMaxWidth = 850
+            } else if (content.length > 1500) {
+                initialMaxWidth = 700
+            } else if (content.length > 750) {
+                initialMaxWidth = 600
             }
-            const $dialog = dialog.dialog({
-                ...options,
-                title,
-                dialogClass: className,
-                height,
+
+            // Now render the content as HTML so later we can gauge its size and dynamically adjust to keep it reasonable
+            const $dialog = $('<div>')
+            $dialog.css({
+                overflow: 'auto',
+                height: 'auto',
+                width: 'auto',
+                minHeight: 200,
+                maxHeight: window70vh,
+                minWidth: window.innerWidth > 500 ? 500 : initialMaxWidth < window70vw ? initialMaxWidth : window70vw, // minimum width of 500px if possible
+                maxWidth: initialMaxWidth,
+                display: 'none' // initially hidden
+            })
+            if (renderMode === 'html') {
+                $dialog.html(content) // render as HTML
+            } else {
+                $dialog.text(content) // render as plain text
+            }
+            $dialog.appendTo('body')
+
+            const initialWidth = $dialog.width()
+            const width = initialWidth > window70vw ? window70vw : initialWidth
+            const initialHeight = $dialog.height() + 30 // +30 for padding/grace etc
+            const height = initialHeight > window70vh ? window70vh : initialHeight
+
+            // now remove the divs min/max so that it sizes to the maximum size of the jquery dialog
+            $dialog.css({ maxWidth: '', minWidth: '', maxHeight: '', minHeight: '' })
+
+            // set the default dialog options
+            const defaultOptions = {
+                title: title + ' (content length:' + content.length + ')',
+                modal: true,
+                resizable: true,
                 width,
-                modal: options.modal ?? true,
-                resizable: options.resizable ?? true,
-                draggable: options.draggable ?? true,
-                closeOnEscape: options.closeOnEscape ?? true,
+                height,
+                dialogClass: 'ff-nr-ai-dialog-message',
+                closeOnEscape: true,
+                draggable: true,
+                minHeight: 280,
+                minWidth: window.innerWidth > 500 ? 500 : window.innerWidth, // minimum width of 500px if possible
                 show: { effect: 'fade', duration: 300 },
                 hide: { effect: 'fade', duration: 300 },
-                open: function (event, ui) {
+                open: function () {
                     RED.keyboard.disable()
                 },
                 close: function () {
                     RED.keyboard.enable()
-                    $dialog.remove()
+                    $(this).dialog('destroy').remove() // clean up
                 }
-            })
-            return $dialog
+            }
+
+            // create the dialog with any additional options passed in & return it for later programmatic control
+            return $dialog.dialog($.extend({}, defaultOptions, options))
         }
 
         function explainSelectedNodes () {
@@ -929,7 +973,7 @@
 
                     try {
                         const text = reply.data || 'No reply from server'
-                        showMessage(plugin._('explain-flows.dialog-result.title'), RED.utils.renderMarkdown(text), {})
+                        showMessage(plugin._('explain-flows.dialog-result.title'), RED.utils.renderMarkdown(text), 'html', {})
                     } catch (error) {
                         console.warn('Error rendering reply', error)
                         showNotification('Sorry, something went wrong, please try again', { type: 'error' })


### PR DESCRIPTION
## Description

* Adds a codelens for CSS mode and and HTML (db2 flavour only) mode editors

![chrome_1SRc168t0p](https://github.com/user-attachments/assets/40b6ad55-9bf2-43e0-87d8-2bd49ef78d6b)



### TODO: Decide if we want to introduce a "supported features" endpoint in the backend that permits/prevents features being enabled for users (so we can enable (or disable) these at some future point?)

## Related Issue(s)

#55

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

