### PR TITLE
feat: add automation/remove-tab action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -392,6 +392,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (!ws) {
             throw new Error(`Tab with id ${id} not found`)
         }
+        if (ws.locked) {
+            throw new Error(`Tab ${id} is locked and cannot be removed`)
+        }
         this.RED.workspaces.delete(ws)
     }
 

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -98,8 +98,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 }
             }
-        }
-,
+        },
         [REMOVE_TAB]: {
             params: {
                 type: 'object',

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -246,9 +246,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
      */
     removeTab (id) {
         const ws = this.RED.nodes.workspace(id)
-        if (ws) {
-            this.RED.workspaces.delete(ws)
+        if (!ws) {
+            throw new Error(`Tab with id ${id} not found`)
         }
+        this.RED.workspaces.delete(ws)
     }
 
     get supportedActions () {

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -6,9 +6,10 @@ const GET_NODES = 'automation/get-nodes'
 const EDIT_NODE = 'automation/open-node-edit'
 const SEARCH = 'automation/search'
 const ADD_FLOW_TAB = 'automation/add-flow-tab'
+const REMOVE_TAB = 'automation/remove-tab'
 
 /**
- * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB} ExpertAutomationsActionsEnum
+ * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB|REMOVE_TAB} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -96,6 +97,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         description: 'Optional title for the new flow tab'
                     }
                 }
+            }
+        }
+,
+        [REMOVE_TAB]: {
+            params: {
+                type: 'object',
+                properties: {
+                    id: { type: 'string', description: 'ID of the tab to remove' }
+                },
+                required: ['id']
             }
         }
     })
@@ -229,6 +240,17 @@ export class ExpertAutomations extends ExpertActionsInterface {
         return newTab
     }
 
+    /**
+     * Remove an existing flow tab from the NR4 editor.
+     * @param {string} id - tab ID to remove
+     */
+    removeTab (id) {
+        const ws = this.RED.nodes.workspace(id)
+        if (ws) {
+            this.RED.workspaces.delete(ws)
+        }
+    }
+
     get supportedActions () {
         return this.actions
     }
@@ -300,6 +322,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
+        case REMOVE_TAB:
+            this.removeTab(params.id)
+            result.success = true
+            break
         default:
             result.handled = false
             result.success = false

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -65,7 +65,7 @@ describeMain('expertAutomations', () => {
         it('should have supported actions', () => {
             const supportedActions = expertAutomations.supportedActions
             supportedActions.should.be.an.Object()
-            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab')
+            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab', 'automation/remove-tab')
         })
         it('should have hasAction method', () => {
             expertAutomations.should.have.property('hasAction').which.is.a.Function()
@@ -323,5 +323,18 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
+            describe('removeTab action', () => {
+                it('should remove an existing tab', async () => {
+                    const mockWs = { id: 'tab1', type: 'tab' }
+                    mockRED.nodes.workspace = sinon.stub().withArgs('tab1').returns(mockWs)
+                    mockRED.workspaces = { delete: sinon.stub() }
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/remove-tab', {
+                        params: { id: 'tab1' }
+                    }, result)
+                    mockRED.workspaces.delete.calledWith(mockWs).should.be.true()
+                    result.should.have.property('success', true)
+                })
+            })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -323,32 +323,32 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
-            describe('removeTab action', () => {
-                it('should remove an existing tab', async () => {
-                    const mockWs = { id: 'tab1', type: 'tab' }
-                    mockRED.nodes.workspace = sinon.stub().withArgs('tab1').returns(mockWs)
-                    mockRED.workspaces = { delete: sinon.stub() }
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/remove-tab', {
-                        params: { id: 'tab1' }
-                    }, result)
-                    mockRED.workspaces.delete.calledWith(mockWs).should.be.true()
-                    result.should.have.property('success', true)
-                })
-                it('should throw if tab not found', async () => {
-                    mockRED.nodes.workspace = sinon.stub().returns(null)
-                    mockRED.workspaces = { delete: sinon.stub() }
-                    await should(expertAutomations.invokeAction('automation/remove-tab', {
-                        params: { id: 'does-not-exist' }
-                    }, {})).rejectedWith(/Tab with id does-not-exist not found/)
-                })
-                it('should throw if id is empty', async () => {
-                    mockRED.nodes.workspace = sinon.stub().returns(null)
-                    mockRED.workspaces = { delete: sinon.stub() }
-                    await should(expertAutomations.invokeAction('automation/remove-tab', {
-                        params: { id: '' }
-                    }, {})).rejectedWith(/Tab with id .* not found/)
-                })
+        describe('removeTab action', () => {
+            it('should remove an existing tab', async () => {
+                const mockWs = { id: 'tab1', type: 'tab' }
+                mockRED.nodes.workspace = sinon.stub().withArgs('tab1').returns(mockWs)
+                mockRED.workspaces = { delete: sinon.stub() }
+                const result = {}
+                await expertAutomations.invokeAction('automation/remove-tab', {
+                    params: { id: 'tab1' }
+                }, result)
+                mockRED.workspaces.delete.calledWith(mockWs).should.be.true()
+                result.should.have.property('success', true)
             })
+            it('should throw if tab not found', async () => {
+                mockRED.nodes.workspace = sinon.stub().returns(null)
+                mockRED.workspaces = { delete: sinon.stub() }
+                await should(expertAutomations.invokeAction('automation/remove-tab', {
+                    params: { id: 'does-not-exist' }
+                }, {})).rejectedWith(/Tab with id does-not-exist not found/)
+            })
+            it('should throw if id is empty', async () => {
+                mockRED.nodes.workspace = sinon.stub().returns(null)
+                mockRED.workspaces = { delete: sinon.stub() }
+                await should(expertAutomations.invokeAction('automation/remove-tab', {
+                    params: { id: '' }
+                }, {})).rejectedWith(/Tab with id .* not found/)
+            })
+        })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -335,6 +335,20 @@ describeMain('expertAutomations', () => {
                     mockRED.workspaces.delete.calledWith(mockWs).should.be.true()
                     result.should.have.property('success', true)
                 })
+                it('should throw if tab not found', async () => {
+                    mockRED.nodes.workspace = sinon.stub().returns(null)
+                    mockRED.workspaces = { delete: sinon.stub() }
+                    await should(expertAutomations.invokeAction('automation/remove-tab', {
+                        params: { id: 'does-not-exist' }
+                    }, {})).rejectedWith(/Tab with id does-not-exist not found/)
+                })
+                it('should throw if id is empty', async () => {
+                    mockRED.nodes.workspace = sinon.stub().returns(null)
+                    mockRED.workspaces = { delete: sinon.stub() }
+                    await should(expertAutomations.invokeAction('automation/remove-tab', {
+                        params: { id: '' }
+                    }, {})).rejectedWith(/Tab with id .* not found/)
+                })
             })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -349,6 +349,14 @@ describeMain('expertAutomations', () => {
                     params: { id: '' }
                 }, {})).rejectedWith(/Tab with id .* not found/)
             })
+            it('should throw if tab is locked', async () => {
+                mockRED.nodes.workspace = sinon.stub().withArgs('locked-tab').returns({ id: 'locked-tab', type: 'tab', locked: true })
+                mockRED.workspaces = { delete: sinon.stub() }
+                await should(expertAutomations.invokeAction('automation/remove-tab', {
+                    params: { id: 'locked-tab' }
+                }, {})).rejectedWith(/Tab locked-tab is locked/)
+                mockRED.workspaces.delete.called.should.be.false()
+            })
         })
         describe('addTab action', () => {
             beforeEach(() => {


### PR DESCRIPTION
## Summary
- Adds `automation/remove-tab` action to `ExpertAutomations`
- Resolves workspace via `RED.nodes.workspace(id)`, calls `RED.workspaces.delete(ws)`
- No-op if tab doesn't exist

Closes #201