### PR TITLE
feat: add automation/update-node action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -6,9 +6,10 @@ const GET_NODES = 'automation/get-nodes'
 const EDIT_NODE = 'automation/open-node-edit'
 const SEARCH = 'automation/search'
 const ADD_FLOW_TAB = 'automation/add-flow-tab'
+const UPDATE_NODE = 'automation/update-node'
 
 /**
- * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB} ExpertAutomationsActionsEnum
+ * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB|UPDATE_NODE} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -96,6 +97,17 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         description: 'Optional title for the new flow tab'
                     }
                 }
+            }
+        }
+,
+        [UPDATE_NODE]: {
+            params: {
+                type: 'object',
+                properties: {
+                    id: { type: 'string', description: 'ID of the node to update' },
+                    properties: { type: 'object', description: 'Key-value pairs to merge into the node object' }
+                },
+                required: ['id', 'properties']
             }
         }
     })
@@ -229,6 +241,23 @@ export class ExpertAutomations extends ExpertActionsInterface {
         return newTab
     }
 
+    /**
+     * Update properties of an existing node in place.
+     * @param {string} id - node ID
+     * @param {Object} properties - key-value pairs to merge into the node
+     */
+    updateNode (id, properties) {
+        const node = this.RED.nodes.node(id)
+        if (!node) throw new Error(`Node ${id} not found`)
+        Object.assign(node, properties)
+        node.dirty = true
+        this.RED.nodes.dirty(true)
+        if (this.RED.editor?.validateNode) {
+            this.RED.editor.validateNode(node)
+        }
+        this.RED.view.redraw()
+    }
+
     get supportedActions () {
         return this.actions
     }
@@ -300,6 +329,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
+        case UPDATE_NODE:
+            this.updateNode(params.id, params.properties)
+            result.success = true
+            break
         default:
             result.handled = false
             result.success = false

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -98,8 +98,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 }
             }
