### PR TITLE
feat(set-links): add automation/set-links action for link nodes

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -660,6 +660,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (sourceNode.type === 'link out' && sourceNode.mode === 'return') {
             throw new Error(`Source node ${source} is a link out in return mode and cannot have outbound links`)
         }
+        // link call in "dynamic" mode cannot have static links
+        if (sourceNode.type === 'link call' && sourceNode.linkType === 'dynamic') {
+            throw new Error(`Source node ${source} is a link call in dynamic mode and cannot have static links`)
+        }
         // Check workspace locks for both nodes
         if (sourceNode.z && this.RED.workspaces.isLocked(sourceNode.z)) {
             throw new Error(`Cannot modify links — workspace ${sourceNode.z} is locked`)
@@ -680,7 +684,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
             }
             // Record history before mutating
             editHistories.push({ t: 'edit', node: sourceNode, changes: { links: [...sourceLinks] }, changed: wasSourceChanged })
-            sourceNode.links = [...sourceLinks, target]
+            // link call can only have one target — replace instead of append
+            sourceNode.links = sourceNode.type === 'link call' ? [target] : [...sourceLinks, target]
             if (isBidirectional) {
                 editHistories.push({ t: 'edit', node: targetNode, changes: { links: [...targetLinks] }, changed: wasTargetChanged })
                 targetNode.links = [...targetLinks, source]
@@ -707,6 +712,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (this.RED.editor?.validateNode) {
             this.RED.editor.validateNode(sourceNode)
             this.RED.editor.validateNode(targetNode)
+        }
+        // Refresh selection to update virtual link wires on the canvas
+        const selection = this.RED.view.selection()
+        if (selection?.nodes) {
+            this.RED.view.select({ nodes: selection.nodes })
         }
         this.RED.view.redraw()
     }

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -656,6 +656,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
         this.RED.history.push({ t: 'multi', events: editHistories, dirty: wasDirty })
         this.RED.nodes.dirty(true)
