### PR TITLE
feat: add automation/get-workspace-nodes action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -6,9 +6,10 @@ const GET_NODES = 'automation/get-nodes'
 const EDIT_NODE = 'automation/open-node-edit'
 const SEARCH = 'automation/search'
 const ADD_FLOW_TAB = 'automation/add-flow-tab'
+const GET_FLOW = 'automation/get-flow'
 
 /**
- * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB} ExpertAutomationsActionsEnum
+ * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB|GET_FLOW} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -97,6 +98,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 }
             }
+        }
+,
+        [GET_FLOW]: {
+            params: null
         }
     })
 
@@ -229,6 +234,42 @@ export class ExpertAutomations extends ExpertActionsInterface {
         return newTab
     }
 
+    /**
+     * Read the live canvas state (including undeployed edits) and return it.
+     * @returns {Object[]} full flows array (tabs + nodes + config nodes)
+     */
+    getFlow () {
+        const flows = []
+        this.RED.nodes.eachWorkspace(ws => {
+            flows.push({ id: ws.id, type: 'tab', label: ws.label, disabled: ws.disabled || false })
+        })
+        this.RED.nodes.eachNode(node => {
+            const plain = { id: node.id, type: node.type, z: node.z, name: node.name }
+            if (node.x !== undefined) plain.x = node.x
+            if (node.y !== undefined) plain.y = node.y
+            if (node.outputs > 0) {
+                const wires = Array.from({ length: node.outputs }, () => [])
+                this.RED.nodes.getNodeLinks(node.id).forEach(link => {
+                    if (link.source?.id === node.id && wires[link.sourcePort]) {
+                        wires[link.sourcePort].push(link.target.id)
+                    }
+                })
+                plain.wires = wires
+            } else {
+                plain.wires = []
+            }
+            if (node._config) {
+                for (const k of Object.keys(node._config)) {
+                    if (k !== 'x' && k !== 'y' && plain[k] === undefined) {
+                        try { plain[k] = JSON.parse(node._config[k]) } catch { plain[k] = node._config[k] }
+                    }
+                }
+            }
+            flows.push(plain)
+        })
+        return flows
+    }
+
     get supportedActions () {
         return this.actions
     }
@@ -300,6 +341,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
+        case GET_FLOW:
+            result.flows = this.getFlow()
+            result.success = true
+            break
         default:
             result.handled = false
             result.success = false

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -6,7 +6,7 @@ const GET_NODES = 'automation/get-nodes'
 const EDIT_NODE = 'automation/open-node-edit'
 const SEARCH = 'automation/search'
 const ADD_FLOW_TAB = 'automation/add-flow-tab'
