### PR TITLE
Improve discoverability of supported features

### DIFF
--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -253,8 +253,8 @@
                         continue // nodeRedEvent already registered
                     }
                     this.nodeRedEventsMap[nodeRedEvent] = callBackName
-                    this.RED.events.on(key, (eventData) => {
-                        this.postReply({ type: callBackName, eventMapping, eventData }, event)
+                    this.RED.events.on(nodeRedEvent, (eventData) => {
+                        this.postParent({ type: callBackName, eventMapping, eventData })
                     })
                 }
             }


### PR DESCRIPTION
## Description

This pull request enhances the communication protocol between the FlowFuse Expert and the Node-RED Assistant, primarily by expanding the set of supported events and actions, introducing a comprehensive feature discovery mechanism, and improving test coverage for new behaviors. The changes make it easier for the Expert to determine the Assistant's capabilities and to programmatically control UI elements like search and action lists.

Key changes include:

**Feature Discovery and Initialization:**
* Added a `features` object that enumerates all supported commands, actions, registered events, and core capabilities (like flow selection and palette management). This is now sent as part of the `assistant-ready` message, allowing the Expert to dynamically determine what the Assistant supports. [[1]](diffhunk://#diff-637659b6869108e05c4538455e7101b71e09643c68b841248750f09e14dbc35aR144-R156) [[2]](diffhunk://#diff-637659b6869108e05c4538455e7101b71e09643c68b841248750f09e14dbc35aL147-R179)
* The `get-assistant-features` command was added, enabling the Expert to explicitly request the current feature set.

**Expanded Event and Action Handling:**
* Added new custom actions: `custom:close-search`, `custom:close-typeSearch`, and `custom:close-actionList`, which allow the Expert to remotely close specific UI panels in Node-RED. [[1]](diffhunk://#diff-637659b6869108e05c4538455e7101b71e09643c68b841248750f09e14dbc35aL78-R81) [[2]](diffhunk://#diff-637659b6869108e05c4538455e7101b71e09643c68b841248750f09e14dbc35aL259-R313)
* Extended the `nodeRedEventsMap` to include open/close events for search, type search, and action list panels, and grouped event types by theme for clarity.

**Internal Refactoring:**
* Renamed `expertEventsMap` to `commandMap` for clarity and consistency, and updated all references accordingly. [[1]](diffhunk://#diff-637659b6869108e05c4538455e7101b71e09643c68b841248750f09e14dbc35aL115-R131) [[2]](diffhunk://#diff-637659b6869108e05c4538455e7101b71e09643c68b841248750f09e14dbc35aL179-R221)

**Test Enhancements:**
* Updated and expanded unit tests to verify the new initialization message, feature discovery, and custom action handling, ensuring that new events and actions are properly registered and acknowledged. [[1]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3L149-R212) [[2]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3R771-R845)
* Improved test setup and coverage for event filtering and message handling, including additional stubs and assertions for new UI actions. [[1]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3R88-R99) [[2]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3R270-R278) [[3]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3R291-R299) [[4]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3R312-R320) [[5]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3R333-R334)

These updates make the integration between FlowFuse Expert and Node-RED Assistant more robust and flexible, supporting richer UI automation and clearer capability negotiation.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

