### PR TITLE
feat: add automation/add-tab action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -98,8 +98,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 }
             }
-        }
-,
+        },
         [ADD_TAB]: {
             params: {
                 type: 'object',

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -355,6 +355,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
      */
     addTab (tab) {
         if (tab.label == null) throw new Error('Tab label is required')
+        if (tab.id && (this.RED.nodes.node(tab.id) || this.RED.nodes.workspace(tab.id) || this.RED.nodes.subflow(tab.id))) {
+            throw new Error(`ID ${tab.id} already exists — provide a unique ID or omit to auto-generate`)
+        }
         const ws = {
             type: 'tab',
             id: tab.id || this.RED.nodes.id(),

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -6,9 +6,10 @@ const GET_NODES = 'automation/get-nodes'
 const EDIT_NODE = 'automation/open-node-edit'
 const SEARCH = 'automation/search'
 const ADD_FLOW_TAB = 'automation/add-flow-tab'
+const ADD_TAB = 'automation/add-tab'
 
 /**
- * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB} ExpertAutomationsActionsEnum
+ * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB|ADD_TAB} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -96,6 +97,20 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         description: 'Optional title for the new flow tab'
                     }
                 }
+            }
+        }
+,
+        [ADD_TAB]: {
+            params: {
+                type: 'object',
+                properties: {
+                    id: { type: 'string', description: 'Tab ID — auto-generated if omitted' },
+                    label: { type: 'string', description: 'Tab label' },
+                    disabled: { type: 'boolean', description: 'Create as disabled' },
+                    info: { type: 'string', description: 'Tab notes' },
+                    env: { type: 'array', description: 'Environment variables' }
+                },
+                required: ['label']
             }
         }
     })
@@ -229,6 +244,24 @@ export class ExpertAutomations extends ExpertActionsInterface {
         return newTab
     }
 
+    /**
+     * Add a new flow tab with an explicit ID and configuration.
+     * @param {Object} tab - tab definition with id, label, disabled, info, env
+     */
+    addTab (tab) {
+        const ws = {
+            type: 'tab',
+            id: tab.id || this.RED.nodes.id(),
+            label: tab.label,
+            disabled: tab.disabled || false,
+            info: tab.info || '',
+            env: tab.env || []
+        }
+        this.RED.nodes.addWorkspace(ws)
+        this.RED.workspaces.add(ws)
+        this.RED.workspaces.show(ws.id)
+    }
+
     get supportedActions () {
         return this.actions
     }
@@ -300,6 +333,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
+        case ADD_TAB:
+            this.addTab(params)
+            result.success = true
+            break
         default:
             result.handled = false
             result.success = false

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -260,6 +260,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {Object} tab - tab definition with id, label, disabled, info, env
      */
     addTab (tab) {
+        if (tab.label == null) throw new Error('Tab label is required')
         const ws = {
             type: 'tab',
             id: tab.id || this.RED.nodes.id(),

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -108,7 +108,18 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     label: { type: 'string', description: 'Tab label' },
                     disabled: { type: 'boolean', description: 'Create as disabled' },
                     info: { type: 'string', description: 'Tab notes' },
-                    env: { type: 'array', description: 'Environment variables' }
+                    env: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                name: { type: 'string' },
+                                value: { type: 'string' },
+                                type: { type: 'string' }
+                            }
+                        },
+                        description: 'Environment variables'
+                    }
                 },
                 required: ['label']
             }
@@ -259,6 +270,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
         this.RED.nodes.addWorkspace(ws)
         this.RED.workspaces.add(ws)
+        this.RED.history.push({ t: 'add', workspaces: [ws], dirty: this.RED.nodes.dirty() })
+        this.RED.nodes.dirty(true)
         this.RED.workspaces.show(ws.id)
     }
 

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -323,49 +323,49 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
-            describe('addTab action', () => {
-                beforeEach(() => {
-                    mockRED.nodes.addWorkspace = sinon.stub()
-                    mockRED.nodes.id = sinon.stub().returns('gen-id')
-                    mockRED.nodes.dirty = sinon.stub()
-                    mockRED.history = { push: sinon.stub() }
-                    mockRED.workspaces = { add: sinon.stub(), show: sinon.stub() }
-                })
-                it('should create a new tab with history and dirty', async () => {
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/add-tab', {
-                        params: { label: 'My Tab' }
-                    }, result)
-                    mockRED.nodes.addWorkspace.calledOnce.should.be.true()
-                    mockRED.workspaces.add.calledOnce.should.be.true()
-                    mockRED.workspaces.show.calledOnce.should.be.true()
-                    const ws = mockRED.nodes.addWorkspace.firstCall.args[0]
-                    ws.should.have.property('label', 'My Tab')
-                    ws.should.have.property('type', 'tab')
-                    mockRED.history.push.calledOnce.should.be.true()
-                    const historyArg = mockRED.history.push.firstCall.args[0]
-                    historyArg.should.have.property('t', 'add')
-                    historyArg.should.have.property('workspaces').which.is.an.Array().with.lengthOf(1)
-                    mockRED.nodes.dirty.calledWith(true).should.be.true()
-                    result.should.have.property('success', true)
-                })
-                it('should use defaults when optional fields omitted', async () => {
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/add-tab', {
-                        params: { label: 'Minimal Tab' }
-                    }, result)
-                    const ws = mockRED.nodes.addWorkspace.firstCall.args[0]
-                    ws.should.have.property('disabled', false)
-                    ws.should.have.property('info', '')
-                    ws.should.have.property('env').which.deepEqual([])
-                    result.should.have.property('success', true)
-                })
-                it('should throw if label is missing', async () => {
-                    const result = {}
-                    await should(expertAutomations.invokeAction('automation/add-tab', {
-                        params: {}
-                    }, result)).rejectedWith(/Tab label is required/)
-                })
+        describe('addTab action', () => {
+            beforeEach(() => {
+                mockRED.nodes.addWorkspace = sinon.stub()
+                mockRED.nodes.id = sinon.stub().returns('gen-id')
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.history = { push: sinon.stub() }
+                mockRED.workspaces = { add: sinon.stub(), show: sinon.stub() }
             })
+            it('should create a new tab with history and dirty', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/add-tab', {
+                    params: { label: 'My Tab' }
+                }, result)
+                mockRED.nodes.addWorkspace.calledOnce.should.be.true()
+                mockRED.workspaces.add.calledOnce.should.be.true()
+                mockRED.workspaces.show.calledOnce.should.be.true()
+                const ws = mockRED.nodes.addWorkspace.firstCall.args[0]
+                ws.should.have.property('label', 'My Tab')
+                ws.should.have.property('type', 'tab')
+                mockRED.history.push.calledOnce.should.be.true()
+                const historyArg = mockRED.history.push.firstCall.args[0]
+                historyArg.should.have.property('t', 'add')
+                historyArg.should.have.property('workspaces').which.is.an.Array().with.lengthOf(1)
+                mockRED.nodes.dirty.calledWith(true).should.be.true()
+                result.should.have.property('success', true)
+            })
+            it('should use defaults when optional fields omitted', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/add-tab', {
+                    params: { label: 'Minimal Tab' }
+                }, result)
+                const ws = mockRED.nodes.addWorkspace.firstCall.args[0]
+                ws.should.have.property('disabled', false)
+                ws.should.have.property('info', '')
+                ws.should.have.property('env').which.deepEqual([])
+                result.should.have.property('success', true)
+            })
+            it('should throw if label is missing', async () => {
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/add-tab', {
+                    params: {}
+                }, result)).rejectedWith(/Tab label is required/)
+            })
+        })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -65,7 +65,7 @@ describeMain('expertAutomations', () => {
         it('should have supported actions', () => {
             const supportedActions = expertAutomations.supportedActions
             supportedActions.should.be.an.Object()
-            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab')
+            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab', 'automation/add-tab')
         })
         it('should have hasAction method', () => {
             expertAutomations.should.have.property('hasAction').which.is.a.Function()
@@ -323,5 +323,21 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
+            describe('addTab action', () => {
+                it('should create a new tab', async () => {
+                    mockRED.nodes.addWorkspace = sinon.stub()
+                    mockRED.nodes.id = sinon.stub().returns('gen-id')
+                    mockRED.workspaces = { add: sinon.stub(), show: sinon.stub() }
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/add-tab', {
+                        params: { label: 'My Tab' }
+                    }, result)
+                    mockRED.nodes.addWorkspace.calledOnce.should.be.true()
+                    const ws = mockRED.nodes.addWorkspace.firstCall.args[0]
+                    ws.should.have.property('label', 'My Tab')
+                    ws.should.have.property('type', 'tab')
+                    result.should.have.property('success', true)
+                })
+            })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -328,6 +328,8 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.addWorkspace = sinon.stub()
                 mockRED.nodes.id = sinon.stub().returns('gen-id')
                 mockRED.nodes.dirty = sinon.stub()
+                mockRED.nodes.workspace = sinon.stub().returns(null)
+                mockRED.nodes.subflow = sinon.stub().returns(null)
                 mockRED.history = { push: sinon.stub() }
                 mockRED.workspaces = { add: sinon.stub(), show: sinon.stub() }
             })
