### PR TITLE
Add tables codelens feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
             const jsonCommandId = 'nr-assistant-json-inline'
             const cssCommandId = 'nr-assistant-css-inline'
             const db2uiTemplateCommandId = 'nr-assistant-html-dashboard2-template-inline'
+            const ffTablesNodeCommandId = 'nr-assistant-ff-tables-node-inline'
 
             debug('registering code lens providers...')
 
@@ -260,6 +261,48 @@
                         id: codeLens.id,
                         title: 'Ask the FlowFuse Assistant 🪄',
                         tooltip: 'Click to ask FlowFuse Assistant for help with VUE or HTML',
+                        arguments: [model, codeLens, token]
+                    }
+                    return codeLens
+                }
+            })
+
+            assistantOptions.tablesEnabled && monaco.languages.registerCodeLensProvider('sql', {
+                provideCodeLenses: function (model, token) {
+                    debug('SQL CodeLens provider called', model, token)
+                    const thisEditor = getMonacoEditorForModel(model)
+                    if (!thisEditor) {
+                        return
+                    }
+                    const node = RED.view.selection()?.nodes?.[0]
+                    // only support tables query nodes for now
+                    if (!node || node.type !== 'tables-query' || node._def?.set?.id !== '@flowfuse/nr-tables-nodes/tables-query') {
+                        return
+                    }
+                    return {
+                        lenses: [
+                            {
+                                range: {
+                                    startLineNumber: 1,
+                                    startColumn: 1,
+                                    endLineNumber: 2,
+                                    endColumn: 1
+                                },
+                                id: ffTablesNodeCommandId
+                            }
+                        ],
+                        dispose: () => { }
+                    }
+                },
+                resolveCodeLens: function (model, codeLens, token) {
+                    debug('SQL CodeLens resolve called', model, codeLens, token)
+                    if (codeLens.id !== ffTablesNodeCommandId) {
+                        return codeLens
+                    }
+                    codeLens.command = {
+                        id: codeLens.id,
+                        title: 'Ask the FlowFuse Assistant 🪄',
+                        tooltip: 'Click to ask FlowFuse Assistant for help with PostgreSQL',
                         arguments: [model, codeLens, token]
                     }
                     return codeLens
@@ -574,6 +617,69 @@
                                 {
                                     range: new monaco.Range(currentSelection.startLineNumber, currentSelection.startColumn, currentSelection.endLineNumber, currentSelection.endColumn),
                                     text: responseData.html
+                                }
+                            ])
+                        }
+                    })
+                } else {
+                    console.warn('Could not find editor for model', model.uri.toString())
+                }
+            })
+
+            assistantOptions.tablesEnabled && monaco.editor.registerCommand(ffTablesNodeCommandId, function (accessor, model, codeLens, token) {
+                debug('running command', ffTablesNodeCommandId)
+                const node = RED.view.selection()?.nodes?.[0]
+                if (!node) {
+                    console.warn('No node selected') // should not happen
+                    return
+                }
+                if (!assistantOptions.enabled) {
+                    RED.notify(plugin._('errors.assistant-not-enabled'), 'warning')
+                    return
+                }
+                const thisEditor = getMonacoEditorForModel(model)
+                if (thisEditor) {
+                    if (!document.body.contains(thisEditor.getDomNode())) {
+                        console.warn('Editor is no longer in the DOM, cannot proceed.')
+                        return
+                    }
+
+                    // FUTURE: for including selected text in the context for features like "fix my code", "refactor this", "what is this?" etc
+                    // const userSelection = triggeredEditor.getSelection()
+                    // const selectedText = model.getValueInRange(userSelection)
+                    /** @type {PromptOptions} */
+                    const promptOptions = {
+                        method: 'flowfuse-tables-query',
+                        lang: 'sql',
+                        dialect: 'g',
+                        type: node.type
+                        // selectedText: model.getValueInRange(userSelection)
+                    }
+                    /** @type {PromptUIOptions} */
+                    const uiOptions = {
+                        title: 'FlowFuse Assistant : FlowFuse Query',
+                        explanation: 'The FlowFuse Assistant can help you write SQL queries.',
+                        description: 'Enter a short description of what you want it to do.'
+                    }
+                    doPrompt(node, thisEditor, promptOptions, uiOptions, (error, response) => {
+                        if (error) {
+                            console.warn('Error processing request', error)
+                            return
+                        }
+                        debug('sql response', response)
+                        const responseData = response?.data
+                        if (responseData && responseData.sql) {
+                            // ensure the editor is still present in the DOM
+                            if (!document.body.contains(thisEditor.getDomNode())) {
+                                console.warn('Editor is no longer in the DOM')
+                                return
+                            }
+                            thisEditor.focus()
+                            const currentSelection = thisEditor.getSelection()
+                            thisEditor.executeEdits('', [
+                                {
+                                    range: new monaco.Range(currentSelection.startLineNumber, currentSelection.startColumn, currentSelection.endLineNumber, currentSelection.endColumn),
+                                    text: responseData.sql
                                 }
                             ])
                         }

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
         const modulesAllowed = RED.settings.functionExternalModules !== false
         const assistantOptions = {
             enabled: false,
+            tablesEnabled: false,
             requestTimeout: AI_TIMEOUT
         }
         let assistantInitialised = false
@@ -42,6 +43,7 @@
                     if (topic === 'nr-assistant/initialise') {
                         assistantOptions.enabled = !!msg?.enabled
                         assistantOptions.requestTimeout = msg?.requestTimeout || AI_TIMEOUT
+                        assistantOptions.tablesEnabled = msg?.tablesEnabled === true
                         initAssistant(msg)
                         RED.actions.add('flowfuse-nr-assistant:function-builder', showFunctionBuilderPrompt, { label: '@flowfuse/nr-assistant/flowfuse-nr-assistant:function-builder.action.label' })
                         setMenuShortcutKey('ff-assistant-function-builder', 'red-ui-workspace', 'ctrl-alt-f', 'flowfuse-nr-assistant:function-builder')
@@ -69,7 +71,7 @@
         }
         RED.plugins.registerPlugin('flowfuse-nr-assistant', plugin)
 
-        function initAssistant () {
+        function initAssistant (options) {
             if (assistantInitialised) {
                 return
             }

--- a/lib/assistant.js
+++ b/lib/assistant.js
@@ -70,7 +70,7 @@ class Assistant {
             await this.dispose() // Dispose of any existing instance before initializing a new one
             this.RED = RED
             this.options = options || {}
-            this.got = this.options.got || require('got') // got can me passed in for testing purposes
+            this.got = this.options.got || require('got') // got can be passed in for testing purposes
 
             if (!this.options.enabled) {
                 RED.log.info('FlowFuse Assistant Plugin is not enabled')

--- a/lib/assistant.js
+++ b/lib/assistant.js
@@ -88,6 +88,7 @@ class Assistant {
 
             const clientSettings = {
                 enabled: this.options.enabled !== false && !!this.options.url,
+                tablesEnabled: this.options.tables?.enabled === true,
                 requestTimeout: this.options.requestTimeout || 60000
             }
             RED.comms.publish('nr-assistant/initialise', clientSettings, true /* retain */)

--- a/lib/assistant.js
+++ b/lib/assistant.js
@@ -6,20 +6,12 @@ const { getLongestUpstreamPath } = require('./flowGraph')
 const { hasProperty } = require('./utils')
 const semver = require('semver')
 
-const FF_ASSISTANT_USER_AGENT = 'FlowFuse Assistant Plugin/' + require('../package.json').version
-
+// import typedef AssistantSettings
 /**
- * @typedef {Object} AssistantSettings
- * @property {boolean} enabled - Whether the Assistant is enabled
- * @property {number} requestTimeout - The timeout for requests to the Assistant backend in milliseconds
- * @property {string} url - The URL of the Assistant server
- * @property {string} token - The authentication token for the Assistant server
- * @property {Object} [got] - The got instance to use for HTTP requests
- * @property {Object} completions - Settings for completions
- * @property {string} completions.modelUrl - The URL to the ML model
- * @property {string} completions.vocabularyUrl - The URL to the completions vocabulary lookup data
+ * @typedef {import('./settings.js').AssistantSettings} AssistantSettings
  */
 
+const FF_ASSISTANT_USER_AGENT = 'FlowFuse Assistant Plugin/' + require('../package.json').version
 class Assistant {
     constructor () {
         // Main properties

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,4 +1,23 @@
+/**
+ * @typedef {Object} AssistantSettings
+ * @property {boolean} enabled - Whether the Assistant is enabled
+ * @property {number} requestTimeout - The timeout for requests to the Assistant backend in milliseconds
+ * @property {string} url - The URL of the Assistant server
+ * @property {string} token - The authentication token for the Assistant server
+ * @property {Object} [got] - The got instance to use for HTTP requests
+ * @property {Object} completions - Settings for completions
+ * @property {string} completions.modelUrl - The URL to the ML model
+ * @property {string} completions.vocabularyUrl - The URL to the completions vocabulary lookup data
+ * @property {Object} tables - Settings for tables
+ * @property {Boolean} tables.enabled - Whether the tables feature is enabled
+ */
+
 module.exports = {
+    /**
+     * Get the Assistant settings from the RED instance.
+     * @param {Object} RED - The RED instance
+     * @returns {AssistantSettings} - The Assistant settings
+     */
     getSettings: (RED) => {
         const assistantSettings = (RED.settings.flowforge && RED.settings.flowforge.assistant) || {}
         if (assistantSettings.enabled !== true) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -32,6 +32,9 @@ module.exports = {
             modelUrl: null,
             vocabularyUrl: null
         }
+        assistantSettings.tables = {
+            enabled: !!(RED.settings.flowforge?.tables?.token) // for MVP, use the presence of a token is an indicator that tables are enabled
+        }
         return assistantSettings
     }
 }

--- a/test/unit/lib/assistant.test.js
+++ b/test/unit/lib/assistant.test.js
@@ -31,6 +31,9 @@ const RED = {
     },
     settings: {
         flowforge: {
+            tables: {
+                token: 'test-token'
+            },
             assistant: {
                 enabled: true,
                 url: 'http://localhost:8080/assistant',
@@ -198,12 +201,14 @@ describe('assistant', () => {
         RED.comms.publish.firstCall.args[0].should.equal('nr-assistant/initialise')
         RED.comms.publish.firstCall.args[1].should.eql({
             enabled: true,
+            tablesEnabled: false,
             requestTimeout: 60000
         })
 
         RED.comms.publish.secondCall.args[0].should.equal('nr-assistant/mcp/ready')
         RED.comms.publish.secondCall.args[1].should.eql({
             enabled: true,
+            tablesEnabled: false,
             requestTimeout: 60000
         })
 

--- a/test/unit/settings.test.js
+++ b/test/unit/settings.test.js
@@ -1,0 +1,64 @@
+/// <reference types="should" />
+'use strict'
+
+const should = require('should')
+const settings = require('../../lib/settings')
+
+describe('assistant settings.getSettings', function () {
+    let RED
+
+    beforeEach(function () {
+        RED = { settings: { flowforge: {} } }
+    })
+
+    it('should be disabled if assistant is not enabled', function () {
+        RED.settings.flowforge.assistant = { enabled: false }
+        const result = settings.getSettings(RED)
+        result.enabled.should.be.false()
+    })
+
+    it('should be enabled with defaults', function () {
+        RED.settings.flowforge.assistant = { enabled: true }
+        const result = settings.getSettings(RED)
+        result.enabled.should.be.true()
+        result.completions.should.be.an.Object()
+        result.completions.enabled.should.be.true()
+        should(result.completions.modelUrl).be.null()
+        should(result.completions.vocabularyUrl).be.null()
+    })
+
+    it('should preserve completions if provided and enabled', function () {
+        RED.settings.flowforge.assistant = {
+            enabled: true,
+            completions: {
+                enabled: false,
+                modelUrl: 'http://model',
+                vocabularyUrl: 'http://vocab'
+            }
+        }
+        const result = settings.getSettings(RED)
+        result.completions.enabled.should.be.false()
+        result.completions.modelUrl.should.equal('http://model')
+        result.completions.vocabularyUrl.should.equal('http://vocab')
+    })
+
+    it('should set tables.enabled true if tables token exists', function () {
+        RED.settings.flowforge.tables = { token: 'abc' }
+        RED.settings.flowforge.assistant = { enabled: true }
+        const result = settings.getSettings(RED)
+        result.tables.enabled.should.be.true()
+    })
+
+    it('should set mcp.enabled true by default', function () {
+        RED.settings.flowforge.assistant = { enabled: true }
+        const result = settings.getSettings(RED)
+        result.mcp.should.be.an.Object()
+        result.mcp.enabled.should.be.true()
+    })
+
+    it('should not throw if flowforge or assistant is missing', function () {
+        RED = { settings: {} }
+        const result = settings.getSettings(RED)
+        result.enabled.should.be.false()
+    })
+})

--- a/test/unit/settings.test.js
+++ b/test/unit/settings.test.js
@@ -4,61 +4,63 @@
 const should = require('should')
 const settings = require('../../lib/settings')
 
-describe('assistant settings.getSettings', function () {
+describe('settings', function () {
     let RED
 
     beforeEach(function () {
         RED = { settings: { flowforge: {} } }
     })
 
-    it('should be disabled if assistant is not enabled', function () {
-        RED.settings.flowforge.assistant = { enabled: false }
-        const result = settings.getSettings(RED)
-        result.enabled.should.be.false()
-    })
+    describe('getSettings', function () {
+        it('should be disabled if assistant is not enabled', function () {
+            RED.settings.flowforge.assistant = { enabled: false }
+            const result = settings.getSettings(RED)
+            result.enabled.should.be.false()
+        })
 
-    it('should be enabled with defaults', function () {
-        RED.settings.flowforge.assistant = { enabled: true }
-        const result = settings.getSettings(RED)
-        result.enabled.should.be.true()
-        result.completions.should.be.an.Object()
-        result.completions.enabled.should.be.true()
-        should(result.completions.modelUrl).be.null()
-        should(result.completions.vocabularyUrl).be.null()
-    })
+        it('should be enabled with defaults', function () {
+            RED.settings.flowforge.assistant = { enabled: true }
+            const result = settings.getSettings(RED)
+            result.enabled.should.be.true()
+            result.completions.should.be.an.Object()
+            result.completions.enabled.should.be.true()
+            should(result.completions.modelUrl).be.null()
+            should(result.completions.vocabularyUrl).be.null()
+        })
 
-    it('should preserve completions if provided and enabled', function () {
-        RED.settings.flowforge.assistant = {
-            enabled: true,
-            completions: {
-                enabled: false,
-                modelUrl: 'http://model',
-                vocabularyUrl: 'http://vocab'
+        it('should preserve completions if provided and enabled', function () {
+            RED.settings.flowforge.assistant = {
+                enabled: true,
+                completions: {
+                    enabled: false,
+                    modelUrl: 'http://model',
+                    vocabularyUrl: 'http://vocab'
+                }
             }
-        }
-        const result = settings.getSettings(RED)
-        result.completions.enabled.should.be.false()
-        result.completions.modelUrl.should.equal('http://model')
-        result.completions.vocabularyUrl.should.equal('http://vocab')
-    })
+            const result = settings.getSettings(RED)
+            result.completions.enabled.should.be.false()
+            result.completions.modelUrl.should.equal('http://model')
+            result.completions.vocabularyUrl.should.equal('http://vocab')
+        })
 
-    it('should set tables.enabled true if tables token exists', function () {
-        RED.settings.flowforge.tables = { token: 'abc' }
-        RED.settings.flowforge.assistant = { enabled: true }
-        const result = settings.getSettings(RED)
-        result.tables.enabled.should.be.true()
-    })
+        it('should set tables.enabled true if tables token exists', function () {
+            RED.settings.flowforge.tables = { token: 'abc' }
+            RED.settings.flowforge.assistant = { enabled: true }
+            const result = settings.getSettings(RED)
+            result.tables.enabled.should.be.true()
+        })
 
-    it('should set mcp.enabled true by default', function () {
-        RED.settings.flowforge.assistant = { enabled: true }
-        const result = settings.getSettings(RED)
-        result.mcp.should.be.an.Object()
-        result.mcp.enabled.should.be.true()
-    })
+        it('should set mcp.enabled true by default', function () {
+            RED.settings.flowforge.assistant = { enabled: true }
+            const result = settings.getSettings(RED)
+            result.mcp.should.be.an.Object()
+            result.mcp.enabled.should.be.true()
+        })
 
-    it('should not throw if flowforge or assistant is missing', function () {
-        RED = { settings: {} }
-        const result = settings.getSettings(RED)
-        result.enabled.should.be.false()
+        it('should not throw if flowforge or assistant is missing', function () {
+            RED = { settings: {} }
+            const result = settings.getSettings(RED)
+            result.enabled.should.be.false()
+        })
     })
 })


### PR DESCRIPTION
## Description

* Adds setting for `tablesEnabled`
   * MVP - this is picked up by the presence of settings `flowforge.tables.token`
* Adds codelens for `SQL` type but limits its operation to `nr-tables-nodes` `query` node
* tests (see below)

### update tests
```
  assistant
    ✔ should initialize with valid default settings
```

### new tests
```
  settings
    getSettings
      ✔ should be disabled if assistant is not enabled
      ✔ should be enabled with defaults
      ✔ should preserve completions if provided and enabled
      ✔ should set tables.enabled true if tables token exists
      ✔ should set mcp.enabled true by default
      ✔ should not throw if flowforge or assistant is missing
```


## Related Issue(s)

closes #71

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