-        }
-,
+        },
         [UPDATE_NODE]: {
             params: {
                 type: 'object',

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -249,7 +249,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
     updateNode (id, properties) {
         const node = this.RED.nodes.node(id)
         if (!node) throw new Error(`Node ${id} not found`)
+        const changes = {}
+        for (const key in properties) {
+            if (Object.prototype.hasOwnProperty.call(properties, key)) {
+                changes[key] = node[key]
+            }
+        }
+        const wasChanged = node.changed
         Object.assign(node, properties)
+        this.RED.history.push({ t: 'edit', node, changes, changed: wasChanged, dirty: this.RED.nodes.dirty() })
+        node.changed = true
         node.dirty = true
         this.RED.nodes.dirty(true)
         if (this.RED.editor?.validateNode) {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -323,54 +323,54 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
-            describe('updateNode action', () => {
-                it('should update node properties with history and changed flag', async () => {
-                    const mockNode = { id: 'n1', name: 'old', changed: false }
-                    mockRED.nodes.node.withArgs('n1').returns(mockNode)
-                    mockRED.nodes.dirty = sinon.stub()
-                    mockRED.history = { push: sinon.stub() }
-                    mockRED.editor = { validateNode: sinon.stub() }
-                    mockRED.view.redraw = sinon.stub()
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', properties: { name: 'new' } }
-                    }, result)
-                    mockNode.name.should.equal('new')
-                    mockNode.changed.should.be.true()
-                    mockNode.dirty.should.be.true()
-                    mockRED.history.push.calledOnce.should.be.true()
-                    const historyArg = mockRED.history.push.firstCall.args[0]
-                    historyArg.should.have.property('t', 'edit')
-                    historyArg.should.have.property('node', mockNode)
-                    historyArg.should.have.property('changes').which.deepEqual({ name: 'old' })
-                    historyArg.should.have.property('changed', false)
-                    mockRED.nodes.dirty.calledWith(true).should.be.true()
-                    mockRED.view.redraw.calledOnce.should.be.true()
-                    result.should.have.property('success', true)
-                })
-                it('should capture old values correctly before applying changes', async () => {
-                    const mockNode = { id: 'n1', name: 'original', x: 100, changed: true }
-                    mockRED.nodes.node.withArgs('n1').returns(mockNode)
-                    mockRED.nodes.dirty = sinon.stub()
-                    mockRED.history = { push: sinon.stub() }
-                    mockRED.view.redraw = sinon.stub()
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', properties: { name: 'updated', x: 200 } }
-                    }, result)
-                    const historyArg = mockRED.history.push.firstCall.args[0]
-                    historyArg.changes.should.deepEqual({ name: 'original', x: 100 })
-                    historyArg.changed.should.be.true()
-                    mockNode.name.should.equal('updated')
-                    mockNode.x.should.equal(200)
-                })
-                it('should throw if node not found', async () => {
-                    mockRED.nodes.node.returns(null)
-                    const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'missing', properties: {} }
-                    }, result)).rejectedWith(/Node missing not found/)
-                })
+        describe('updateNode action', () => {
+            it('should update node properties with history and changed flag', async () => {
+                const mockNode = { id: 'n1', name: 'old', changed: false }
+                mockRED.nodes.node.withArgs('n1').returns(mockNode)
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.history = { push: sinon.stub() }
+                mockRED.editor = { validateNode: sinon.stub() }
+                mockRED.view.redraw = sinon.stub()
+                const result = {}
+                await expertAutomations.invokeAction('automation/update-node', {
+                    params: { id: 'n1', properties: { name: 'new' } }
+                }, result)
+                mockNode.name.should.equal('new')
+                mockNode.changed.should.be.true()
+                mockNode.dirty.should.be.true()
+                mockRED.history.push.calledOnce.should.be.true()
+                const historyArg = mockRED.history.push.firstCall.args[0]
+                historyArg.should.have.property('t', 'edit')
+                historyArg.should.have.property('node', mockNode)
+                historyArg.should.have.property('changes').which.deepEqual({ name: 'old' })
+                historyArg.should.have.property('changed', false)
+                mockRED.nodes.dirty.calledWith(true).should.be.true()
+                mockRED.view.redraw.calledOnce.should.be.true()
+                result.should.have.property('success', true)
             })
+            it('should capture old values correctly before applying changes', async () => {
+                const mockNode = { id: 'n1', name: 'original', x: 100, changed: true }
+                mockRED.nodes.node.withArgs('n1').returns(mockNode)
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.history = { push: sinon.stub() }
+                mockRED.view.redraw = sinon.stub()
+                const result = {}
+                await expertAutomations.invokeAction('automation/update-node', {
+                    params: { id: 'n1', properties: { name: 'updated', x: 200 } }
+                }, result)
+                const historyArg = mockRED.history.push.firstCall.args[0]
+                historyArg.changes.should.deepEqual({ name: 'original', x: 100 })
+                historyArg.changed.should.be.true()
+                mockNode.name.should.equal('updated')
+                mockNode.x.should.equal(200)
+            })
+            it('should throw if node not found', async () => {
+                mockRED.nodes.node.returns(null)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/update-node', {
+                    params: { id: 'missing', properties: {} }
+                }, result)).rejectedWith(/Node missing not found/)
+            })
+        })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -65,7 +65,7 @@ describeMain('expertAutomations', () => {
         it('should have supported actions', () => {
             const supportedActions = expertAutomations.supportedActions
             supportedActions.should.be.an.Object()
-            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab')
+            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab', 'automation/update-node')
         })
         it('should have hasAction method', () => {
             expertAutomations.should.have.property('hasAction').which.is.a.Function()
@@ -323,5 +323,28 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
+            describe('updateNode action', () => {
+                it('should update node properties', async () => {
+                    const mockNode = { id: 'n1', name: 'old' }
+                    mockRED.nodes.node.withArgs('n1').returns(mockNode)
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.editor = { validateNode: sinon.stub() }
+                    mockRED.view.redraw = sinon.stub()
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/update-node', {
+                        params: { id: 'n1', properties: { name: 'new' } }
+                    }, result)
+                    mockNode.name.should.equal('new')
+                    mockNode.dirty.should.be.true()
+                    result.should.have.property('success', true)
+                })
+                it('should throw if node not found', async () => {
+                    mockRED.nodes.node.returns(null)
+                    const result = {}
+                    await should(expertAutomations.invokeAction('automation/update-node', {
+                        params: { id: 'missing', properties: {} }
+                    }, result)).rejectedWith(/Node missing not found/)
+                })
+            })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -324,10 +324,11 @@ describeMain('expertAutomations', () => {
             })
         })
             describe('updateNode action', () => {
-                it('should update node properties', async () => {
-                    const mockNode = { id: 'n1', name: 'old' }
+                it('should update node properties with history and changed flag', async () => {
+                    const mockNode = { id: 'n1', name: 'old', changed: false }
                     mockRED.nodes.node.withArgs('n1').returns(mockNode)
                     mockRED.nodes.dirty = sinon.stub()
+                    mockRED.history = { push: sinon.stub() }
                     mockRED.editor = { validateNode: sinon.stub() }
                     mockRED.view.redraw = sinon.stub()
                     const result = {}
@@ -335,8 +336,33 @@ describeMain('expertAutomations', () => {
                         params: { id: 'n1', properties: { name: 'new' } }
                     }, result)
                     mockNode.name.should.equal('new')
+                    mockNode.changed.should.be.true()
                     mockNode.dirty.should.be.true()
+                    mockRED.history.push.calledOnce.should.be.true()
+                    const historyArg = mockRED.history.push.firstCall.args[0]
+                    historyArg.should.have.property('t', 'edit')
+                    historyArg.should.have.property('node', mockNode)
+                    historyArg.should.have.property('changes').which.deepEqual({ name: 'old' })
+                    historyArg.should.have.property('changed', false)
+                    mockRED.nodes.dirty.calledWith(true).should.be.true()
+                    mockRED.view.redraw.calledOnce.should.be.true()
                     result.should.have.property('success', true)
+                })
+                it('should capture old values correctly before applying changes', async () => {
+                    const mockNode = { id: 'n1', name: 'original', x: 100, changed: true }
+                    mockRED.nodes.node.withArgs('n1').returns(mockNode)
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.history = { push: sinon.stub() }
+                    mockRED.view.redraw = sinon.stub()
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/update-node', {
+                        params: { id: 'n1', properties: { name: 'updated', x: 200 } }
+                    }, result)
+                    const historyArg = mockRED.history.push.firstCall.args[0]
+                    historyArg.changes.should.deepEqual({ name: 'original', x: 100 })
+                    historyArg.changed.should.be.true()
+                    mockNode.name.should.equal('updated')
+                    mockNode.x.should.equal(200)
                 })
                 it('should throw if node not found', async () => {
                     mockRED.nodes.node.returns(null)


### PR DESCRIPTION
## Summary
- Adds `automation/update-node` action to `ExpertAutomations`
- Merges properties onto existing node via `Object.assign`, validates, redraws

Closes #198