-const GET_FLOW = 'automation/get-flow'
+const GET_FLOW = 'automation/get-workspace-nodes'
 
 /**
  * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB|GET_FLOW} ExpertAutomationsActionsEnum

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -98,8 +98,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 }
             }
-        }
-,
+        },
         [GET_FLOW]: {
             params: null
         }

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -323,138 +323,138 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
-            describe('getWorkspaceNodes action', () => {
-                it('should return flows with tabs and nodes', async () => {
-                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(cb => {
-                        cb({ id: 'tab1', label: 'Flow 1', disabled: false })
-                    })
-                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
-                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', x: 100, y: 200, outputs: 1, _config: {} })
-                    })
-                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
-                    result.should.have.property('success', true)
-                    result.should.have.property('flows').which.is.an.Array()
-                    result.flows.should.have.length(2)
-                    result.flows[0].should.have.property('type', 'tab')
+        describe('getWorkspaceNodes action', () => {
+            it('should return flows with tabs and nodes', async () => {
+                mockRED.nodes.eachWorkspace = sinon.stub().callsFake(cb => {
+                    cb({ id: 'tab1', label: 'Flow 1', disabled: false })
                 })
-                it('should include _config properties in node output', async () => {
-                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
-                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
-                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', outputs: 0, _config: { topic: '"hello"' } })
-                    })
-                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
-                    result.flows[0].should.have.property('topic', 'hello')
+                mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                    cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', x: 100, y: 200, outputs: 1, _config: {} })
                 })
-                it('should populate wires from links', async () => {
-                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
-                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
-                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', outputs: 1, _config: {} })
-                    })
-                    mockRED.nodes.getNodeLinks = sinon.stub().returns([
-                        { source: { id: 'n1' }, sourcePort: 0, target: { id: 'n2' } }
-                    ])
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
-                    result.flows[0].should.have.property('wires').which.deepEqual([['n2']])
-                })
-                it('should return empty wires for nodes with zero outputs', async () => {
-                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
-                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
-                        cb({ id: 'n1', type: 'debug', z: 'tab1', name: 'dbg', outputs: 0, _config: {} })
-                    })
-                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
-                    result.flows[0].should.have.property('wires').which.deepEqual([])
-                })
-                it('should handle multiple tabs', async () => {
-                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(cb => {
-                        cb({ id: 'tab1', label: 'Flow 1', disabled: false })
-                        cb({ id: 'tab2', label: 'Flow 2', disabled: true })
-                    })
-                    mockRED.nodes.eachNode = sinon.stub().callsFake(() => {})
-                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
-                    result.flows.should.have.length(2)
-                    result.flows[0].should.have.property('label', 'Flow 1')
-                    result.flows[1].should.have.property('label', 'Flow 2')
-                    result.flows[1].should.have.property('disabled', true)
-                })
-                it('should omit x and y when node has no coordinates', async () => {
-                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
-                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
-                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'no-coords', outputs: 0, _config: {} })
-                    })
-                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
-                    result.flows[0].should.not.have.property('x')
-                    result.flows[0].should.not.have.property('y')
-                })
-                it('should populate wires on multiple output ports', async () => {
-                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
-                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
-                        cb({ id: 'n1', type: 'switch', z: 'tab1', name: 'sw', outputs: 2, _config: {} })
-                    })
-                    mockRED.nodes.getNodeLinks = sinon.stub().returns([
-                        { source: { id: 'n1' }, sourcePort: 0, target: { id: 'a1' } },
-                        { source: { id: 'n1' }, sourcePort: 1, target: { id: 'b1' } },
-                        { source: { id: 'n1' }, sourcePort: 0, target: { id: 'a2' } }
-                    ])
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
-                    result.flows[0].should.have.property('wires').which.deepEqual([['a1', 'a2'], ['b1']])
-                })
-                it('should exclude x and y keys from _config', async () => {
-                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
-                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
-                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', x: 10, y: 20, outputs: 0, _config: { x: '999', y: '888', topic: '"hi"' } })
-                    })
-                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
-                    result.flows[0].should.have.property('x', 10)
-                    result.flows[0].should.have.property('y', 20)
-                    result.flows[0].should.have.property('topic', 'hi')
-                })
-                it('should not overwrite existing plain properties from _config', async () => {
-                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
-                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
-                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'original', outputs: 0, _config: { name: '"overwritten"' } })
-                    })
-                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
-                    result.flows[0].should.have.property('name', 'original')
-                })
-                it('should fall back to raw string when _config value is not valid JSON', async () => {
-                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
-                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
-                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', outputs: 0, _config: { payload: 'not-valid-json{' } })
-                    })
-                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
-                    result.flows[0].should.have.property('payload', 'not-valid-json{')
-                })
-                it('should handle node without _config property', async () => {
-                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
-                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
-                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'no-config', x: 50, y: 60, outputs: 0 })
-                    })
-                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
-                    result.should.have.property('success', true)
-                    result.flows[0].should.have.property('id', 'n1')
-                    result.flows[0].should.have.property('name', 'no-config')
-                    result.flows[0].should.have.property('wires').which.deepEqual([])
-                })
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('flows').which.is.an.Array()
+                result.flows.should.have.length(2)
+                result.flows[0].should.have.property('type', 'tab')
             })
+            it('should include _config properties in node output', async () => {
+                mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                    cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', outputs: 0, _config: { topic: '"hello"' } })
+                })
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                result.flows[0].should.have.property('topic', 'hello')
+            })
+            it('should populate wires from links', async () => {
+                mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                    cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', outputs: 1, _config: {} })
+                })
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([
+                    { source: { id: 'n1' }, sourcePort: 0, target: { id: 'n2' } }
+                ])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                result.flows[0].should.have.property('wires').which.deepEqual([['n2']])
+            })
+            it('should return empty wires for nodes with zero outputs', async () => {
+                mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                    cb({ id: 'n1', type: 'debug', z: 'tab1', name: 'dbg', outputs: 0, _config: {} })
+                })
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                result.flows[0].should.have.property('wires').which.deepEqual([])
+            })
+            it('should handle multiple tabs', async () => {
+                mockRED.nodes.eachWorkspace = sinon.stub().callsFake(cb => {
+                    cb({ id: 'tab1', label: 'Flow 1', disabled: false })
+                    cb({ id: 'tab2', label: 'Flow 2', disabled: true })
+                })
+                mockRED.nodes.eachNode = sinon.stub().callsFake(() => {})
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                result.flows.should.have.length(2)
+                result.flows[0].should.have.property('label', 'Flow 1')
+                result.flows[1].should.have.property('label', 'Flow 2')
+                result.flows[1].should.have.property('disabled', true)
+            })
+            it('should omit x and y when node has no coordinates', async () => {
+                mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                    cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'no-coords', outputs: 0, _config: {} })
+                })
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                result.flows[0].should.not.have.property('x')
+                result.flows[0].should.not.have.property('y')
+            })
+            it('should populate wires on multiple output ports', async () => {
+                mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                    cb({ id: 'n1', type: 'switch', z: 'tab1', name: 'sw', outputs: 2, _config: {} })
+                })
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([
+                    { source: { id: 'n1' }, sourcePort: 0, target: { id: 'a1' } },
+                    { source: { id: 'n1' }, sourcePort: 1, target: { id: 'b1' } },
+                    { source: { id: 'n1' }, sourcePort: 0, target: { id: 'a2' } }
+                ])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                result.flows[0].should.have.property('wires').which.deepEqual([['a1', 'a2'], ['b1']])
+            })
+            it('should exclude x and y keys from _config', async () => {
+                mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                    cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', x: 10, y: 20, outputs: 0, _config: { x: '999', y: '888', topic: '"hi"' } })
+                })
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                result.flows[0].should.have.property('x', 10)
+                result.flows[0].should.have.property('y', 20)
+                result.flows[0].should.have.property('topic', 'hi')
+            })
+            it('should not overwrite existing plain properties from _config', async () => {
+                mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                    cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'original', outputs: 0, _config: { name: '"overwritten"' } })
+                })
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                result.flows[0].should.have.property('name', 'original')
+            })
+            it('should fall back to raw string when _config value is not valid JSON', async () => {
+                mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                    cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', outputs: 0, _config: { payload: 'not-valid-json{' } })
+                })
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                result.flows[0].should.have.property('payload', 'not-valid-json{')
+            })
+            it('should handle node without _config property', async () => {
+                mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                    cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'no-config', x: 50, y: 60, outputs: 0 })
+                })
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                result.should.have.property('success', true)
+                result.flows[0].should.have.property('id', 'n1')
+                result.flows[0].should.have.property('name', 'no-config')
+                result.flows[0].should.have.property('wires').which.deepEqual([])
+            })
+        })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -65,7 +65,7 @@ describeMain('expertAutomations', () => {
         it('should have supported actions', () => {
             const supportedActions = expertAutomations.supportedActions
             supportedActions.should.be.an.Object()
-            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab')
+            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab', 'automation/get-flow')
         })
         it('should have hasAction method', () => {
             expertAutomations.should.have.property('hasAction').which.is.a.Function()
@@ -323,5 +323,22 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
+            describe('getFlow action', () => {
+                it('should return flows with tabs and nodes', async () => {
+                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(cb => {
+                        cb({ id: 'tab1', label: 'Flow 1', disabled: false })
+                    })
+                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', x: 100, y: 200, outputs: 1, _config: {} })
+                    })
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/get-flow', { params: {} }, result)
+                    result.should.have.property('success', true)
+                    result.should.have.property('flows').which.is.an.Array()
+                    result.flows.should.have.length(2)
+                    result.flows[0].should.have.property('type', 'tab')
+                })
+            })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -385,6 +385,76 @@ describeMain('expertAutomations', () => {
                     result.flows[1].should.have.property('label', 'Flow 2')
                     result.flows[1].should.have.property('disabled', true)
                 })
+                it('should omit x and y when node has no coordinates', async () => {
+                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'no-coords', outputs: 0, _config: {} })
+                    })
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                    result.flows[0].should.not.have.property('x')
+                    result.flows[0].should.not.have.property('y')
+                })
+                it('should populate wires on multiple output ports', async () => {
+                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                        cb({ id: 'n1', type: 'switch', z: 'tab1', name: 'sw', outputs: 2, _config: {} })
+                    })
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([
+                        { source: { id: 'n1' }, sourcePort: 0, target: { id: 'a1' } },
+                        { source: { id: 'n1' }, sourcePort: 1, target: { id: 'b1' } },
+                        { source: { id: 'n1' }, sourcePort: 0, target: { id: 'a2' } }
+                    ])
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                    result.flows[0].should.have.property('wires').which.deepEqual([['a1', 'a2'], ['b1']])
+                })
+                it('should exclude x and y keys from _config', async () => {
+                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', x: 10, y: 20, outputs: 0, _config: { x: '999', y: '888', topic: '"hi"' } })
+                    })
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                    result.flows[0].should.have.property('x', 10)
+                    result.flows[0].should.have.property('y', 20)
+                    result.flows[0].should.have.property('topic', 'hi')
+                })
+                it('should not overwrite existing plain properties from _config', async () => {
+                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'original', outputs: 0, _config: { name: '"overwritten"' } })
+                    })
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                    result.flows[0].should.have.property('name', 'original')
+                })
+                it('should fall back to raw string when _config value is not valid JSON', async () => {
+                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', outputs: 0, _config: { payload: 'not-valid-json{' } })
+                    })
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                    result.flows[0].should.have.property('payload', 'not-valid-json{')
+                })
+                it('should handle node without _config property', async () => {
+                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'no-config', x: 50, y: 60, outputs: 0 })
+                    })
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                    result.should.have.property('success', true)
+                    result.flows[0].should.have.property('id', 'n1')
+                    result.flows[0].should.have.property('name', 'no-config')
+                    result.flows[0].should.have.property('wires').which.deepEqual([])
+                })
             })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -65,7 +65,7 @@ describeMain('expertAutomations', () => {
         it('should have supported actions', () => {
             const supportedActions = expertAutomations.supportedActions
             supportedActions.should.be.an.Object()
-            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab', 'automation/get-flow')
+            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab', 'automation/get-workspace-nodes')
         })
         it('should have hasAction method', () => {
             expertAutomations.should.have.property('hasAction').which.is.a.Function()
@@ -323,7 +323,7 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
-            describe('getFlow action', () => {
+            describe('getWorkspaceNodes action', () => {
                 it('should return flows with tabs and nodes', async () => {
                     mockRED.nodes.eachWorkspace = sinon.stub().callsFake(cb => {
                         cb({ id: 'tab1', label: 'Flow 1', disabled: false })
@@ -333,11 +333,57 @@ describeMain('expertAutomations', () => {
                     })
                     mockRED.nodes.getNodeLinks = sinon.stub().returns([])
                     const result = {}
-                    await expertAutomations.invokeAction('automation/get-flow', { params: {} }, result)
+                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
                     result.should.have.property('success', true)
                     result.should.have.property('flows').which.is.an.Array()
                     result.flows.should.have.length(2)
                     result.flows[0].should.have.property('type', 'tab')
+                })
+                it('should include _config properties in node output', async () => {
+                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', outputs: 0, _config: { topic: '"hello"' } })
+                    })
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                    result.flows[0].should.have.property('topic', 'hello')
+                })
+                it('should populate wires from links', async () => {
+                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                        cb({ id: 'n1', type: 'inject', z: 'tab1', name: 'test', outputs: 1, _config: {} })
+                    })
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([
+                        { source: { id: 'n1' }, sourcePort: 0, target: { id: 'n2' } }
+                    ])
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                    result.flows[0].should.have.property('wires').which.deepEqual([['n2']])
+                })
+                it('should return empty wires for nodes with zero outputs', async () => {
+                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(() => {})
+                    mockRED.nodes.eachNode = sinon.stub().callsFake(cb => {
+                        cb({ id: 'n1', type: 'debug', z: 'tab1', name: 'dbg', outputs: 0, _config: {} })
+                    })
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                    result.flows[0].should.have.property('wires').which.deepEqual([])
+                })
+                it('should handle multiple tabs', async () => {
+                    mockRED.nodes.eachWorkspace = sinon.stub().callsFake(cb => {
+                        cb({ id: 'tab1', label: 'Flow 1', disabled: false })
+                        cb({ id: 'tab2', label: 'Flow 2', disabled: true })
+                    })
+                    mockRED.nodes.eachNode = sinon.stub().callsFake(() => {})
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/get-workspace-nodes', { params: {} }, result)
+                    result.flows.should.have.length(2)
+                    result.flows[0].should.have.property('label', 'Flow 1')
+                    result.flows[1].should.have.property('label', 'Flow 2')
+                    result.flows[1].should.have.property('disabled', true)
                 })
             })
     })


### PR DESCRIPTION
## Summary
- Adds `automation/get-flow` action to `ExpertAutomations`
- Reads live canvas state including undeployed edits
- Reconstructs wires from NR4 link objects (reading `node.wires` returns stale data)
- Copies user-edited values from `node._config`

Closes #202