+        if (this.RED.editor?.validateNode) {
+            this.RED.editor.validateNode(sourceNode)
+            this.RED.editor.validateNode(targetNode)
+        }
         this.RED.view.redraw()
     }
 

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -21,7 +21,24 @@ const SET_LINKS = 'automation/set-links'
 const IMPORT_FLOW = 'automation/import-flow'
 
 /**
- * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB|UPDATE_NODE|SHOW_WORKSPACE|GET_FLOW|CLOSE_SEARCH|CLOSE_TYPE_SEARCH|CLOSE_ACTION_LIST|ADD_TAB|REMOVE_TAB|ADD_NODES|REMOVE_NODES|SET_WIRES|SET_LINKS|IMPORT_FLOW} ExpertAutomationsActionsEnum
+ * @typedef {SELECT_NODES
+ *   |GET_NODES
+ *   |EDIT_NODE
+ *   |SEARCH
+ *   |ADD_FLOW_TAB
+ *   |UPDATE_NODE
+ *   |SHOW_WORKSPACE
+ *   |GET_FLOW
+ *   |CLOSE_SEARCH
+ *   |CLOSE_TYPE_SEARCH
+ *   |CLOSE_ACTION_LIST
+ *   |ADD_TAB
+ *   |REMOVE_TAB
+ *   |ADD_NODES
+ *   |REMOVE_NODES
+ *   |SET_WIRES
+ *   |SET_LINKS
+ *   |IMPORT_FLOW} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -17,9 +17,10 @@ const REMOVE_TAB = 'automation/remove-tab'
 const ADD_NODES = 'automation/add-nodes'
 const REMOVE_NODES = 'automation/remove-nodes'
 const SET_WIRES = 'automation/set-wires'
+const SET_LINKS = 'automation/set-links'
 
 /**
- * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB|UPDATE_NODE|SHOW_WORKSPACE|GET_FLOW|CLOSE_SEARCH|CLOSE_TYPE_SEARCH|CLOSE_ACTION_LIST|ADD_TAB|REMOVE_TAB|ADD_NODES|REMOVE_NODES|SET_WIRES} ExpertAutomationsActionsEnum
+ * @typedef {SELECT_NODES|GET_NODES|EDIT_NODE|SEARCH|ADD_FLOW_TAB|UPDATE_NODE|SHOW_WORKSPACE|GET_FLOW|CLOSE_SEARCH|CLOSE_TYPE_SEARCH|CLOSE_ACTION_LIST|ADD_TAB|REMOVE_TAB|ADD_NODES|REMOVE_NODES|SET_WIRES|SET_LINKS} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -215,6 +216,17 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     to: { type: 'string', description: 'Target node ID' }
                 },
                 required: ['mode', 'from', 'to']
+            }
+        },
+        [SET_LINKS]: {
+            params: {
+                type: 'object',
+                properties: {
+                    mode: { type: 'string', enum: ['add', 'remove'], description: 'Whether to add or remove a virtual link between link nodes' },
+                    source: { type: 'string', description: 'Source link node ID (link out or link call)' },
+                    target: { type: 'string', description: 'Target link node ID (link in)' }
+                },
+                required: ['mode', 'source', 'target']
             }
         }
     })
@@ -574,6 +586,79 @@ export class ExpertAutomations extends ExpertActionsInterface {
         this.RED.view.redraw()
     }
 
+    /**
+     * Add or remove a virtual link between link nodes (link out → link in, link call → link in).
+     * For link out ↔ link in, the connection is bidirectional (both nodes' `links` arrays are updated).
+     * For link call → link in, only the link call node's `links` array is updated.
+     * @param {object} params
+     * @param {'add'|'remove'} params.mode
+     * @param {string} params.source - Source link node ID (link out or link call)
+     * @param {string} params.target - Target link node ID (link in)
+     */
+    setLinks ({ mode, source, target }) {
+        if (source === target) throw new Error('Cannot link a node to itself')
+        const sourceNode = this.RED.nodes.node(source)
+        if (!sourceNode) throw new Error(`Source node ${source} not found`)
+        const targetNode = this.RED.nodes.node(target)
+        if (!targetNode) throw new Error(`Target node ${target} not found`)
+        // Validate types: source must be link out or link call, target must be link in
+        if (sourceNode.type !== 'link out' && sourceNode.type !== 'link call') {
+            throw new Error(`Source node ${source} must be a link out or link call node (got ${sourceNode.type})`)
+        }
+        if (targetNode.type !== 'link in') {
+            throw new Error(`Target node ${target} must be a link in node (got ${targetNode.type})`)
+        }
+        // link out in "return" mode cannot have outbound links
+        if (sourceNode.type === 'link out' && sourceNode.mode === 'return') {
+            throw new Error(`Source node ${source} is a link out in return mode and cannot have outbound links`)
+        }
+        // Check workspace locks for both nodes
+        if (sourceNode.z && this.RED.workspaces.isLocked(sourceNode.z)) {
+            throw new Error(`Cannot modify links — workspace ${sourceNode.z} is locked`)
+        }
+        if (targetNode.z && targetNode.z !== sourceNode.z && this.RED.workspaces.isLocked(targetNode.z)) {
+            throw new Error(`Cannot modify links — workspace ${targetNode.z} is locked`)
+        }
+        const isBidirectional = sourceNode.type === 'link out'
+        const sourceLinks = sourceNode.links || []
+        const targetLinks = targetNode.links || []
+        const wasDirty = this.RED.nodes.dirty()
+        const wasSourceChanged = sourceNode.changed
+        const wasTargetChanged = targetNode.changed
+        const editHistories = []
+        if (mode === 'add') {
+            if (sourceLinks.includes(target)) {
+                throw new Error(`Link already exists from ${source} to ${target}`)
+            }
+            // Record history before mutating
+            editHistories.push({ t: 'edit', node: sourceNode, changes: { links: [...sourceLinks] }, changed: wasSourceChanged })
+            sourceNode.links = [...sourceLinks, target]
+            if (isBidirectional) {
+                editHistories.push({ t: 'edit', node: targetNode, changes: { links: [...targetLinks] }, changed: wasTargetChanged })
+                targetNode.links = [...targetLinks, source]
+            }
+        } else {
+            if (!sourceLinks.includes(target)) {
+                throw new Error(`Link not found from ${source} to ${target}`)
+            }
+            editHistories.push({ t: 'edit', node: sourceNode, changes: { links: [...sourceLinks] }, changed: wasSourceChanged })
+            sourceNode.links = sourceLinks.filter(id => id !== target)
+            if (isBidirectional) {
+                editHistories.push({ t: 'edit', node: targetNode, changes: { links: [...targetLinks] }, changed: wasTargetChanged })
+                targetNode.links = targetLinks.filter(id => id !== source)
+            }
+        }
+        sourceNode.changed = true
+        sourceNode.dirty = true
+        if (isBidirectional) {
+            targetNode.changed = true
+            targetNode.dirty = true
+        }
+        this.RED.history.push({ t: 'multi', events: editHistories, dirty: wasDirty })
+        this.RED.nodes.dirty(true)
+        this.RED.view.redraw()
+    }
+
     get supportedActions () {
         return this.actions
     }
