### PR TITLE
feat: add automation/add-nodes action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -278,6 +278,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
             }
             return node
         })
+        // importNodes places nodes on the active workspace when addFlow=false,
+        // so switch to the target tab first if nodes target a different one
+        const targetZ = prepared[0]?.z
+        const activeZ = this.RED.workspaces.active()
+        if (targetZ && targetZ !== activeZ) {
+            this.RED.workspaces.show(targetZ)
+        }
         this.RED.view.importNodes(prepared, { generateIds: false, addFlow: false, notify: false, touchImport: true })
         this.RED.nodes.dirty(true)
     }

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -442,17 +442,12 @@ export class ExpertAutomations extends ExpertActionsInterface {
             if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
             return { ...rawNode }
         })
-        // Validate target tab exists before switching
-        const targetZ = prepared[0]?.z
-        if (targetZ) {
-            const targetWs = this.RED.nodes.workspace(targetZ)
-            if (!targetWs) throw new Error(`Target tab ${targetZ} not found`)
-        }
-        // importNodes places nodes on the active workspace when addFlow=false,
-        // so switch to the target tab first if nodes target a different one
-        const activeZ = this.RED.workspaces.active()
-        if (targetZ && targetZ !== activeZ) {
-            this.showWorkspace(targetZ)
+        // Validate all target tabs exist and are not locked
+        const uniqueZs = [...new Set(prepared.map(n => n.z))]
+        for (const z of uniqueZs) {
+            this.showWorkspace(z) // validates workspace exists (throws if not)
+            const ws = this.RED.nodes.workspace(z)
+            if (ws.locked) throw new Error(`Target tab ${z} is locked`)
         }
         this.RED.view.importNodes(prepared, { generateIds, addFlow: false, notify: false, touchImport: true, applyNodeDefaults: true })
         // Validate import actually succeeded (only when IDs are known)

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -261,22 +261,14 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {Object[]} nodes - array of raw node objects (must include id, type, z)
      */
     addNodes (nodes) {
-        // Validate required fields and types, then fill in default values for omitted properties
+        // Validate required fields and types
         const prepared = nodes.map(rawNode => {
             if (!rawNode.id) throw new Error('Node is missing required property: id')
             if (!rawNode.type) throw new Error('Node is missing required property: type')
             if (!rawNode.z) throw new Error('Node is missing required property: z')
             const def = this.RED.nodes.getType(rawNode.type)
             if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
-            const node = { ...rawNode }
-            if (def.defaults) {
-                for (const d in def.defaults) {
-                    if (Object.prototype.hasOwnProperty.call(def.defaults, d) && !Object.prototype.hasOwnProperty.call(node, d)) {
-                        node[d] = def.defaults[d].value
-                    }
-                }
-            }
-            return node
+            return { ...rawNode }
         })
         // importNodes places nodes on the active workspace when addFlow=false,
         // so switch to the target tab first if nodes target a different one
@@ -285,7 +277,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (targetZ && targetZ !== activeZ) {
             this.RED.workspaces.show(targetZ)
         }
-        this.RED.view.importNodes(prepared, { generateIds: false, addFlow: false, notify: false, touchImport: true })
+        this.RED.view.importNodes(prepared, { generateIds: false, addFlow: false, notify: false, touchImport: true, applyNodeDefaults: true })
         this.RED.nodes.dirty(true)
     }
 

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -256,58 +256,27 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
     /**
      * Add one or more nodes to the live NR4 canvas.
+     * Delegates to RED.view.importNodes which handles node initialisation,
+     * history (undo/redo) and view updates internally.
      * @param {Object[]} nodes - array of raw node objects (must include id, type, z)
      */
     addNodes (nodes) {
-        const addedNodes = []
-        for (const rawNode of nodes) {
+        // Validate types and fill in default values for omitted properties
+        const prepared = nodes.map(rawNode => {
             const def = this.RED.nodes.getType(rawNode.type)
             if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
-            const node = {
-                id: rawNode.id, type: rawNode.type,
-                x: parseFloat(rawNode.x || 0), y: parseFloat(rawNode.y || 0),
-                z: rawNode.z, name: rawNode.name || '', changed: true,
-                wires: [], _config: {}, _def: def,
-                inputs: def.inputs || 0, outputs: def.outputs || 0
-            }
-            for (const d in def.defaults) {
-                if (Object.prototype.hasOwnProperty.call(def.defaults, d) && d !== 'inputs' && d !== 'outputs') {
-                    node[d] = Object.prototype.hasOwnProperty.call(rawNode, d) ? rawNode[d] : def.defaults[d].value
-                    node._config[d] = JSON.stringify(node[d])
+            const node = { ...rawNode }
+            if (def.defaults) {
+                for (const d in def.defaults) {
+                    if (Object.prototype.hasOwnProperty.call(def.defaults, d) && !Object.prototype.hasOwnProperty.call(node, d)) {
+                        node[d] = def.defaults[d].value
+                    }
                 }
             }
-            node._config.x = node.x
-            node._config.y = node.y
-            if (Object.prototype.hasOwnProperty.call(rawNode, 'outputs') && def.defaults && Object.prototype.hasOwnProperty.call(def.defaults, 'outputs')) {
-                node.outputs = parseInt(rawNode.outputs, 10) || def.outputs || 0
-                node._config.outputs = JSON.stringify(rawNode.outputs)
-            }
-            if (Object.prototype.hasOwnProperty.call(rawNode, 'inputs') && def.defaults && Object.prototype.hasOwnProperty.call(def.defaults, 'inputs')) {
-                node.inputs = parseInt(rawNode.inputs, 10) || def.inputs || 0
-                node._config.inputs = JSON.stringify(rawNode.inputs)
-            }
-            node._ = def._
-            this.RED.nodes.add(node)
-            addedNodes.push(node)
-            if (this.RED.editor?.validateNode) {
-                this.RED.editor.validateNode(node)
-            }
-        }
-        this.RED.history.push({ t: 'add', nodes: addedNodes, dirty: this.RED.nodes.dirty() })
+            return node
+        })
+        this.RED.view.importNodes(prepared, { generateIds: false, addFlow: false, notify: false, touchImport: true })
         this.RED.nodes.dirty(true)
-
-        // Switch to the target tab if nodes belong to a different workspace
-        const targetTabId = nodes[0]?.z
-        const currentTab = this.RED.workspaces.active()
-        if (targetTabId && targetTabId !== currentTab) {
-            // show() triggers workspace:change internally which rebuilds activeNodes
-            this.RED.workspaces.show(targetTabId)
-        } else {
-            // Rebuild activeNodes and redraw — avoids emitting workspace:change
-            // which would fire notifyWorkspaceChange when no tab actually changed
-            this.RED.view.updateActive()
-            this.RED.view.redraw()
-        }
     }
 
     get supportedActions () {

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -259,6 +259,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {Object[]} nodes - array of raw node objects (must include id, type, z)
      */
     addNodes (nodes) {
+        const addedNodes = []
         for (const rawNode of nodes) {
             const def = this.RED.nodes.getType(rawNode.type)
             if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
@@ -287,10 +288,12 @@ export class ExpertAutomations extends ExpertActionsInterface {
             }
             node._ = def._
             this.RED.nodes.add(node)
+            addedNodes.push(node)
             if (this.RED.editor?.validateNode) {
                 this.RED.editor.validateNode(node)
             }
         }
+        this.RED.history.push({ t: 'add', nodes: addedNodes, dirty: this.RED.nodes.dirty() })
         this.RED.nodes.dirty(true)
 
         // Switch to the target tab if nodes belong to a different workspace

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -98,8 +98,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 }
             }
-        }
-,
+        },
         [ADD_NODES]: {
             params: {
                 type: 'object',

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -261,8 +261,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {Object[]} nodes - array of raw node objects (must include id, type, z)
      */
     addNodes (nodes) {
-        // Validate types and fill in default values for omitted properties
+        // Validate required fields and types, then fill in default values for omitted properties
         const prepared = nodes.map(rawNode => {
+            if (!rawNode.id) throw new Error('Node is missing required property: id')
+            if (!rawNode.type) throw new Error('Node is missing required property: type')
+            if (!rawNode.z) throw new Error('Node is missing required property: z')
             const def = this.RED.nodes.getType(rawNode.type)
             if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
             const node = { ...rawNode }

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -292,13 +292,18 @@ export class ExpertAutomations extends ExpertActionsInterface {
             }
         }
         this.RED.nodes.dirty(true)
+
+        // Switch to the target tab if nodes belong to a different workspace
         const targetTabId = nodes[0]?.z
         const currentTab = this.RED.workspaces.active()
         if (targetTabId && targetTabId !== currentTab) {
+            // show() triggers workspace:change internally which rebuilds activeNodes
             this.RED.workspaces.show(targetTabId)
         } else {
-            const tab = targetTabId || currentTab
-            this.RED.events.emit('workspace:change', { old: tab, workspace: tab })
+            // Rebuild activeNodes and redraw — avoids emitting workspace:change
+            // which would fire notifyWorkspaceChange when no tab actually changed
+            this.RED.view.updateActive()
+            this.RED.view.redraw()
         }
     }
 

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -406,7 +406,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         this.RED.workspaces.add(ws)
         this.RED.history.push({ t: 'add', workspaces: [ws], dirty: this.RED.nodes.dirty() })
         this.RED.nodes.dirty(true)
-        this.RED.workspaces.show(ws.id)
+        this.showWorkspace(ws.id)
     }
 
     /**
@@ -452,7 +452,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         // so switch to the target tab first if nodes target a different one
         const activeZ = this.RED.workspaces.active()
         if (targetZ && targetZ !== activeZ) {
-            this.RED.workspaces.show(targetZ)
+            this.showWorkspace(targetZ)
         }
         this.RED.view.importNodes(prepared, { generateIds, addFlow: false, notify: false, touchImport: true, applyNodeDefaults: true })
         // Validate import actually succeeded (only when IDs are known)

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -184,7 +184,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
                             required: ['id', 'type', 'z']
                         },
                         description: 'Array of node objects to add to the canvas'
-                    }
+                    },
+                    generateIds: { type: 'boolean', description: 'Regenerate node IDs during import (use if IDs may conflict). Default: false', default: false }
                 },
                 required: ['nodes']
             }
@@ -439,8 +440,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * Delegates to RED.view.importNodes which handles node initialisation,
      * history (undo/redo) and view updates internally.
      * @param {Object[]} nodes - array of raw node objects (must include id, type, z)
+     * @param {Object} [options]
+     * @param {boolean} [options.generateIds=false] - regenerate node IDs during import
      */
-    addNodes (nodes) {
+    addNodes (nodes, { generateIds = false } = {}) {
         // Validate required fields and types
         const prepared = nodes.map(rawNode => {
             if (!rawNode.id) throw new Error('Node is missing required property: id')
@@ -450,14 +453,26 @@ export class ExpertAutomations extends ExpertActionsInterface {
             if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
             return { ...rawNode }
         })
+        // Validate target tab exists before switching
+        const targetZ = prepared[0]?.z
+        if (targetZ) {
+            const targetWs = this.RED.nodes.workspace(targetZ)
+            if (!targetWs) throw new Error(`Target tab ${targetZ} not found`)
+        }
         // importNodes places nodes on the active workspace when addFlow=false,
         // so switch to the target tab first if nodes target a different one
-        const targetZ = prepared[0]?.z
         const activeZ = this.RED.workspaces.active()
         if (targetZ && targetZ !== activeZ) {
             this.RED.workspaces.show(targetZ)
         }
-        this.RED.view.importNodes(prepared, { generateIds: false, addFlow: false, notify: false, touchImport: true, applyNodeDefaults: true })
+        this.RED.view.importNodes(prepared, { generateIds, addFlow: false, notify: false, touchImport: true, applyNodeDefaults: true })
+        // Validate import actually succeeded (only when IDs are known)
+        if (!generateIds) {
+            const missing = prepared.filter(n => !this.RED.nodes.node(n.id))
+            if (missing.length > 0) {
+                throw new Error(`Failed to add node(s): ${missing.map(n => n.id).join(', ')} — IDs may already exist. Retry with generateIds: true`)
+            }
+        }
         this.RED.nodes.dirty(true)
     }
 
@@ -571,7 +586,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             break
 
         case ADD_NODES:
-            this.addNodes(params.nodes)
+            this.addNodes(params.nodes, { generateIds: params.generateIds ?? false })
             result.success = true
             break
         default:

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -272,8 +272,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
             }
             for (const d in def.defaults) {
                 if (Object.prototype.hasOwnProperty.call(def.defaults, d) && d !== 'inputs' && d !== 'outputs') {
-                    node[d] = rawNode[d]
-                    node._config[d] = JSON.stringify(rawNode[d])
+                    node[d] = Object.prototype.hasOwnProperty.call(rawNode, d) ? rawNode[d] : def.defaults[d].value
+                    node._config[d] = JSON.stringify(node[d])
                 }
             }
             node._config.x = node.x

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -6,9 +6,10 @@ const GET_NODES = 'automation/get-nodes'
 const EDIT_NODE = 'automation/open-node-edit'
 const SEARCH = 'automation/search'
 const ADD_FLOW_TAB = 'automation/add-flow-tab'
+const ADD_NODES = 'automation/add-nodes'
 
 /**
- * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB} ExpertAutomationsActionsEnum
+ * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB|ADD_NODES} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -96,6 +97,30 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         description: 'Optional title for the new flow tab'
                     }
                 }
+            }
+        }
+,
+        [ADD_NODES]: {
+            params: {
+                type: 'object',
+                properties: {
+                    nodes: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                id: { type: 'string', description: 'Unique node ID' },
+                                type: { type: 'string', description: 'Node type identifier' },
+                                x: { type: 'number', description: 'Canvas x position' },
+                                y: { type: 'number', description: 'Canvas y position' },
+                                z: { type: 'string', description: 'Tab (workspace) ID' }
+                            },
+                            required: ['id', 'type', 'z']
+                        },
+                        description: 'Array of node objects to add to the canvas'
+                    }
+                },
+                required: ['nodes']
             }
         }
     })
@@ -229,6 +254,54 @@ export class ExpertAutomations extends ExpertActionsInterface {
         return newTab
     }
 
+    /**
+     * Add one or more nodes to the live NR4 canvas.
+     * @param {Object[]} nodes - array of raw node objects (must include id, type, z)
+     */
+    addNodes (nodes) {
+        for (const rawNode of nodes) {
+            const def = this.RED.nodes.getType(rawNode.type)
+            if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
+            const node = {
+                id: rawNode.id, type: rawNode.type,
+                x: parseFloat(rawNode.x || 0), y: parseFloat(rawNode.y || 0),
+                z: rawNode.z, name: rawNode.name || '', changed: true,
+                wires: [], _config: {}, _def: def,
+                inputs: def.inputs || 0, outputs: def.outputs || 0
+            }
+            for (const d in def.defaults) {
+                if (Object.prototype.hasOwnProperty.call(def.defaults, d) && d !== 'inputs' && d !== 'outputs') {
+                    node[d] = rawNode[d]
+                    node._config[d] = JSON.stringify(rawNode[d])
+                }
+            }
+            node._config.x = node.x
+            node._config.y = node.y
+            if (Object.prototype.hasOwnProperty.call(rawNode, 'outputs') && def.defaults && Object.prototype.hasOwnProperty.call(def.defaults, 'outputs')) {
+                node.outputs = parseInt(rawNode.outputs, 10) || def.outputs || 0
+                node._config.outputs = JSON.stringify(rawNode.outputs)
+            }
+            if (Object.prototype.hasOwnProperty.call(rawNode, 'inputs') && def.defaults && Object.prototype.hasOwnProperty.call(def.defaults, 'inputs')) {
+                node.inputs = parseInt(rawNode.inputs, 10) || def.inputs || 0
+                node._config.inputs = JSON.stringify(rawNode.inputs)
+            }
+            node._ = def._
+            this.RED.nodes.add(node)
+            if (this.RED.editor?.validateNode) {
+                this.RED.editor.validateNode(node)
+            }
+        }
+        this.RED.nodes.dirty(true)
+        const targetTabId = nodes[0]?.z
+        const currentTab = this.RED.workspaces.active()
+        if (targetTabId && targetTabId !== currentTab) {
+            this.RED.workspaces.show(targetTabId)
+        } else {
+            const tab = targetTabId || currentTab
+            this.RED.events.emit('workspace:change', { old: tab, workspace: tab })
+        }
+    }
+
     get supportedActions () {
         return this.actions
     }
@@ -300,6 +373,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
+        case ADD_NODES:
+            this.addNodes(params.nodes)
+            result.success = true
+            break
         default:
             result.handled = false
             result.success = false

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -115,6 +115,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                                 y: { type: 'number', description: 'Canvas y position' },
                                 z: { type: 'string', description: 'Tab (workspace) ID' }
                             },
+                            additionalProperties: true,
                             required: ['id', 'type', 'z']
                         },
                         description: 'Array of node objects to add to the canvas'

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -353,6 +353,24 @@ describeMain('expertAutomations', () => {
                         params: { nodes: [{ id: 'n1', type: 'unknown', z: 'tab1' }] }
                     }, result)).rejectedWith(/Unknown node type/)
                 })
