### PR TITLE
feat: add automation/import-flow action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -326,7 +326,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {boolean} importOptions.addFlow whether to add the nodes to a new flow or to the current flow
      * @param {boolean} [importOptions.notify=true] whether to show notifications for import success/failure (default true)
      */
-    importFlow (nodesStr, { addFlow = false, generateIds = true, notify = true } = { addFlow: false, generateIds: true, notify: true }) {
+    importFlow (nodesStr, { addFlow = false, generateIds = true } = { addFlow: false, generateIds: true }) {
         let newNodes = nodesStr
         if (typeof nodesStr === 'string') {
             try {
@@ -340,10 +340,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 e.code = 'NODE_RED'
                 throw e
             }
-        } else if (!Array.isArray(nodesStr)) {
+        } else if (Array.isArray(nodesStr)) {
+            this.redOps.validateFlow(nodesStr)
+        } else {
             throw new Error('importFlow expects a JSON string or an array of node objects')
         }
-        this.RED.view.importNodes(newNodes, { generateIds, addFlow, notify, touchImport: true, applyNodeDefaults: true })
+        // If importing onto the current tab (not creating a new one), check it's not locked
+        if (!addFlow && this.RED.workspaces.isLocked()) {
+            throw new Error('Cannot import into a locked workspace')
+        }
+        this.RED.view.importNodes(newNodes, { generateIds, addFlow, touchImport: true, applyNodeDefaults: true })
         this.RED.nodes.dirty(true)
     }
 

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -203,7 +203,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
     /// Function extracted from Node-RED source `editor-client/src/js/ui/clipboard.js`
     /**
      * Performs the import of nodes, handling any conflicts that may arise
-     * @param {string} nodesStr the nodes to import as a string
+     * @param {string|Object[]} nodesStr the nodes to import — either a JSON string or an array of node objects
      * @param {object} importOptions
      * @param {boolean} importOptions.addFlow whether to add the nodes to a new flow or to the current flow
      * @param {boolean} [importOptions.notify=true] whether to show notifications for import success/failure (default true)
@@ -222,6 +222,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 e.code = 'NODE_RED'
                 throw e
             }
+        } else if (!Array.isArray(nodesStr)) {
+            throw new Error('importFlow expects a JSON string or an array of node objects')
         }
         this.RED.view.importNodes(newNodes, { generateIds, addFlow, notify, touchImport: true, applyNodeDefaults: true })
         this.RED.nodes.dirty(true)

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -98,8 +98,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 }
             }
-        }
-,
+        },
         [IMPORT_FLOW]: {
             params: {
                 type: 'object',

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -224,6 +224,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             }
         }
         this.RED.view.importNodes(newNodes, { generateIds, addFlow, notify, touchImport: true })
+        this.RED.nodes.dirty(true)
     }
 
     async addFlowTab (title) {

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -6,9 +6,10 @@ const GET_NODES = 'automation/get-nodes'
 const EDIT_NODE = 'automation/open-node-edit'
 const SEARCH = 'automation/search'
 const ADD_FLOW_TAB = 'automation/add-flow-tab'
+const IMPORT_FLOW = 'automation/import-flow'
 
 /**
- * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB} ExpertAutomationsActionsEnum
+ * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB|IMPORT_FLOW} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -96,6 +97,28 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         description: 'Optional title for the new flow tab'
                     }
                 }
+            }
+        }
+,
+        [IMPORT_FLOW]: {
+            params: {
+                type: 'object',
+                properties: {
+                    flow: {
+                        type: ['string', 'array'],
+                        description: 'Flow JSON string or array to import onto the canvas'
+                    },
+                    addFlow: {
+                        type: 'boolean',
+                        description: 'Whether to create a new tab for the imported nodes (true) or import into the current tab (false). Default: false'
+                    },
+                    generateIds: {
+                        type: 'boolean',
+                        description: 'Whether to regenerate node IDs during import. Default: true.',
+                        default: true
+                    }
+                },
+                required: ['flow']
             }
         }
     })
@@ -200,7 +223,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 throw e
             }
         }
-        this.RED.view.importNodes(newNodes, { generateIds, addFlow, notify })
+        this.RED.view.importNodes(newNodes, { generateIds, addFlow, notify, touchImport: true })
     }
 
     async addFlowTab (title) {
@@ -300,6 +323,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
+        case IMPORT_FLOW:
+            this.importFlow(params.flow, { addFlow: params.addFlow, generateIds: params.generateIds ?? true })
+            result.success = true
+            break
         default:
             result.handled = false
             result.success = false

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -223,7 +223,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 throw e
             }
         }
-        this.RED.view.importNodes(newNodes, { generateIds, addFlow, notify, touchImport: true })
+        this.RED.view.importNodes(newNodes, { generateIds, addFlow, notify, touchImport: true, applyNodeDefaults: true })
         this.RED.nodes.dirty(true)
     }
 

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -108,7 +108,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         type: ['string', 'array'],
                         description: 'Flow JSON string or array to import onto the canvas'
                     },
-                    addFlow: {
+                    addFlowTab: {
                         type: 'boolean',
                         description: 'Whether to create a new tab for the imported nodes (true) or import into the current tab (false). Default: false'
                     },
@@ -324,7 +324,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             break
 
         case IMPORT_FLOW:
-            this.importFlow(params.flow, { addFlow: params.addFlow, generateIds: params.generateIds ?? true })
+            this.importFlow(params.flow, { addFlow: params.addFlowTab, generateIds: params.generateIds ?? true })
             result.success = true
             break
         default:

--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -693,10 +693,11 @@ export class ExpertComms {
                     if (propSchema.type && propExists) {
                         const expectedType = propSchema.type
                         const actualType = Array.isArray(data[propName]) ? 'array' : typeof data[propName]
-                        if (actualType !== expectedType) {
+                        const allowedTypes = Array.isArray(expectedType) ? expectedType : [expectedType]
+                        if (!allowedTypes.includes(actualType)) {
                             return {
                                 valid: false,
-                                error: `Data parameter "${propName}" is of type "${actualType}" but expected type is "${expectedType}"`
+                                error: `Data parameter "${propName}" is of type "${actualType}" but expected type is "${allowedTypes.join(' or ')}"`
                             }
                         }
                     }

--- a/resources/redOps.js
+++ b/resources/redOps.js
@@ -11,23 +11,26 @@ export class RedOps {
      * @param {string} flowString the string to validate
      * @returns If valid, returns the node array
      */
-    validateFlowString (flowString) {
-        const res = JSON.parse(flowString)
-        if (!Array.isArray(res)) {
+    validateFlow (flow) {
+        if (!Array.isArray(flow)) {
             throw new Error(this.RED._('clipboard.import.errors.notArray'))
         }
-        for (let i = 0; i < res.length; i++) {
-            if (typeof res[i] !== 'object') {
+        for (let i = 0; i < flow.length; i++) {
+            if (typeof flow[i] !== 'object') {
                 throw new Error(this.RED._('clipboard.import.errors.itemNotObject', { index: i }))
             }
-            if (!Object.hasOwn(res[i], 'id')) {
+            if (!Object.hasOwn(flow[i], 'id')) {
                 throw new Error(this.RED._('clipboard.import.errors.missingId', { index: i }))
             }
-            if (!Object.hasOwn(res[i], 'type')) {
+            if (!Object.hasOwn(flow[i], 'type')) {
                 throw new Error(this.RED._('clipboard.import.errors.missingType', { index: i }))
             }
         }
-        return res
+        return flow
+    }
+
+    validateFlowString (flowString) {
+        return this.validateFlow(JSON.parse(flowString))
     }
 
     /**

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -33,7 +33,8 @@ describeMain('expertAutomations', () => {
             nodes: {
                 node: sinon.stub(),
                 getAllFlowNodes: sinon.stub(),
-                createExportableNodeSet: sinon.stub().callsFake((nodes) => nodes || [])
+                createExportableNodeSet: sinon.stub().callsFake((nodes) => nodes || []),
+                dirty: sinon.stub()
             },
             settings: {
                 version: '4.1.4'

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -324,53 +324,53 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
-            describe('importFlow action', () => {
-                it('should import flow JSON string', async () => {
-                    mockRED.view.importNodes = sinon.stub()
-                    mockRED._ = sinon.stub().returns('error')
-                    const flowJson = JSON.stringify([{ id: 'n1', type: 'inject' }])
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/import-flow', {
-                        params: { flow: flowJson }
-                    }, result)
-                    mockRED.view.importNodes.calledOnce.should.be.true()
-                    const args = mockRED.view.importNodes.firstCall.args
-                    args[1].should.have.property('touchImport', true)
-                    result.should.have.property('success', true)
-                })
-                it('should import flow array directly without JSON.parse', async () => {
-                    mockRED.view.importNodes = sinon.stub()
-                    const flowArray = [{ id: 'n1', type: 'inject' }]
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/import-flow', {
-                        params: { flow: flowArray }
-                    }, result)
-                    mockRED.view.importNodes.calledOnce.should.be.true()
-                    const args = mockRED.view.importNodes.firstCall.args
-                    args[0].should.deepEqual(flowArray)
-                    args[1].should.have.property('touchImport', true)
-                    result.should.have.property('success', true)
-                })
-                it('should throw when flow param is neither string nor array', async () => {
-                    mockRED.view.importNodes = sinon.stub()
-                    mockRED._ = sinon.stub().returns('error')
-                    const result = {}
-                    await should(expertAutomations.invokeAction('automation/import-flow', {
-                        params: { flow: 12345 }
-                    }, result)).rejectedWith('importFlow expects a JSON string or an array of node objects')
-                })
-                it('should pass addFlowTab: true to importNodes as addFlow: true', async () => {
-                    mockRED.view.importNodes = sinon.stub()
-                    const flowArray = [{ id: 'n1', type: 'inject' }]
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/import-flow', {
-                        params: { flow: flowArray, addFlowTab: true }
-                    }, result)
-                    mockRED.view.importNodes.calledOnce.should.be.true()
-                    const args = mockRED.view.importNodes.firstCall.args
-                    args[1].should.have.property('addFlow', true)
-                    result.should.have.property('success', true)
-                })
+        describe('importFlow action', () => {
+            it('should import flow JSON string', async () => {
+                mockRED.view.importNodes = sinon.stub()
+                mockRED._ = sinon.stub().returns('error')
+                const flowJson = JSON.stringify([{ id: 'n1', type: 'inject' }])
+                const result = {}
+                await expertAutomations.invokeAction('automation/import-flow', {
+                    params: { flow: flowJson }
+                }, result)
+                mockRED.view.importNodes.calledOnce.should.be.true()
+                const args = mockRED.view.importNodes.firstCall.args
+                args[1].should.have.property('touchImport', true)
+                result.should.have.property('success', true)
             })
+            it('should import flow array directly without JSON.parse', async () => {
+                mockRED.view.importNodes = sinon.stub()
+                const flowArray = [{ id: 'n1', type: 'inject' }]
+                const result = {}
+                await expertAutomations.invokeAction('automation/import-flow', {
+                    params: { flow: flowArray }
+                }, result)
+                mockRED.view.importNodes.calledOnce.should.be.true()
+                const args = mockRED.view.importNodes.firstCall.args
+                args[0].should.deepEqual(flowArray)
+                args[1].should.have.property('touchImport', true)
+                result.should.have.property('success', true)
+            })
+            it('should throw when flow param is neither string nor array', async () => {
+                mockRED.view.importNodes = sinon.stub()
+                mockRED._ = sinon.stub().returns('error')
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/import-flow', {
+                    params: { flow: 12345 }
+                }, result)).rejectedWith('importFlow expects a JSON string or an array of node objects')
+            })
+            it('should pass addFlowTab: true to importNodes as addFlow: true', async () => {
+                mockRED.view.importNodes = sinon.stub()
+                const flowArray = [{ id: 'n1', type: 'inject' }]
+                const result = {}
+                await expertAutomations.invokeAction('automation/import-flow', {
+                    params: { flow: flowArray, addFlowTab: true }
+                }, result)
+                mockRED.view.importNodes.calledOnce.should.be.true()
+                const args = mockRED.view.importNodes.firstCall.args
+                args[1].should.have.property('addFlow', true)
+                result.should.have.property('success', true)
+            })
+        })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -65,7 +65,7 @@ describeMain('expertAutomations', () => {
         it('should have supported actions', () => {
             const supportedActions = expertAutomations.supportedActions
             supportedActions.should.be.an.Object()
-            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab')
+            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab', 'automation/import-flow')
         })
         it('should have hasAction method', () => {
             expertAutomations.should.have.property('hasAction').which.is.a.Function()
@@ -310,7 +310,7 @@ describeMain('expertAutomations', () => {
                 mockRED.view.importNodes.calledOnce.should.be.true()
                 const args = mockRED.view.importNodes.firstCall.args
                 args[0].should.deepEqual([{ id: '', type: 'tab', label: 'My New Flow', disabled: false, info: '', env: [] }])
-                args[1].should.deepEqual({ generateIds: true, addFlow: false, notify: false })
+                args[1].should.deepEqual({ generateIds: true, addFlow: false, notify: false, touchImport: true })
                 result.should.have.property('success', true)
                 result.should.have.property('handled', true)
             })
@@ -323,5 +323,20 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
+            describe('importFlow action', () => {
+                it('should import flow JSON', async () => {
+                    mockRED.view.importNodes = sinon.stub()
+                    mockRED._ = sinon.stub().returns('error')
+                    const flowJson = JSON.stringify([{ id: 'n1', type: 'inject' }])
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/import-flow', {
+                        params: { flow: flowJson }
+                    }, result)
+                    mockRED.view.importNodes.calledOnce.should.be.true()
+                    const args = mockRED.view.importNodes.firstCall.args
+                    args[1].should.have.property('touchImport', true)
+                    result.should.have.property('success', true)
+                })
+            })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -351,6 +351,14 @@ describeMain('expertAutomations', () => {
                     args[1].should.have.property('touchImport', true)
                     result.should.have.property('success', true)
                 })
+                it('should throw when flow param is neither string nor array', async () => {
+                    mockRED.view.importNodes = sinon.stub()
+                    mockRED._ = sinon.stub().returns('error')
+                    const result = {}
+                    await should(expertAutomations.invokeAction('automation/import-flow', {
+                        params: { flow: 12345 }
+                    }, result)).rejectedWith('importFlow expects a JSON string or an array of node objects')
+                })
                 it('should pass addFlowTab: true to importNodes as addFlow: true', async () => {
                     mockRED.view.importNodes = sinon.stub()
                     const flowArray = [{ id: 'n1', type: 'inject' }]

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -307,6 +307,8 @@ describeMain('expertAutomations', () => {
             it('should use importNodes when addFlowTab is provided a title', async () => {
                 const result = {}
                 mockRED.view.importNodes = sinon.stub()
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().returns(false) }
                 sinon.stub(expertAutomations.redOps, 'commandAndWait').callsFake((cmd, event, options) => {
                     cmd() // execute the command immediately for testing
                     return Promise.resolve()
@@ -315,7 +317,7 @@ describeMain('expertAutomations', () => {
                 mockRED.view.importNodes.calledOnce.should.be.true()
                 const args = mockRED.view.importNodes.firstCall.args
                 args[0].should.deepEqual([{ id: '', type: 'tab', label: 'My New Flow', disabled: false, info: '', env: [] }])
-                args[1].should.deepEqual({ generateIds: true, addFlow: false, notify: false, touchImport: true, applyNodeDefaults: true })
+                args[1].should.deepEqual({ generateIds: true, addFlow: false, touchImport: true, applyNodeDefaults: true })
                 result.should.have.property('success', true)
                 result.should.have.property('handled', true)
             })
@@ -836,9 +838,13 @@ describeMain('expertAutomations', () => {
             })
         })
         describe('importFlow action', () => {
-            it('should import flow JSON string', async () => {
+            beforeEach(() => {
                 mockRED.view.importNodes = sinon.stub()
+                mockRED.nodes.dirty = sinon.stub()
                 mockRED._ = sinon.stub().returns('error')
+                mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().returns(false) }
+            })
+            it('should import flow JSON string', async () => {
                 const flowJson = JSON.stringify([{ id: 'n1', type: 'inject' }])
                 const result = {}
                 await expertAutomations.invokeAction('automation/import-flow', {
@@ -849,29 +855,28 @@ describeMain('expertAutomations', () => {
                 args[1].should.have.property('touchImport', true)
                 result.should.have.property('success', true)
             })
-            it('should import flow array directly without JSON.parse', async () => {
-                mockRED.view.importNodes = sinon.stub()
+            it('should import flow array and validate via redOps.validateFlow', async () => {
+                sinon.stub(expertAutomations.redOps, 'validateFlow').returns([{ id: 'n1', type: 'inject' }])
                 const flowArray = [{ id: 'n1', type: 'inject' }]
                 const result = {}
                 await expertAutomations.invokeAction('automation/import-flow', {
                     params: { flow: flowArray }
                 }, result)
+                expertAutomations.redOps.validateFlow.calledWith(flowArray).should.be.true()
                 mockRED.view.importNodes.calledOnce.should.be.true()
                 const args = mockRED.view.importNodes.firstCall.args
                 args[0].should.deepEqual(flowArray)
                 args[1].should.have.property('touchImport', true)
                 result.should.have.property('success', true)
+                expertAutomations.redOps.validateFlow.restore()
             })
             it('should throw when flow param is neither string nor array', async () => {
-                mockRED.view.importNodes = sinon.stub()
-                mockRED._ = sinon.stub().returns('error')
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/import-flow', {
                     params: { flow: 12345 }
                 }, result)).rejectedWith('importFlow expects a JSON string or an array of node objects')
             })
             it('should pass addFlowTab: true to importNodes as addFlow: true', async () => {
-                mockRED.view.importNodes = sinon.stub()
                 const flowArray = [{ id: 'n1', type: 'inject' }]
                 const result = {}
                 await expertAutomations.invokeAction('automation/import-flow', {
@@ -880,6 +885,25 @@ describeMain('expertAutomations', () => {
                 mockRED.view.importNodes.calledOnce.should.be.true()
                 const args = mockRED.view.importNodes.firstCall.args
                 args[1].should.have.property('addFlow', true)
+                result.should.have.property('success', true)
+            })
+            it('should throw if importing into a locked workspace', async () => {
+                mockRED.workspaces.isLocked = sinon.stub().returns(true)
+                const flowArray = [{ id: 'n1', type: 'inject' }]
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/import-flow', {
+                    params: { flow: flowArray }
+                }, result)).rejectedWith(/Cannot import into a locked workspace/)
+                mockRED.view.importNodes.called.should.be.false()
+            })
+            it('should allow import into locked workspace when addFlowTab is true', async () => {
+                mockRED.workspaces.isLocked = sinon.stub().returns(true)
+                const flowArray = [{ id: 'n1', type: 'inject' }]
+                const result = {}
+                await expertAutomations.invokeAction('automation/import-flow', {
+                    params: { flow: flowArray, addFlowTab: true }
+                }, result)
+                mockRED.view.importNodes.calledOnce.should.be.true()
                 result.should.have.property('success', true)
             })
         })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -311,7 +311,7 @@ describeMain('expertAutomations', () => {
                 mockRED.view.importNodes.calledOnce.should.be.true()
                 const args = mockRED.view.importNodes.firstCall.args
                 args[0].should.deepEqual([{ id: '', type: 'tab', label: 'My New Flow', disabled: false, info: '', env: [] }])
-                args[1].should.deepEqual({ generateIds: true, addFlow: false, notify: false, touchImport: true })
+                args[1].should.deepEqual({ generateIds: true, addFlow: false, notify: false, touchImport: true, applyNodeDefaults: true })
                 result.should.have.property('success', true)
                 result.should.have.property('handled', true)
             })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -324,7 +324,7 @@ describeMain('expertAutomations', () => {
             })
         })
             describe('importFlow action', () => {
-                it('should import flow JSON', async () => {
+                it('should import flow JSON string', async () => {
                     mockRED.view.importNodes = sinon.stub()
                     mockRED._ = sinon.stub().returns('error')
                     const flowJson = JSON.stringify([{ id: 'n1', type: 'inject' }])
@@ -335,6 +335,31 @@ describeMain('expertAutomations', () => {
                     mockRED.view.importNodes.calledOnce.should.be.true()
                     const args = mockRED.view.importNodes.firstCall.args
                     args[1].should.have.property('touchImport', true)
+                    result.should.have.property('success', true)
+                })
+                it('should import flow array directly without JSON.parse', async () => {
+                    mockRED.view.importNodes = sinon.stub()
+                    const flowArray = [{ id: 'n1', type: 'inject' }]
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/import-flow', {
+                        params: { flow: flowArray }
+                    }, result)
+                    mockRED.view.importNodes.calledOnce.should.be.true()
+                    const args = mockRED.view.importNodes.firstCall.args
+                    args[0].should.deepEqual(flowArray)
+                    args[1].should.have.property('touchImport', true)
+                    result.should.have.property('success', true)
+                })
+                it('should pass addFlowTab: true to importNodes as addFlow: true', async () => {
+                    mockRED.view.importNodes = sinon.stub()
+                    const flowArray = [{ id: 'n1', type: 'inject' }]
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/import-flow', {
+                        params: { flow: flowArray, addFlowTab: true }
+                    }, result)
+                    mockRED.view.importNodes.calledOnce.should.be.true()
+                    const args = mockRED.view.importNodes.firstCall.args
+                    args[1].should.have.property('addFlow', true)
                     result.should.have.property('success', true)
                 })
             })

--- a/test/unit/resources/expertComms.test.js
+++ b/test/unit/resources/expertComms.test.js
@@ -951,7 +951,8 @@ describeMain('expertComms', function () {
             mockRED.view.importNodes.firstCall.args[1].should.eql({
                 generateIds: true,
                 addFlow: false,
-                notify: true
+                notify: true,
+                touchImport: true
             })
 
             eventSource.postMessage.calledOnce.should.be.true()

--- a/test/unit/resources/expertComms.test.js
+++ b/test/unit/resources/expertComms.test.js
@@ -119,6 +119,9 @@ describeMain('expertComms', function () {
             actionList: {
                 hide: sinon.stub()
             },
+            workspaces: {
+                isLocked: sinon.stub().returns(false)
+            },
             nrAssistant: {
                 DEBUG: false
             },
@@ -952,7 +955,6 @@ describeMain('expertComms', function () {
             mockRED.view.importNodes.firstCall.args[1].should.eql({
                 generateIds: true,
                 addFlow: false,
-                notify: true,
                 touchImport: true,
                 applyNodeDefaults: true
             })

--- a/test/unit/resources/expertComms.test.js
+++ b/test/unit/resources/expertComms.test.js
@@ -953,7 +953,8 @@ describeMain('expertComms', function () {
                 generateIds: true,
                 addFlow: false,
                 notify: true,
-                touchImport: true
+                touchImport: true,
+                applyNodeDefaults: true
             })
 
             eventSource.postMessage.calledOnce.should.be.true()

--- a/test/unit/resources/expertComms.test.js
+++ b/test/unit/resources/expertComms.test.js
@@ -84,7 +84,8 @@ describeMain('expertComms', function () {
                 selection: sinon.stub()
             },
             nodes: {
-                createExportableNodeSet: sinon.stub().callsFake((nodes) => nodes || [])
+                createExportableNodeSet: sinon.stub().callsFake((nodes) => nodes || []),
+                dirty: sinon.stub()
             },
             notify: sinon.stub(),
             _: sinon.stub().callsFake((key, params) => {

--- a/test/unit/resources/redOps.test.js
+++ b/test/unit/resources/redOps.test.js
@@ -66,6 +66,23 @@ describeMain('redOps', () => {
         })
     })
 
+    describe('validateFlow', () => {
+        it('should validate a valid flow array', () => {
+            const flow = [{ id: 'n1', type: 'inject' }, { id: 'n2', type: 'debug' }]
+            const result = redOps.validateFlow(flow)
+            result.should.be.an.Array()
+            result.should.have.length(2)
+        })
+        it('should reject non-array input', () => {
+            should(() => redOps.validateFlow({ id: 'n1' })).throw()
+        })
+        it('should reject nodes missing id', () => {
+            should(() => redOps.validateFlow([{ type: 'inject' }])).throw()
+        })
+        it('should reject nodes missing type', () => {
+            should(() => redOps.validateFlow([{ id: 'n1' }])).throw()
+        })
+    })
     describe('validateFlowString', () => {
         it('should validate valid flow JSON string', () => {
             const flowString = JSON.stringify([


### PR DESCRIPTION
## Summary
- Adds `automation/import-flow` action to `ExpertAutomations`
- Migrates from legacy `custom:import-flow` in expertComms.js (custom: variant kept for backwards compat)
- Supports flow JSON string or array, addFlow flag, and generateIds option
- Adds `touchImport: true` to `importNodes()` call

Closes #172