### PR TITLE
feat: add automation/show-workspace action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -276,6 +276,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
         this.RED.view.redraw()
     }
 
+    /**
+     * Navigate to a workspace tab, validating it exists first.
+     * @param {string} id - workspace ID to show
+     */
+    showWorkspace (id) {
+        const ws = this.RED.nodes.workspace(id)
+        if (!ws) throw new Error(`Workspace ${id} not found`)
+        this.RED.workspaces.show(id)
+    }
+
     get supportedActions () {
         return this.actions
     }
@@ -353,7 +363,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             break
 
         case SHOW_WORKSPACE:
-            this.RED.workspaces.show(params.id)
+            this.showWorkspace(params.id)
             result.success = true
             break
         default:

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -6,9 +6,10 @@ const GET_NODES = 'automation/get-nodes'
 const EDIT_NODE = 'automation/open-node-edit'
 const SEARCH = 'automation/search'
 const ADD_FLOW_TAB = 'automation/add-flow-tab'
+const SHOW_WORKSPACE = 'automation/show-workspace'
 
 /**
- * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB} ExpertAutomationsActionsEnum
+ * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB|SHOW_WORKSPACE} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -96,6 +97,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         description: 'Optional title for the new flow tab'
                     }
                 }
+            }
+        }
+,
+        [SHOW_WORKSPACE]: {
+            params: {
+                type: 'object',
+                properties: {
+                    id: { type: 'string', description: 'ID of the flow tab or subflow to navigate to' }
+                },
+                required: ['id']
             }
         }
     })
@@ -300,6 +311,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
+        case SHOW_WORKSPACE:
+            this.RED.workspaces.show(params.id)
+            result.success = true
+            break
         default:
             result.handled = false
             result.success = false

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -98,8 +98,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 }
             }
-        }
-,
+        },
         [SHOW_WORKSPACE]: {
             params: {
                 type: 'object',

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -65,7 +65,7 @@ describeMain('expertAutomations', () => {
         it('should have supported actions', () => {
             const supportedActions = expertAutomations.supportedActions
             supportedActions.should.be.an.Object()
-            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab')
+            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab', 'automation/show-workspace')
         })
         it('should have hasAction method', () => {
             expertAutomations.should.have.property('hasAction').which.is.a.Function()
@@ -323,5 +323,16 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
+            describe('showWorkspace action', () => {
+                it('should navigate to the specified workspace', async () => {
+                    mockRED.workspaces = { show: sinon.stub() }
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/show-workspace', {
+                        params: { id: 'tab1' }
+                    }, result)
+                    mockRED.workspaces.show.calledWith('tab1').should.be.true()
+                    result.should.have.property('success', true)
+                })
+            })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -374,6 +374,7 @@ describeMain('expertAutomations', () => {
         })
         describe('showWorkspace action', () => {
             it('should navigate to the specified workspace', async () => {
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', type: 'tab' })
                 mockRED.workspaces = { show: sinon.stub() }
                 const result = {}
                 await expertAutomations.invokeAction('automation/show-workspace', {
@@ -381,6 +382,14 @@ describeMain('expertAutomations', () => {
                 }, result)
                 mockRED.workspaces.show.calledWith('tab1').should.be.true()
                 result.should.have.property('success', true)
+            })
+            it('should throw if workspace does not exist', async () => {
+                mockRED.nodes.workspace = sinon.stub().returns(null)
+                mockRED.workspaces = { show: sinon.stub() }
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/show-workspace', {
+                    params: { id: 'nonexistent' }
+                }, result)).rejectedWith(/Workspace nonexistent not found/)
             })
         })
     })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -323,16 +323,16 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
-            describe('showWorkspace action', () => {
-                it('should navigate to the specified workspace', async () => {
-                    mockRED.workspaces = { show: sinon.stub() }
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/show-workspace', {
-                        params: { id: 'tab1' }
-                    }, result)
-                    mockRED.workspaces.show.calledWith('tab1').should.be.true()
-                    result.should.have.property('success', true)
-                })
+        describe('showWorkspace action', () => {
+            it('should navigate to the specified workspace', async () => {
+                mockRED.workspaces = { show: sinon.stub() }
+                const result = {}
+                await expertAutomations.invokeAction('automation/show-workspace', {
+                    params: { id: 'tab1' }
+                }, result)
+                mockRED.workspaces.show.calledWith('tab1').should.be.true()
+                result.should.have.property('success', true)
             })
+        })
     })
 })


### PR DESCRIPTION
## Summary
- Adds `automation/show-workspace` action to `ExpertAutomations`
- Navigates to a specific flow tab or subflow via `RED.workspaces.show(id)`

Closes #188