+                it('should throw if node is missing required property z', async () => {
+                    const result = {}
+                    await should(expertAutomations.invokeAction('automation/add-nodes', {
+                        params: { nodes: [{ id: 'n1', type: 'inject' }] }
+                    }, result)).rejectedWith(/missing required property: z/)
+                })
+                it('should throw if node is missing required property id', async () => {
+                    const result = {}
+                    await should(expertAutomations.invokeAction('automation/add-nodes', {
+                        params: { nodes: [{ type: 'inject', z: 'tab1' }] }
+                    }, result)).rejectedWith(/missing required property: id/)
+                })
+                it('should throw if node is missing required property type', async () => {
+                    const result = {}
+                    await should(expertAutomations.invokeAction('automation/add-nodes', {
+                        params: { nodes: [{ id: 'n1', z: 'tab1' }] }
+                    }, result)).rejectedWith(/missing required property: type/)
+                })
             })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -327,78 +327,78 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
-            describe('addNodes action', () => {
-                it('should validate types and delegate to importNodes with applyNodeDefaults', async () => {
-                    mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: { name: { value: '' }, repeat: { value: '' } } })
-                    mockRED.view.importNodes = sinon.stub()
-                    mockRED.nodes.dirty = sinon.stub()
-                    const nodes = [{ id: 'n1', type: 'inject', z: 'tab1', x: 100, y: 200 }]
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/add-nodes', {
-                        params: { nodes }
-                    }, result)
-                    mockRED.nodes.getType.calledWith('inject').should.be.true()
-                    mockRED.view.importNodes.calledOnce.should.be.true()
-                    const importArgs = mockRED.view.importNodes.firstCall.args
-                    importArgs[0][0].should.have.property('id', 'n1')
-                    importArgs[1].should.have.property('generateIds', false)
-                    importArgs[1].should.have.property('addFlow', false)
-                    importArgs[1].should.have.property('notify', false)
-                    importArgs[1].should.have.property('applyNodeDefaults', true)
-                    result.should.have.property('success', true)
-                    result.should.have.property('handled', true)
-                })
-                it('should throw if node type is unknown', async () => {
-                    mockRED.nodes.getType = sinon.stub().returns(null)
-                    const result = {}
-                    await should(expertAutomations.invokeAction('automation/add-nodes', {
-                        params: { nodes: [{ id: 'n1', type: 'unknown', z: 'tab1' }] }
-                    }, result)).rejectedWith(/Unknown node type/)
-                })
-                it('should switch to target tab when nodes target a different workspace', async () => {
-                    mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
-                    mockRED.view.importNodes = sinon.stub()
-                    mockRED.nodes.dirty = sinon.stub()
-                    mockRED.workspaces.active.returns('active-tab')
-                    const nodes = [{ id: 'n1', type: 'inject', z: 'other-tab', x: 100, y: 200 }]
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/add-nodes', {
-                        params: { nodes }
-                    }, result)
-                    mockRED.workspaces.show.calledWith('other-tab').should.be.true()
-                    result.should.have.property('success', true)
-                })
-                it('should not switch tabs when nodes target the active workspace', async () => {
-                    mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
-                    mockRED.view.importNodes = sinon.stub()
-                    mockRED.nodes.dirty = sinon.stub()
-                    mockRED.workspaces.active.returns('active-tab')
-                    const nodes = [{ id: 'n1', type: 'inject', z: 'active-tab', x: 100, y: 200 }]
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/add-nodes', {
-                        params: { nodes }
-                    }, result)
-                    mockRED.workspaces.show.called.should.be.false()
-                    result.should.have.property('success', true)
-                })
-                it('should throw if node is missing required property z', async () => {
-                    const result = {}
-                    await should(expertAutomations.invokeAction('automation/add-nodes', {
-                        params: { nodes: [{ id: 'n1', type: 'inject' }] }
-                    }, result)).rejectedWith(/missing required property: z/)
-                })
-                it('should throw if node is missing required property id', async () => {
-                    const result = {}
-                    await should(expertAutomations.invokeAction('automation/add-nodes', {
-                        params: { nodes: [{ type: 'inject', z: 'tab1' }] }
-                    }, result)).rejectedWith(/missing required property: id/)
-                })
-                it('should throw if node is missing required property type', async () => {
-                    const result = {}
-                    await should(expertAutomations.invokeAction('automation/add-nodes', {
-                        params: { nodes: [{ id: 'n1', z: 'tab1' }] }
-                    }, result)).rejectedWith(/missing required property: type/)
-                })
+        describe('addNodes action', () => {
+            it('should validate types and delegate to importNodes with applyNodeDefaults', async () => {
+                mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: { name: { value: '' }, repeat: { value: '' } } })
+                mockRED.view.importNodes = sinon.stub()
+                mockRED.nodes.dirty = sinon.stub()
+                const nodes = [{ id: 'n1', type: 'inject', z: 'tab1', x: 100, y: 200 }]
+                const result = {}
+                await expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes }
+                }, result)
+                mockRED.nodes.getType.calledWith('inject').should.be.true()
+                mockRED.view.importNodes.calledOnce.should.be.true()
+                const importArgs = mockRED.view.importNodes.firstCall.args
+                importArgs[0][0].should.have.property('id', 'n1')
+                importArgs[1].should.have.property('generateIds', false)
+                importArgs[1].should.have.property('addFlow', false)
+                importArgs[1].should.have.property('notify', false)
+                importArgs[1].should.have.property('applyNodeDefaults', true)
+                result.should.have.property('success', true)
+                result.should.have.property('handled', true)
             })