@@ -695,6 +780,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
         case SET_WIRES:
             this.setWires(params)
+            result.success = true
+            break
+
+        case SET_LINKS:
+            this.setLinks(params)
             result.success = true
             break
         default:

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -560,6 +560,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.dirty = sinon.stub()
                 mockRED.history = { push: sinon.stub() }
                 mockRED.view.redraw = sinon.stub()
+                mockRED.view.selection = sinon.stub().returns(null)
                 mockRED.workspaces = {
                     ...mockRED.workspaces,
                     isLocked: sinon.stub().returns(false)
@@ -721,6 +722,39 @@ describeMain('expertAutomations', () => {
                 linkOut.links.should.containEql('li1')
                 linkIn.links.should.containEql('lo1')
                 result.should.have.property('success', true)
+            })
+            it('should replace existing link when adding to link call (single target only)', async () => {
+                const linkCall = { id: 'lc1', type: 'link call', linkType: 'static', z: 'tab1', links: ['li1'], dirty: false, changed: false }
+                const newLinkIn = { id: 'li2', type: 'link in', z: 'tab1', links: [], dirty: false, changed: false }
+                mockRED.nodes.node.withArgs('lc1').returns(linkCall)
+                mockRED.nodes.node.withArgs('li2').returns(newLinkIn)
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lc1', target: 'li2' }
+                }, result)
+                linkCall.links.should.deepEqual(['li2'])
+                linkCall.links.should.not.containEql('li1')
+                result.should.have.property('success', true)
+            })
+            it('should throw if link call is in dynamic mode', async () => {
+                mockRED.nodes.node.withArgs('lc1').returns({ id: 'lc1', type: 'link call', linkType: 'dynamic', z: 'tab1' })
+                mockRED.nodes.node.withArgs('li1').returns({ id: 'li1', type: 'link in', z: 'tab1' })
+                await should(expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lc1', target: 'li1' }
+                }, {})).rejectedWith(/dynamic mode.*cannot have static links/)
+            })
+            it('should refresh selection to update virtual wires', async () => {
+                const linkOut = { id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: [], dirty: false, changed: false }
+                const linkIn = { id: 'li1', type: 'link in', z: 'tab1', links: [], dirty: false, changed: false }
+                mockRED.nodes.node.withArgs('lo1').returns(linkOut)
+                mockRED.nodes.node.withArgs('li1').returns(linkIn)
+                mockRED.view.selection.returns({ nodes: [linkOut] })
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lo1', target: 'li1' }
+                }, result)
+                mockRED.view.select.calledWith({ nodes: [linkOut] }).should.be.true()
+                mockRED.view.redraw.calledOnce.should.be.true()
             })
             it('should preserve history with previous links state for undo', async () => {
                 const linkOut = { id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: ['existing1'], dirty: false, changed: false }

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -69,7 +69,7 @@ describeMain('expertAutomations', () => {
         it('should have supported actions', () => {
             const supportedActions = expertAutomations.supportedActions
             supportedActions.should.be.an.Object()
-            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab', 'automation/update-node', 'automation/show-workspace', 'automation/get-workspace-nodes', 'automation/close-search', 'automation/close-type-search', 'automation/close-action-list', 'automation/add-tab', 'automation/remove-tab', 'automation/add-nodes', 'automation/remove-nodes', 'automation/set-wires')
+            supportedActions.should.only.have.keys('automation/get-nodes', 'automation/select-nodes', 'automation/open-node-edit', 'automation/search', 'automation/add-flow-tab', 'automation/update-node', 'automation/show-workspace', 'automation/get-workspace-nodes', 'automation/close-search', 'automation/close-type-search', 'automation/close-action-list', 'automation/add-tab', 'automation/remove-tab', 'automation/add-nodes', 'automation/remove-nodes', 'automation/set-wires', 'automation/set-links')
         })
         it('should have hasAction method', () => {
             expertAutomations.should.have.property('hasAction').which.is.a.Function()
@@ -550,6 +550,187 @@ describeMain('expertAutomations', () => {
                 await should(expertAutomations.invokeAction('automation/set-wires', {
                     params: { mode: 'remove', from: 'n1', output: 0, to: 'n2' }
                 }, result)).rejectedWith(/Wire not found from n1 port 0 to n2/)
+            })
+        })
+        describe('setLinks action', () => {
+            beforeEach(() => {
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.history = { push: sinon.stub() }
+                mockRED.view.redraw = sinon.stub()
+                mockRED.workspaces = {
+                    ...mockRED.workspaces,
+                    isLocked: sinon.stub().returns(false)
+                }
+            })
+            it('should add a bidirectional link between link out and link in', async () => {
+                const linkOut = { id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: [], dirty: false, changed: false }
+                const linkIn = { id: 'li1', type: 'link in', z: 'tab1', links: [], dirty: false, changed: false }
+                mockRED.nodes.node.withArgs('lo1').returns(linkOut)
+                mockRED.nodes.node.withArgs('li1').returns(linkIn)
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lo1', target: 'li1' }
+                }, result)
+                linkOut.links.should.containEql('li1')
+                linkIn.links.should.containEql('lo1')
+                linkOut.dirty.should.be.true()
+                linkIn.dirty.should.be.true()
+                linkOut.changed.should.be.true()
+                linkIn.changed.should.be.true()
+                mockRED.history.push.calledOnce.should.be.true()
+                const historyArg = mockRED.history.push.firstCall.args[0]
+                historyArg.should.have.property('t', 'multi')
+                historyArg.events.should.have.lengthOf(2)
+                mockRED.nodes.dirty.calledWith(true).should.be.true()
+                mockRED.view.redraw.calledOnce.should.be.true()
+                result.should.have.property('success', true)
+            })
+            it('should remove a bidirectional link between link out and link in', async () => {
+                const linkOut = { id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: ['li1'], dirty: false, changed: false }
+                const linkIn = { id: 'li1', type: 'link in', z: 'tab1', links: ['lo1'], dirty: false, changed: false }
+                mockRED.nodes.node.withArgs('lo1').returns(linkOut)
+                mockRED.nodes.node.withArgs('li1').returns(linkIn)
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'remove', source: 'lo1', target: 'li1' }
+                }, result)
+                linkOut.links.should.not.containEql('li1')
+                linkIn.links.should.not.containEql('lo1')
+                mockRED.history.push.calledOnce.should.be.true()
+                const historyArg = mockRED.history.push.firstCall.args[0]
+                historyArg.should.have.property('t', 'multi')
+                historyArg.events.should.have.lengthOf(2)
+                result.should.have.property('success', true)
+            })
+            it('should add a unidirectional link from link call to link in', async () => {
+                const linkCall = { id: 'lc1', type: 'link call', z: 'tab1', links: [], dirty: false, changed: false }
+                const linkIn = { id: 'li1', type: 'link in', z: 'tab1', links: [], dirty: false, changed: false }
+                mockRED.nodes.node.withArgs('lc1').returns(linkCall)
+                mockRED.nodes.node.withArgs('li1').returns(linkIn)
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lc1', target: 'li1' }
+                }, result)
+                linkCall.links.should.containEql('li1')
+                linkIn.links.should.not.containEql('lc1')
+                linkCall.dirty.should.be.true()
+                linkIn.dirty.should.be.false()
+                const historyArg = mockRED.history.push.firstCall.args[0]
+                historyArg.events.should.have.lengthOf(1)
+                result.should.have.property('success', true)
+            })
+            it('should remove a unidirectional link from link call to link in', async () => {
+                const linkCall = { id: 'lc1', type: 'link call', z: 'tab1', links: ['li1'], dirty: false, changed: false }
+                const linkIn = { id: 'li1', type: 'link in', z: 'tab1', links: [], dirty: false, changed: false }
+                mockRED.nodes.node.withArgs('lc1').returns(linkCall)
+                mockRED.nodes.node.withArgs('li1').returns(linkIn)
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'remove', source: 'lc1', target: 'li1' }
+                }, result)
+                linkCall.links.should.not.containEql('li1')
+                linkIn.links.should.not.containEql('lc1')
+                result.should.have.property('success', true)
+            })
+            it('should throw if linking a node to itself', async () => {
+                mockRED.nodes.node.withArgs('lo1').returns({ id: 'lo1', type: 'link out', z: 'tab1' })
+                await should(expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lo1', target: 'lo1' }
+                }, {})).rejectedWith(/Cannot link a node to itself/)
+            })
+            it('should throw if source node not found', async () => {
+                mockRED.nodes.node.returns(null)
+                await should(expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'missing', target: 'li1' }
+                }, {})).rejectedWith(/Source node missing not found/)
+            })
+            it('should throw if target node not found', async () => {
+                mockRED.nodes.node.withArgs('lo1').returns({ id: 'lo1', type: 'link out', z: 'tab1' })
+                mockRED.nodes.node.withArgs('li1').returns(null)
+                await should(expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lo1', target: 'li1' }
+                }, {})).rejectedWith(/Target node li1 not found/)
+            })
+            it('should throw if source is not a link out or link call', async () => {
+                mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', type: 'inject', z: 'tab1' })
+                mockRED.nodes.node.withArgs('li1').returns({ id: 'li1', type: 'link in', z: 'tab1' })
+                await should(expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'n1', target: 'li1' }
+                }, {})).rejectedWith(/must be a link out or link call node/)
+            })
+            it('should throw if target is not a link in', async () => {
+                mockRED.nodes.node.withArgs('lo1').returns({ id: 'lo1', type: 'link out', mode: 'link', z: 'tab1' })
+                mockRED.nodes.node.withArgs('lo2').returns({ id: 'lo2', type: 'link out', mode: 'link', z: 'tab1' })
+                await should(expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lo1', target: 'lo2' }
+                }, {})).rejectedWith(/must be a link in node/)
+            })
+            it('should throw if source is link out in return mode', async () => {
+                mockRED.nodes.node.withArgs('lo1').returns({ id: 'lo1', type: 'link out', mode: 'return', z: 'tab1' })
+                mockRED.nodes.node.withArgs('li1').returns({ id: 'li1', type: 'link in', z: 'tab1' })
+                await should(expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lo1', target: 'li1' }
+                }, {})).rejectedWith(/return mode.*cannot have outbound links/)
+            })
+            it('should throw if source workspace is locked', async () => {
+                mockRED.nodes.node.withArgs('lo1').returns({ id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: [] })
+                mockRED.nodes.node.withArgs('li1').returns({ id: 'li1', type: 'link in', z: 'tab1', links: [] })
+                mockRED.workspaces.isLocked.withArgs('tab1').returns(true)
+                await should(expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lo1', target: 'li1' }
+                }, {})).rejectedWith(/workspace tab1 is locked/)
+            })
+            it('should throw if target workspace is locked (cross-tab)', async () => {
+                mockRED.nodes.node.withArgs('lo1').returns({ id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: [] })
+                mockRED.nodes.node.withArgs('li1').returns({ id: 'li1', type: 'link in', z: 'tab2', links: [] })
+                mockRED.workspaces.isLocked.withArgs('tab2').returns(true)
+                await should(expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lo1', target: 'li1' }
+                }, {})).rejectedWith(/workspace tab2 is locked/)
+            })
+            it('should throw if adding a link that already exists', async () => {
+                const linkOut = { id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: ['li1'] }
+                const linkIn = { id: 'li1', type: 'link in', z: 'tab1', links: ['lo1'] }
+                mockRED.nodes.node.withArgs('lo1').returns(linkOut)
+                mockRED.nodes.node.withArgs('li1').returns(linkIn)
+                await should(expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lo1', target: 'li1' }
+                }, {})).rejectedWith(/Link already exists from lo1 to li1/)
+            })
+            it('should throw if removing a link that does not exist', async () => {
+                const linkOut = { id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: [] }
+                const linkIn = { id: 'li1', type: 'link in', z: 'tab1', links: [] }
+                mockRED.nodes.node.withArgs('lo1').returns(linkOut)
+                mockRED.nodes.node.withArgs('li1').returns(linkIn)
+                await should(expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'remove', source: 'lo1', target: 'li1' }
+                }, {})).rejectedWith(/Link not found from lo1 to li1/)
+            })
+            it('should allow cross-tab links between link out and link in', async () => {
+                const linkOut = { id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: [], dirty: false, changed: false }
+                const linkIn = { id: 'li1', type: 'link in', z: 'tab2', links: [], dirty: false, changed: false }
+                mockRED.nodes.node.withArgs('lo1').returns(linkOut)
+                mockRED.nodes.node.withArgs('li1').returns(linkIn)
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lo1', target: 'li1' }
+                }, result)
+                linkOut.links.should.containEql('li1')
+                linkIn.links.should.containEql('lo1')
+                result.should.have.property('success', true)
+            })
+            it('should preserve history with previous links state for undo', async () => {
+                const linkOut = { id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: ['existing1'], dirty: false, changed: false }
+                const linkIn = { id: 'li1', type: 'link in', z: 'tab1', links: ['existing2'], dirty: false, changed: false }
+                mockRED.nodes.node.withArgs('lo1').returns(linkOut)
+                mockRED.nodes.node.withArgs('li1').returns(linkIn)
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lo1', target: 'li1' }
+                }, result)
+                const historyArg = mockRED.history.push.firstCall.args[0]
+                historyArg.events[0].changes.links.should.deepEqual(['existing1'])
+                historyArg.events[1].changes.links.should.deepEqual(['existing2'])
             })
         })
         describe('addNodes action', () => {


### PR DESCRIPTION
## Summary

- New `automation/set-links` action for managing virtual links between link nodes (`link in`, `link out`, `link call`)
- `link out` <> `link in` connections are **bidirectional** (both nodes' `links` arrays updated)
- `link call` > `link in` connections are **unidirectional** (only `link call` updated)
- Triggers `RED.editor.validateNode` on both nodes after modification to keep NR editor state consistent

## Validation

| Check | Error |
|---|---|
| Self-link | `Cannot link a node to itself` |
| Source not found | `Source node <id> not found` |
| Target not found | `Target node <id> not found` |
| Source not link out/call | `must be a link out or link call node` |
| Target not link in | `must be a link in node` |
| Link out in return mode | `return mode cannot have outbound links` |
| Workspace locked (source) | `Cannot modify links -- workspace <id> is locked` |
| Workspace locked (target) | `Cannot modify links -- workspace <id> is locked` |
| Duplicate link (add) | `Link already exists from <source> to <target>` |
| Missing link (remove) | `Link not found from <source> to <target>` |

## Manual test results

All 13 manual tests passed against a live NR editor:

| Scenario | Result |
|---|---|
| Add link: link out to link in (same tab) | success |
| Remove link: link out to link in | success |
| Add link: link call to link in (unidirectional) | success |
| Remove link: link call to link in | success |
| Self-link | rejected |
| Source node not found | rejected |
| Source is not a link node | rejected |
| Target is not a link in | rejected |
| Link out in return mode | rejected |
| Duplicate link (add same twice) | first succeeds, second rejected |
| Remove non-existent link | rejected |
| Locked workspace | rejected |
| Cross-tab link (link out on tab1, link in on tab2) | success |

Also confirmed: link out can connect to multiple link in nodes (no artificial limit).

## Test plan

- 16 unit tests covering all validation paths, bidirectional/unidirectional behaviour, history/undo, and cross-tab links
- 13 manual console tests against live NR editor
- All 221 unit tests passing

Closes #261

cc @Steve-Mcl -- this addresses the link node handling you flagged during set-wires review. Implemented as a separate action rather than extending set-wires, since link nodes use a `links` property array (not `wires`) with bidirectional semantics.