### PR TITLE
feat: add close UI panel actions

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -238,7 +238,20 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
     closeSearch () { this.RED.search.hide() }
 
-    closeTypeSearch () { this.RED.typeSearch.hide() }
+    closeTypeSearch () {
+        // RED.typeSearch.hide() alone does NOT invoke the cancelCallback set by
+        // RED.view, which cleans up ghost nodes, drag lines, and resets mouse state.
+        // Dispatching ESC on the type-search input triggers NR4's keyboard handler
+        // (scope "red-ui-type-search") which calls both hide() and cancelCallback().
+        try {
+            const input = document.getElementById('red-ui-type-search-input')
+            if (input) {
+                input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }))
+                return
+            }
+        } catch (_) { /* Node.js test env or missing DOM */ }
+        this.RED.typeSearch.hide()
+    }
 
     closeActionList () { this.RED.actionList.hide() }
 

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -100,8 +100,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 }
             }
-        }
-,
+        },
         [CLOSE_SEARCH]: { params: null },
         [CLOSE_TYPE_SEARCH]: { params: null },
         [CLOSE_ACTION_LIST]: { params: null }

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -6,9 +6,12 @@ const GET_NODES = 'automation/get-nodes'
 const EDIT_NODE = 'automation/open-node-edit'
 const SEARCH = 'automation/search'
 const ADD_FLOW_TAB = 'automation/add-flow-tab'