+            it('should throw if node type is unknown', async () => {
+                mockRED.nodes.getType = sinon.stub().returns(null)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'n1', type: 'unknown', z: 'tab1' }] }
+                }, result)).rejectedWith(/Unknown node type/)
+            })
+            it('should switch to target tab when nodes target a different workspace', async () => {
+                mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
+                mockRED.view.importNodes = sinon.stub()
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.workspaces.active.returns('active-tab')
+                const nodes = [{ id: 'n1', type: 'inject', z: 'other-tab', x: 100, y: 200 }]
+                const result = {}
+                await expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes }
+                }, result)
+                mockRED.workspaces.show.calledWith('other-tab').should.be.true()
+                result.should.have.property('success', true)
+            })
+            it('should not switch tabs when nodes target the active workspace', async () => {
+                mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
+                mockRED.view.importNodes = sinon.stub()
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.workspaces.active.returns('active-tab')
+                const nodes = [{ id: 'n1', type: 'inject', z: 'active-tab', x: 100, y: 200 }]
+                const result = {}
+                await expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes }
+                }, result)
+                mockRED.workspaces.show.called.should.be.false()
+                result.should.have.property('success', true)
+            })
+            it('should throw if node is missing required property z', async () => {
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'n1', type: 'inject' }] }
+                }, result)).rejectedWith(/missing required property: z/)
+            })
+            it('should throw if node is missing required property id', async () => {
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ type: 'inject', z: 'tab1' }] }
+                }, result)).rejectedWith(/missing required property: id/)
+            })
+            it('should throw if node is missing required property type', async () => {
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'n1', z: 'tab1' }] }
+                }, result)).rejectedWith(/missing required property: type/)
+            })
+        })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -372,7 +372,7 @@ describeMain('expertAutomations', () => {
                 mockRED.workspaces.show.calledWith('other-tab').should.be.true()
                 result.should.have.property('success', true)
             })
