### PR TITLE
Use git ref_name for version instead of npm info

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -21,8 +21,6 @@ jobs:
         id: getVersion
         shell: bash
         run: |
-          # VERSION=$(npm info . --json version | sed -e 's/"//g')
-          # echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
       - uses: flowfuse/github-actions-workflows/actions/update-nr-flows@v0.52.0
         with:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 24
       - run: npm ci --omit=dev
-      - uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4
+      - uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4.1.5
         with:
           token: ${{ secrets.NPM_PUBLISH_TOKEN }}
           access: public

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 24
       - run: npm ci --omit=dev
-      - uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4.1.5
+      - uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4
         with:
           token: ${{ secrets.NPM_PUBLISH_TOKEN }}
           access: public
@@ -21,8 +21,9 @@ jobs:
         id: getVersion
         shell: bash
         run: |
-          VERSION=$(npm info . --json version | sed -e 's/"//g')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          # VERSION=$(npm info . --json version | sed -e 's/"//g')
+          # echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
       - uses: flowfuse/github-actions-workflows/actions/update-nr-flows@v0.52.0
         with:
           package: '@flowfuse/nr-assistant'


### PR DESCRIPTION
## Description

Stop using `npm info` to retrieve the published version in the `getVersion` step. Instead, read the version directly from `github.ref_name`.

### Why

`npm info` lags after a publish. By the time the `update-nr-flows` action runs, npm is still returning the previous version — so the action polls flows.nodered.org, sees the old version in the catalog, and times out waiting for a version that has already shipped.

### How

Comment out the `npm info` retrieval commands and replace with `github.ref_name`, which is the git tag that triggered the release and is always correct.

Same fix applied to `nr-tools-plugin` in #74 by @hardillb.

### Related

- FlowFuse/nr-tools-plugin#74
- https://flowfuse.slack.com/archives/C032Q63FGG1/p1775670662304109


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

