### PR TITLE
Fix relative script source path

### DIFF
--- a/completions.html
+++ b/completions.html
@@ -1,4 +1,4 @@
-<script src="/resources/@flowfuse/nr-assistant/sharedUtils.js"></script>
+<script src="resources/@flowfuse/nr-assistant/sharedUtils.js"></script>
 <script>
     /* global FFAssistantUtils */ /* loaded from sharedUtils.js */
     /* global RED, $ */ /* loaded from Node-RED core */

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<script src="/resources/@flowfuse/nr-assistant/sharedUtils.js"></script>
+<script src="resources/@flowfuse/nr-assistant/sharedUtils.js"></script>
 <script>
     /* global FFAssistantUtils */ /* loaded from sharedUtils.js */
     /* global RED, $ */ /* loaded from Node-RED core */


### PR DESCRIPTION
## Description

Shared routines in a resource file are not loaded on a device due to devices using a sub-path URL /device-editor/

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