-            it('should not switch tabs when nodes target the active workspace', async () => {
+            it('should validate workspace via showWorkspace even when targeting the active tab', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
                 mockRED.nodes.workspace = sinon.stub().returns({ id: 'active-tab', type: 'tab' })
                 mockRED.nodes.node = sinon.stub().returns({ id: 'n1' })
@@ -384,7 +384,7 @@ describeMain('expertAutomations', () => {
                 await expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes }
                 }, result)
-                mockRED.workspaces.show.called.should.be.false()
+                mockRED.workspaces.show.calledWith('active-tab').should.be.true()
                 result.should.have.property('success', true)
             })
             it('should throw if target tab does not exist', async () => {
@@ -393,7 +393,28 @@ describeMain('expertAutomations', () => {
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes: [{ id: 'n1', type: 'inject', z: 'nonexistent' }] }
-                }, result)).rejectedWith(/Target tab nonexistent not found/)
+                }, result)).rejectedWith(/Workspace nonexistent not found/)
+            })
+            it('should throw if any target tab does not exist (mixed z)', async () => {
+                mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
+                mockRED.nodes.workspace = sinon.stub().returns(null)
+                mockRED.nodes.workspace.withArgs('tab1').returns({ id: 'tab1', type: 'tab' })
+                const result = {}
+                const nodes = [
+                    { id: 'n1', type: 'inject', z: 'tab1' },
+                    { id: 'n2', type: 'debug', z: 'tab2' }
+                ]
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes }
+                }, result)).rejectedWith(/Workspace tab2 not found/)
+            })
+            it('should throw if target tab is locked', async () => {
+                mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', type: 'tab', locked: true })
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1' }] }
+                }, result)).rejectedWith(/Target tab tab1 is locked/)
             })
             it('should throw if import silently fails (node IDs already exist)', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -476,7 +476,10 @@ describeMain('expertAutomations', () => {
         })
         describe('addTab action', () => {
             beforeEach(() => {
-                mockRED.nodes.addWorkspace = sinon.stub()
+                mockRED.nodes.addWorkspace = sinon.stub().callsFake(ws => {
+                    // After adding, workspace lookup should find it
+                    mockRED.nodes.workspace.withArgs(ws.id).returns(ws)
+                })
                 mockRED.nodes.id = sinon.stub().returns('gen-id')
                 mockRED.nodes.dirty = sinon.stub()
                 mockRED.nodes.workspace = sinon.stub().returns(null)

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -324,10 +324,11 @@ describeMain('expertAutomations', () => {
             })
         })
             describe('addNodes action', () => {
-                it('should add nodes to the canvas', async () => {
+                it('should add nodes to the canvas and push history', async () => {
                     mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: { name: { value: '' } } })
                     mockRED.nodes.add = sinon.stub()
                     mockRED.nodes.dirty = sinon.stub()
+                    mockRED.history = { push: sinon.stub() }
                     mockRED.editor = { validateNode: sinon.stub() }
                     mockRED.workspaces = { active: sinon.stub().returns('tab1'), show: sinon.stub() }
                     mockRED.view.updateActive = sinon.stub()
@@ -337,6 +338,10 @@ describeMain('expertAutomations', () => {
                         params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1', x: 100, y: 200 }] }
                     }, result)
                     mockRED.nodes.add.calledOnce.should.be.true()
+                    mockRED.history.push.calledOnce.should.be.true()
+                    const historyArg = mockRED.history.push.firstCall.args[0]
+                    historyArg.should.have.property('t', 'add')
+                    historyArg.should.have.property('nodes').which.is.an.Array().with.lengthOf(1)
                     mockRED.nodes.dirty.calledWith(true).should.be.true()
                     mockRED.view.updateActive.calledOnce.should.be.true()
                     mockRED.view.redraw.calledOnce.should.be.true()

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -330,13 +330,16 @@ describeMain('expertAutomations', () => {
                     mockRED.nodes.dirty = sinon.stub()
                     mockRED.editor = { validateNode: sinon.stub() }
                     mockRED.workspaces = { active: sinon.stub().returns('tab1'), show: sinon.stub() }
-                    mockRED.events = { emit: sinon.stub() }
+                    mockRED.view.updateActive = sinon.stub()
+                    mockRED.view.redraw = sinon.stub()
                     const result = {}
                     await expertAutomations.invokeAction('automation/add-nodes', {
                         params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1', x: 100, y: 200 }] }
                     }, result)
                     mockRED.nodes.add.calledOnce.should.be.true()
                     mockRED.nodes.dirty.calledWith(true).should.be.true()
+                    mockRED.view.updateActive.calledOnce.should.be.true()
+                    mockRED.view.redraw.calledOnce.should.be.true()
                     result.should.have.property('success', true)
                     result.should.have.property('handled', true)
                 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -324,27 +324,25 @@ describeMain('expertAutomations', () => {
             })
         })
             describe('addNodes action', () => {
-                it('should add nodes to the canvas and push history', async () => {
-                    mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: { name: { value: '' } } })
-                    mockRED.nodes.add = sinon.stub()
+                it('should validate types, fill defaults, and delegate to importNodes', async () => {
+                    mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: { name: { value: '' }, repeat: { value: '' } } })
+                    mockRED.view.importNodes = sinon.stub()
                     mockRED.nodes.dirty = sinon.stub()
-                    mockRED.history = { push: sinon.stub() }
-                    mockRED.editor = { validateNode: sinon.stub() }
-                    mockRED.workspaces = { active: sinon.stub().returns('tab1'), show: sinon.stub() }
-                    mockRED.view.updateActive = sinon.stub()
-                    mockRED.view.redraw = sinon.stub()
+                    const nodes = [{ id: 'n1', type: 'inject', z: 'tab1', x: 100, y: 200 }]
                     const result = {}
                     await expertAutomations.invokeAction('automation/add-nodes', {
-                        params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1', x: 100, y: 200 }] }
+                        params: { nodes }
                     }, result)
-                    mockRED.nodes.add.calledOnce.should.be.true()
-                    mockRED.history.push.calledOnce.should.be.true()
-                    const historyArg = mockRED.history.push.firstCall.args[0]
-                    historyArg.should.have.property('t', 'add')
-                    historyArg.should.have.property('nodes').which.is.an.Array().with.lengthOf(1)
-                    mockRED.nodes.dirty.calledWith(true).should.be.true()
-                    mockRED.view.updateActive.calledOnce.should.be.true()
-                    mockRED.view.redraw.calledOnce.should.be.true()
+                    mockRED.nodes.getType.calledWith('inject').should.be.true()
+                    mockRED.view.importNodes.calledOnce.should.be.true()
+                    const importArgs = mockRED.view.importNodes.firstCall.args
+                    // Should include defaults filled in
+                    importArgs[0][0].should.have.property('id', 'n1')
+                    importArgs[0][0].should.have.property('name', '')
+                    importArgs[0][0].should.have.property('repeat', '')
+                    importArgs[1].should.have.property('generateIds', false)
+                    importArgs[1].should.have.property('addFlow', false)
+                    importArgs[1].should.have.property('notify', false)
                     result.should.have.property('success', true)
                     result.should.have.property('handled', true)
                 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -38,7 +38,11 @@ describeMain('expertAutomations', () => {
             settings: {
                 version: '4.1.4'
             },
-            state: { DEFAULT: 1 }
+            state: { DEFAULT: 1 },
+            workspaces: {
+                active: sinon.stub().returns('active-tab'),
+                show: sinon.stub()
+            }
         }
     }
 
@@ -352,6 +356,32 @@ describeMain('expertAutomations', () => {
                     await should(expertAutomations.invokeAction('automation/add-nodes', {
                         params: { nodes: [{ id: 'n1', type: 'unknown', z: 'tab1' }] }
                     }, result)).rejectedWith(/Unknown node type/)
+                })
+                it('should switch to target tab when nodes target a different workspace', async () => {
+                    mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
+                    mockRED.view.importNodes = sinon.stub()
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.workspaces.active.returns('active-tab')
+                    const nodes = [{ id: 'n1', type: 'inject', z: 'other-tab', x: 100, y: 200 }]
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/add-nodes', {
+                        params: { nodes }
+                    }, result)
+                    mockRED.workspaces.show.calledWith('other-tab').should.be.true()
+                    result.should.have.property('success', true)
+                })
+                it('should not switch tabs when nodes target the active workspace', async () => {
+                    mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
+                    mockRED.view.importNodes = sinon.stub()
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.workspaces.active.returns('active-tab')
+                    const nodes = [{ id: 'n1', type: 'inject', z: 'active-tab', x: 100, y: 200 }]
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/add-nodes', {
+                        params: { nodes }
+                    }, result)
+                    mockRED.workspaces.show.called.should.be.false()
+                    result.should.have.property('success', true)
                 })
                 it('should throw if node is missing required property z', async () => {
                     const result = {}

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -65,7 +65,7 @@ describeMain('expertAutomations', () => {
         it('should have supported actions', () => {
             const supportedActions = expertAutomations.supportedActions
             supportedActions.should.be.an.Object()
-            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab')
+            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab', 'automation/add-nodes')
         })
         it('should have hasAction method', () => {
             expertAutomations.should.have.property('hasAction').which.is.a.Function()
@@ -323,5 +323,30 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
+            describe('addNodes action', () => {
+                it('should add nodes to the canvas', async () => {
+                    mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: { name: { value: '' } } })
+                    mockRED.nodes.add = sinon.stub()
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.editor = { validateNode: sinon.stub() }
+                    mockRED.workspaces = { active: sinon.stub().returns('tab1'), show: sinon.stub() }
+                    mockRED.events = { emit: sinon.stub() }
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/add-nodes', {
+                        params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1', x: 100, y: 200 }] }
+                    }, result)
+                    mockRED.nodes.add.calledOnce.should.be.true()
+                    mockRED.nodes.dirty.calledWith(true).should.be.true()
+                    result.should.have.property('success', true)
+                    result.should.have.property('handled', true)
+                })
+                it('should throw if node type is unknown', async () => {
+                    mockRED.nodes.getType = sinon.stub().returns(null)
+                    const result = {}
+                    await should(expertAutomations.invokeAction('automation/add-nodes', {
+                        params: { nodes: [{ id: 'n1', type: 'unknown', z: 'tab1' }] }
+                    }, result)).rejectedWith(/Unknown node type/)
+                })
+            })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -328,7 +328,7 @@ describeMain('expertAutomations', () => {
             })
         })
             describe('addNodes action', () => {
-                it('should validate types, fill defaults, and delegate to importNodes', async () => {
+                it('should validate types and delegate to importNodes with applyNodeDefaults', async () => {
                     mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: { name: { value: '' }, repeat: { value: '' } } })
                     mockRED.view.importNodes = sinon.stub()
                     mockRED.nodes.dirty = sinon.stub()
@@ -340,13 +340,11 @@ describeMain('expertAutomations', () => {
                     mockRED.nodes.getType.calledWith('inject').should.be.true()
                     mockRED.view.importNodes.calledOnce.should.be.true()
                     const importArgs = mockRED.view.importNodes.firstCall.args
-                    // Should include defaults filled in
                     importArgs[0][0].should.have.property('id', 'n1')
-                    importArgs[0][0].should.have.property('name', '')
-                    importArgs[0][0].should.have.property('repeat', '')
                     importArgs[1].should.have.property('generateIds', false)
                     importArgs[1].should.have.property('addFlow', false)
                     importArgs[1].should.have.property('notify', false)
+                    importArgs[1].should.have.property('applyNodeDefaults', true)
                     result.should.have.property('success', true)
                     result.should.have.property('handled', true)
                 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -330,6 +330,8 @@ describeMain('expertAutomations', () => {
         describe('addNodes action', () => {
             it('should validate types and delegate to importNodes with applyNodeDefaults', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: { name: { value: '' }, repeat: { value: '' } } })
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', type: 'tab' })
+                mockRED.nodes.node = sinon.stub().returns({ id: 'n1' })
                 mockRED.view.importNodes = sinon.stub()
                 mockRED.nodes.dirty = sinon.stub()
                 const nodes = [{ id: 'n1', type: 'inject', z: 'tab1', x: 100, y: 200 }]
@@ -357,6 +359,8 @@ describeMain('expertAutomations', () => {
             })
             it('should switch to target tab when nodes target a different workspace', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'other-tab', type: 'tab' })
+                mockRED.nodes.node = sinon.stub().returns({ id: 'n1' })
                 mockRED.view.importNodes = sinon.stub()
                 mockRED.nodes.dirty = sinon.stub()
                 mockRED.workspaces.active.returns('active-tab')
@@ -370,6 +374,8 @@ describeMain('expertAutomations', () => {
             })
             it('should not switch tabs when nodes target the active workspace', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'active-tab', type: 'tab' })
+                mockRED.nodes.node = sinon.stub().returns({ id: 'n1' })
                 mockRED.view.importNodes = sinon.stub()
                 mockRED.nodes.dirty = sinon.stub()
                 mockRED.workspaces.active.returns('active-tab')
@@ -379,6 +385,39 @@ describeMain('expertAutomations', () => {
                     params: { nodes }
                 }, result)
                 mockRED.workspaces.show.called.should.be.false()
+                result.should.have.property('success', true)
+            })
+            it('should throw if target tab does not exist', async () => {
+                mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
+                mockRED.nodes.workspace = sinon.stub().returns(null)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'n1', type: 'inject', z: 'nonexistent' }] }
+                }, result)).rejectedWith(/Target tab nonexistent not found/)
+            })
+            it('should throw if import silently fails (node IDs already exist)', async () => {
+                mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', type: 'tab' })
+                mockRED.nodes.node = sinon.stub().returns(null)
+                mockRED.view.importNodes = sinon.stub()
+                mockRED.nodes.dirty = sinon.stub()
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1' }] }
+                }, result)).rejectedWith(/Failed to add node/)
+            })
+            it('should pass generateIds option to importNodes', async () => {
+                mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', type: 'tab' })
+                mockRED.view.importNodes = sinon.stub()
+                mockRED.nodes.dirty = sinon.stub()
+                const result = {}
+                await expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1' }], generateIds: true }
+                }, result)
+                mockRED.view.importNodes.calledOnce.should.be.true()
+                const opts = mockRED.view.importNodes.firstCall.args[1]
+                opts.generateIds.should.equal(true)
                 result.should.have.property('success', true)
             })
             it('should throw if node is missing required property z', async () => {


### PR DESCRIPTION
## Summary
- Adds `automation/add-nodes` action to `ExpertAutomations`
- Mirrors `RED.nodes.importNodes()` internals: sets `_def`, `inputs`, `outputs`, populates `_config` to prevent the orange misconfigured triangle
- Handles dynamic inputs/outputs (e.g. function node)
- Validates nodes via `RED.editor.validateNode()`

Closes #196