### PR TITLE
fix(add-nodes): reject empty nodes array and pre-check duplicate IDs

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -491,6 +491,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {boolean} [options.generateIds=false] - regenerate node IDs during import
      */
     addNodes (nodes, { generateIds = false } = {}) {
+        if (!nodes.length) throw new Error('nodes array must not be empty')
         // Validate required fields and types
         const prepared = nodes.map(rawNode => {
             if (!rawNode.id) throw new Error('Node is missing required property: id')
@@ -507,14 +508,14 @@ export class ExpertAutomations extends ExpertActionsInterface {
             const ws = this.RED.nodes.workspace(z)
             if (ws.locked) throw new Error(`Target tab ${z} is locked`)
         }
-        this.RED.view.importNodes(prepared, { generateIds, addFlow: false, notify: false, touchImport: true, applyNodeDefaults: true })
-        // Validate import actually succeeded (only when IDs are known)
+        // Pre-import: reject if any node ID already exists on the canvas
         if (!generateIds) {
-            const missing = prepared.filter(n => !this.RED.nodes.node(n.id))
-            if (missing.length > 0) {
-                throw new Error(`Failed to add node(s): ${missing.map(n => n.id).join(', ')} — IDs may already exist. Retry with generateIds: true`)
+            const existing = prepared.filter(n => this.RED.nodes.node(n.id))
+            if (existing.length > 0) {
+                throw new Error(`Node ID(s) already exist: ${existing.map(n => n.id).join(', ')} — use generateIds: true to auto-assign new IDs`)
             }
         }
+        this.RED.view.importNodes(prepared, { generateIds, addFlow: false, notify: false, touchImport: true, applyNodeDefaults: true })
         this.RED.nodes.dirty(true)
     }
 

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -559,7 +559,7 @@ describeMain('expertAutomations', () => {
             it('should validate types and delegate to importNodes with applyNodeDefaults', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: { name: { value: '' }, repeat: { value: '' } } })
                 mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', type: 'tab' })
-                mockRED.nodes.node = sinon.stub().returns({ id: 'n1' })
+                mockRED.nodes.node = sinon.stub().returns(null) // node doesn't exist yet (pre-import)
                 mockRED.view.importNodes = sinon.stub()
                 mockRED.nodes.dirty = sinon.stub()
                 const nodes = [{ id: 'n1', type: 'inject', z: 'tab1', x: 100, y: 200 }]
@@ -588,7 +588,7 @@ describeMain('expertAutomations', () => {
             it('should switch to target tab when nodes target a different workspace', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
                 mockRED.nodes.workspace = sinon.stub().returns({ id: 'other-tab', type: 'tab' })
-                mockRED.nodes.node = sinon.stub().returns({ id: 'n1' })
+                mockRED.nodes.node = sinon.stub().returns(null)
                 mockRED.view.importNodes = sinon.stub()
                 mockRED.nodes.dirty = sinon.stub()
                 mockRED.workspaces.active.returns('active-tab')
@@ -603,7 +603,7 @@ describeMain('expertAutomations', () => {
             it('should validate workspace via showWorkspace even when targeting the active tab', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
                 mockRED.nodes.workspace = sinon.stub().returns({ id: 'active-tab', type: 'tab' })
-                mockRED.nodes.node = sinon.stub().returns({ id: 'n1' })
+                mockRED.nodes.node = sinon.stub().returns(null)
                 mockRED.view.importNodes = sinon.stub()
                 mockRED.nodes.dirty = sinon.stub()
                 mockRED.workspaces.active.returns('active-tab')
@@ -644,16 +644,23 @@ describeMain('expertAutomations', () => {
                     params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1' }] }
                 }, result)).rejectedWith(/Target tab tab1 is locked/)
             })
-            it('should throw if import silently fails (node IDs already exist)', async () => {
+            it('should throw if node IDs already exist on the canvas', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
                 mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', type: 'tab' })
-                mockRED.nodes.node = sinon.stub().returns(null)
+                mockRED.nodes.node = sinon.stub().returns({ id: 'n1' })
                 mockRED.view.importNodes = sinon.stub()
                 mockRED.nodes.dirty = sinon.stub()
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1' }] }
-                }, result)).rejectedWith(/Failed to add node/)
+                }, result)).rejectedWith(/Node ID\(s\) already exist: n1/)
+                mockRED.view.importNodes.called.should.be.false('importNodes should not be called when IDs already exist')
+            })
+            it('should throw if nodes array is empty', async () => {
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [] }
+                }, result)).rejectedWith(/nodes array must not be empty/)
             })
             it('should pass generateIds option to importNodes', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })


### PR DESCRIPTION
## Summary

- Throw early if `nodes` array is empty instead of silently succeeding
- Check for existing node IDs **before** calling `importNodes` rather than after — the post-import check was unreliable because `RED.nodes.node()` returns the original node when the ID already exists, masking the silent import failure

## Test plan

- [x] Unit test: `should throw if nodes array is empty`
- [x] Unit test: `should throw if node IDs already exist on the canvas` (verifies `importNodes` is never called)
- [x] Existing tests updated and passing (216 total)

Fixes #259, fixes #260