+const CLOSE_SEARCH = 'automation/close-search'
+const CLOSE_TYPE_SEARCH = 'automation/close-type-search'
+const CLOSE_ACTION_LIST = 'automation/close-action-list'
 
 /**
- * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB} ExpertAutomationsActionsEnum
+ * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB|CLOSE_SEARCH|CLOSE_TYPE_SEARCH|CLOSE_ACTION_LIST} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -98,6 +101,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 }
             }
         }
+,
+        [CLOSE_SEARCH]: { params: null },
+        [CLOSE_TYPE_SEARCH]: { params: null },
+        [CLOSE_ACTION_LIST]: { params: null }
     })
 
     /**
@@ -229,6 +236,12 @@ export class ExpertAutomations extends ExpertActionsInterface {
         return newTab
     }
 
+    closeSearch () { this.RED.search.hide() }
+
+    closeTypeSearch () { this.RED.typeSearch.hide() }
+
+    closeActionList () { this.RED.actionList.hide() }
+
     get supportedActions () {
         return this.actions
     }
@@ -300,6 +313,18 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
+        case CLOSE_SEARCH:
+            this.closeSearch()
+            result.success = true
+            break
+        case CLOSE_TYPE_SEARCH:
+            this.closeTypeSearch()
+            result.success = true
+            break
+        case CLOSE_ACTION_LIST:
+            this.closeActionList()
+            result.success = true
+            break
         default:
             result.handled = false
             result.success = false

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -65,7 +65,7 @@ describeMain('expertAutomations', () => {
         it('should have supported actions', () => {
             const supportedActions = expertAutomations.supportedActions
             supportedActions.should.be.an.Object()
-            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab')
+            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab', 'automation/close-search', 'automation/close-type-search', 'automation/close-action-list')
         })
         it('should have hasAction method', () => {
             expertAutomations.should.have.property('hasAction').which.is.a.Function()
@@ -323,5 +323,28 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
+            describe('close UI panel actions', () => {
+                it('should close search', async () => {
+                    mockRED.search = { show: sinon.stub(), search: sinon.stub(), hide: sinon.stub() }
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/close-search', { params: {} }, result)
+                    mockRED.search.hide.calledOnce.should.be.true()
+                    result.should.have.property('success', true)
+                })
+                it('should close type search', async () => {
+                    mockRED.typeSearch = { hide: sinon.stub() }
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/close-type-search', { params: {} }, result)
+                    mockRED.typeSearch.hide.calledOnce.should.be.true()
+                    result.should.have.property('success', true)
+                })
+                it('should close action list', async () => {
+                    mockRED.actionList = { hide: sinon.stub() }
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/close-action-list', { params: {} }, result)
+                    mockRED.actionList.hide.calledOnce.should.be.true()
+                    result.should.have.property('success', true)
+                })
+            })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -331,12 +331,42 @@ describeMain('expertAutomations', () => {
                     mockRED.search.hide.calledOnce.should.be.true()
                     result.should.have.property('success', true)
                 })
-                it('should close type search', async () => {
+                it('should close type search via ESC dispatch when input element exists', async () => {
                     mockRED.typeSearch = { hide: sinon.stub() }
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/close-type-search', { params: {} }, result)
-                    mockRED.typeSearch.hide.calledOnce.should.be.true()
-                    result.should.have.property('success', true)
+                    const mockInput = { dispatchEvent: sinon.stub() }
+                    const origDocument = globalThis.document
+                    const origKeyboardEvent = globalThis.KeyboardEvent
+                    globalThis.document = { getElementById: sinon.stub().withArgs('red-ui-type-search-input').returns(mockInput) }
+                    globalThis.KeyboardEvent = class KeyboardEvent {
+                        constructor (type, opts) { this.type = type; this.key = opts.key; this.keyCode = opts.keyCode; this.bubbles = opts.bubbles }
+                    }
+                    try {
+                        const result = {}
+                        await expertAutomations.invokeAction('automation/close-type-search', { params: {} }, result)
+                        mockInput.dispatchEvent.calledOnce.should.be.true()
+                        const event = mockInput.dispatchEvent.firstCall.args[0]
+                        event.key.should.equal('Escape')
+                        event.keyCode.should.equal(27)
+                        event.bubbles.should.be.true()
+                        mockRED.typeSearch.hide.called.should.be.false()
+                        result.should.have.property('success', true)
+                    } finally {
+                        if (origDocument) { globalThis.document = origDocument } else { delete globalThis.document }
+                        if (origKeyboardEvent) { globalThis.KeyboardEvent = origKeyboardEvent } else { delete globalThis.KeyboardEvent }
+                    }
+                })
+                it('should fall back to RED.typeSearch.hide() when input element not found', async () => {
+                    mockRED.typeSearch = { hide: sinon.stub() }
+                    const origDocument = globalThis.document
+                    globalThis.document = { getElementById: sinon.stub().returns(null) }
+                    try {
+                        const result = {}
+                        await expertAutomations.invokeAction('automation/close-type-search', { params: {} }, result)
+                        mockRED.typeSearch.hide.calledOnce.should.be.true()
+                        result.should.have.property('success', true)
+                    } finally {
+                        if (origDocument) { globalThis.document = origDocument } else { delete globalThis.document }
+                    }
                 })
                 it('should close action list', async () => {
                     mockRED.actionList = { hide: sinon.stub() }

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -323,58 +323,58 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
             })
         })
-            describe('close UI panel actions', () => {
-                it('should close search', async () => {
-                    mockRED.search = { show: sinon.stub(), search: sinon.stub(), hide: sinon.stub() }
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/close-search', { params: {} }, result)
-                    mockRED.search.hide.calledOnce.should.be.true()
-                    result.should.have.property('success', true)
-                })
-                it('should close type search via ESC dispatch when input element exists', async () => {
-                    mockRED.typeSearch = { hide: sinon.stub() }
-                    const mockInput = { dispatchEvent: sinon.stub() }
-                    const origDocument = globalThis.document
-                    const origKeyboardEvent = globalThis.KeyboardEvent
-                    globalThis.document = { getElementById: sinon.stub().withArgs('red-ui-type-search-input').returns(mockInput) }
-                    globalThis.KeyboardEvent = class KeyboardEvent {
-                        constructor (type, opts) { this.type = type; this.key = opts.key; this.keyCode = opts.keyCode; this.bubbles = opts.bubbles }
-                    }
-                    try {
-                        const result = {}
-                        await expertAutomations.invokeAction('automation/close-type-search', { params: {} }, result)
-                        mockInput.dispatchEvent.calledOnce.should.be.true()
-                        const event = mockInput.dispatchEvent.firstCall.args[0]
-                        event.key.should.equal('Escape')
-                        event.keyCode.should.equal(27)
-                        event.bubbles.should.be.true()
-                        mockRED.typeSearch.hide.called.should.be.false()
-                        result.should.have.property('success', true)
-                    } finally {
-                        if (origDocument) { globalThis.document = origDocument } else { delete globalThis.document }
-                        if (origKeyboardEvent) { globalThis.KeyboardEvent = origKeyboardEvent } else { delete globalThis.KeyboardEvent }
-                    }
-                })
-                it('should fall back to RED.typeSearch.hide() when input element not found', async () => {
-                    mockRED.typeSearch = { hide: sinon.stub() }
-                    const origDocument = globalThis.document
-                    globalThis.document = { getElementById: sinon.stub().returns(null) }
-                    try {
-                        const result = {}
-                        await expertAutomations.invokeAction('automation/close-type-search', { params: {} }, result)
-                        mockRED.typeSearch.hide.calledOnce.should.be.true()
-                        result.should.have.property('success', true)
-                    } finally {
-                        if (origDocument) { globalThis.document = origDocument } else { delete globalThis.document }
-                    }
-                })
-                it('should close action list', async () => {
-                    mockRED.actionList = { hide: sinon.stub() }
-                    const result = {}
-                    await expertAutomations.invokeAction('automation/close-action-list', { params: {} }, result)
-                    mockRED.actionList.hide.calledOnce.should.be.true()
-                    result.should.have.property('success', true)
-                })
+        describe('close UI panel actions', () => {
+            it('should close search', async () => {
+                mockRED.search = { show: sinon.stub(), search: sinon.stub(), hide: sinon.stub() }
+                const result = {}
+                await expertAutomations.invokeAction('automation/close-search', { params: {} }, result)
+                mockRED.search.hide.calledOnce.should.be.true()
+                result.should.have.property('success', true)
             })
+            it('should close type search via ESC dispatch when input element exists', async () => {
+                mockRED.typeSearch = { hide: sinon.stub() }
+                const mockInput = { dispatchEvent: sinon.stub() }
+                const origDocument = globalThis.document
+                const origKeyboardEvent = globalThis.KeyboardEvent
+                globalThis.document = { getElementById: sinon.stub().withArgs('red-ui-type-search-input').returns(mockInput) }
+                globalThis.KeyboardEvent = class KeyboardEvent {
+                    constructor (type, opts) { this.type = type; this.key = opts.key; this.keyCode = opts.keyCode; this.bubbles = opts.bubbles }
+                }
+                try {
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/close-type-search', { params: {} }, result)
+                    mockInput.dispatchEvent.calledOnce.should.be.true()
+                    const event = mockInput.dispatchEvent.firstCall.args[0]
+                    event.key.should.equal('Escape')
+                    event.keyCode.should.equal(27)
+                    event.bubbles.should.be.true()
+                    mockRED.typeSearch.hide.called.should.be.false()
+                    result.should.have.property('success', true)
+                } finally {
+                    if (origDocument) { globalThis.document = origDocument } else { delete globalThis.document }
+                    if (origKeyboardEvent) { globalThis.KeyboardEvent = origKeyboardEvent } else { delete globalThis.KeyboardEvent }
+                }
+            })
+            it('should fall back to RED.typeSearch.hide() when input element not found', async () => {
+                mockRED.typeSearch = { hide: sinon.stub() }
+                const origDocument = globalThis.document
+                globalThis.document = { getElementById: sinon.stub().returns(null) }
+                try {
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/close-type-search', { params: {} }, result)
+                    mockRED.typeSearch.hide.calledOnce.should.be.true()
+                    result.should.have.property('success', true)
+                } finally {
+                    if (origDocument) { globalThis.document = origDocument } else { delete globalThis.document }
+                }
+            })
+            it('should close action list', async () => {
+                mockRED.actionList = { hide: sinon.stub() }
+                const result = {}
+                await expertAutomations.invokeAction('automation/close-action-list', { params: {} }, result)
+                mockRED.actionList.hide.calledOnce.should.be.true()
+                result.should.have.property('success', true)
+            })
+        })
     })
 })


### PR DESCRIPTION
## Summary
- Adds three close UI panel actions to `ExpertAutomations`:
  - `automation/close-search` — calls `RED.search.hide()`
  - `automation/close-type-search` — calls `RED.typeSearch.hide()`
  - `automation/close-action-list` — calls `RED.actionList.hide()`
- These are `automation/` counterparts to the existing `custom:` handlers in `expertComms.js`

Closes #234