@@ -365,6 +367,27 @@ describeMain('expertAutomations', () => {
                 await should(expertAutomations.invokeAction('automation/add-tab', {
                     params: {}
                 }, result)).rejectedWith(/Tab label is required/)
+            })
+            it('should throw if tab ID already exists as a node', async () => {
+                mockRED.nodes.node.withArgs('existing-id').returns({ id: 'existing-id' })
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/add-tab', {
+                    params: { id: 'existing-id', label: 'Dupe Tab' }
+                }, result)).rejectedWith(/ID existing-id already exists/)
+            })
+            it('should throw if tab ID already exists as a workspace', async () => {
+                mockRED.nodes.workspace.withArgs('existing-ws').returns({ id: 'existing-ws' })
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/add-tab', {
+                    params: { id: 'existing-ws', label: 'Dupe Tab' }
+                }, result)).rejectedWith(/ID existing-ws already exists/)
+            })
+            it('should throw if tab ID already exists as a subflow', async () => {
+                mockRED.nodes.subflow.withArgs('existing-sf').returns({ id: 'existing-sf' })
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/add-tab', {
+                    params: { id: 'existing-sf', label: 'Dupe Tab' }
+                }, result)).rejectedWith(/ID existing-sf already exists/)
             })
         })
         describe('close UI panel actions', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -324,18 +324,40 @@ describeMain('expertAutomations', () => {
             })
         })
             describe('addTab action', () => {
-                it('should create a new tab', async () => {
+                beforeEach(() => {
                     mockRED.nodes.addWorkspace = sinon.stub()
                     mockRED.nodes.id = sinon.stub().returns('gen-id')
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.history = { push: sinon.stub() }
                     mockRED.workspaces = { add: sinon.stub(), show: sinon.stub() }
+                })
+                it('should create a new tab with history and dirty', async () => {
                     const result = {}
                     await expertAutomations.invokeAction('automation/add-tab', {
                         params: { label: 'My Tab' }
                     }, result)
                     mockRED.nodes.addWorkspace.calledOnce.should.be.true()
+                    mockRED.workspaces.add.calledOnce.should.be.true()
+                    mockRED.workspaces.show.calledOnce.should.be.true()
                     const ws = mockRED.nodes.addWorkspace.firstCall.args[0]
                     ws.should.have.property('label', 'My Tab')
                     ws.should.have.property('type', 'tab')
+                    mockRED.history.push.calledOnce.should.be.true()
+                    const historyArg = mockRED.history.push.firstCall.args[0]
+                    historyArg.should.have.property('t', 'add')
+                    historyArg.should.have.property('workspaces').which.is.an.Array().with.lengthOf(1)
+                    mockRED.nodes.dirty.calledWith(true).should.be.true()
+                    result.should.have.property('success', true)
+                })
+                it('should use defaults when optional fields omitted', async () => {
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/add-tab', {
+                        params: { label: 'Minimal Tab' }
+                    }, result)
+                    const ws = mockRED.nodes.addWorkspace.firstCall.args[0]
+                    ws.should.have.property('disabled', false)
+                    ws.should.have.property('info', '')
+                    ws.should.have.property('env').which.deepEqual([])
                     result.should.have.property('success', true)
                 })
             })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -360,6 +360,12 @@ describeMain('expertAutomations', () => {
                     ws.should.have.property('env').which.deepEqual([])
                     result.should.have.property('success', true)
                 })
+                it('should throw if label is missing', async () => {
+                    const result = {}
+                    await should(expertAutomations.invokeAction('automation/add-tab', {
+                        params: {}
+                    }, result)).rejectedWith(/Tab label is required/)
+                })
             })
     })
 })


### PR DESCRIPTION
## Summary
- Adds `automation/add-tab` action to `ExpertAutomations`
- Calls both `RED.nodes.addWorkspace()` and `RED.workspaces.add()` to avoid the `activeFlowLocked` wire rendering bug
- Supports explicit tab ID or auto-generation
- Deprecates `automation/add-flow-tab`

Closes #200