### PR TITLE
fix: Support nested properties in validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@modelcontextprotocol/sdk": "^1.27.1",
                 "base64url": "^3.0.1",
                 "got": "^11.8.6",
+                "jsonschema": "^1.5.0",
                 "onnxruntime-web": "^1.22.0",
                 "semver": "^7.7.2",
                 "zod": "^3.25.76"
@@ -3127,6 +3128,15 @@
             },
             "bin": {
                 "json5": "lib/cli.js"
+            }
+        },
+        "node_modules/jsonschema": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+            "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "base64url": "^3.0.1",
         "got": "^11.8.6",
+        "jsonschema": "^1.5.0",
         "onnxruntime-web": "^1.22.0",
         "semver": "^7.7.2",
         "zod": "^3.25.76"

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -148,9 +148,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         items: {
                             type: 'object',
                             properties: {
-                                name: { type: 'string' },
-                                value: { type: 'string' },
-                                type: { type: 'string' }
+                                name: { type: 'string', description: 'Environment variable name' },
+                                value: { type: 'string', description: 'Environment variable value' },
+                                type: {
+                                    type: 'string',
+                                    enum: ['str', 'num', 'bool', 'json', 'env', 'cred', 'jsonata'],
+                                    description: 'Environment variable type'
+                                }
                             }
                         },
                         description: 'Environment variables'

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -155,7 +155,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
                                     enum: ['str', 'num', 'bool', 'json', 'env', 'cred', 'jsonata'],
                                     description: 'Environment variable type'
                                 }
-                            }
+                            },
+                            required: ['name', 'value', 'type']
                         },
                         description: 'Environment variables'
                     }

--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -1,4 +1,5 @@
 import { ExpertAutomations } from './expertAutomations.js'
+import { validate as validateJsonSchema } from 'jsonschema'
 
 function debounce (func, wait) {
     let timeout
@@ -537,7 +538,7 @@ export class ExpertComms {
         // Validate params against permitted schema (native/naive parsing for now - may introduce a library later if more complex schemas are needed)
         const actionSchema = this.supportedActions[action].params
         if (actionSchema) {
-            const validation = this.validateSchema(params, actionSchema)
+            const validation = this.validateActionParams(params, actionSchema)
             if (!validation || !validation.valid) {
                 console.warn(`Params for action "${action}" did not validate against the expected schema`, params, actionSchema, validation)
                 this.postReply({ type, action, error: validation.error || 'invalid-parameters' }, event)
@@ -676,64 +677,52 @@ export class ExpertComms {
         return this.RED.nodes.createExportableNodeSet(nodes, { includeModuleConfig })
     }
 
-    validateSchema (data, schema) {
-        if (schema.type === 'object') {
-            if (typeof data !== 'object') {
-                return {
-                    valid: false,
-                    error: 'Data is not of type object'
+    /**
+     * Recursively apply default values from a JSON schema to the data object.
+     * Handles nested object properties.
+     * @param {*} data - the data object to apply defaults to (mutated in place)
+     * @param {object} schema - JSON schema with potential default values
+     * @returns {*} the data object with defaults applied
+     */
+    applySchemaDefaults (data, schema) {
+        if (!schema || typeof schema !== 'object') {
+            return data
+        }
+        if (schema.type === 'object' && schema.properties && typeof data === 'object' && data !== null && !Array.isArray(data)) {
+            for (const [propName, propSchema] of Object.entries(schema.properties)) {
+                if (propSchema.default !== undefined && !(propName in data)) {
+                    data[propName] = propSchema.default
+                }
+                if (propName in data) {
+                    this.applySchemaDefaults(data[propName], propSchema)
                 }
             }
-            if (Array.isArray(data)) {
-                return {
-                    valid: false,
-                    error: 'Data is an array but an object was expected'
-                }
-            }
-            // check required properties
-            if (Array.isArray(schema.required)) {
-                for (const reqProp of schema.required) {
-                    if (!(reqProp in data)) {
-                        return {
-                            valid: false,
-                            error: `Data is missing required parameter "${reqProp}"`
-                        }
-                    }
-                }
-            }
-            // check properties & apply defaults
-            if (schema.properties) {
-                for (const [propName, propSchema] of Object.entries(schema.properties)) {
-                    const propExists = propName in data
-                    // check type
-                    if (propSchema.type && propExists) {
-                        const expectedType = propSchema.type
-                        const actualType = Array.isArray(data[propName]) ? 'array' : typeof data[propName]
-                        const allowedTypes = Array.isArray(expectedType) ? expectedType : [expectedType]
-                        if (!allowedTypes.includes(actualType)) {
-                            return {
-                                valid: false,
-                                error: `Data parameter "${propName}" is of type "${actualType}" but expected type is "${allowedTypes.join(' or ')}"`
-                            }
-                        }
-                    }
-                    // check enum
-                    if (propSchema.enum && propExists) {
-                        if (!propSchema.enum.includes(data[propName])) {
-                            return {
-                                valid: false,
-                                error: `Data parameter "${propName}" has invalid value "${data[propName]}". Should be one of: ${propSchema.enum.join(', ')}`
-                            }
-                        }
-                    }
-                    // apply defaults
-                    if (propSchema.default !== undefined && !propExists) {
-                        data[propName] = propSchema.default
-                    }
-                }
+        } else if (schema.type === 'array' && schema.items && Array.isArray(data)) {
+            for (const item of data) {
+                this.applySchemaDefaults(item, schema.items)
             }
         }
-        return { valid: true }
+        return data
+    }
+
+    validateActionParams (data, schema) {
+        // apply defaults (including nested) before validation
+        this.applySchemaDefaults(data, schema)
+        const result = validateJsonSchema(data, schema, { throwError: false, nestedErrors: true })
+        console.debug('Schema validation result:', { data, schema, result })
+        if (result.valid) {
+            return { valid: true }
+        } else {
+            let errorString
+            if (result.errors && result.errors.length > 0) {
+                errorString = result.errors.map(e => `- ${e.property || 'instance'}: ${e.message}`).join('\n')
+                errorString = `Data does not match schema:\n${errorString}`
+            }
+            return {
+                valid: false,
+                error: errorString || 'Data does not match schema'
+            }
+        }
     }
 
     debug (...args) {

--- a/test/unit/resources/expertComms.test.js
+++ b/test/unit/resources/expertComms.test.js
@@ -887,7 +887,7 @@ describeMain('expertComms', function () {
             consoleWarnStub.calledOnce.should.be.true()
             eventSource.postMessage.calledOnce.should.be.true()
             const reply = eventSource.postMessage.firstCall.args[0]
-            reply.error.should.equal('Data is missing required parameter "filter"')
+            reply.error.should.containEql('requires property "filter"')
 
             consoleWarnStub.restore()
         })
@@ -1381,16 +1381,218 @@ describeMain('expertComms', function () {
         })
     })
 
-    describe('validateSchema', () => {
+    describe('applySchemaDefaults', () => {
+        it('should apply top-level defaults for missing properties', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    mode: { type: 'string', default: 'auto' },
+                    verbose: { type: 'boolean', default: false }
+                }
+            }
+            const data = {}
+            expertComms.applySchemaDefaults(data, schema)
+            data.mode.should.equal('auto')
+            data.verbose.should.equal(false)
+        })
+
+        it('should not overwrite existing values with defaults', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    mode: { type: 'string', default: 'auto' }
+                }
+            }
+            const data = { mode: 'manual' }
+            expertComms.applySchemaDefaults(data, schema)
+            data.mode.should.equal('manual')
+        })
+
+        it('should apply defaults to nested object properties', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    options: {
+                        type: 'object',
+                        properties: {
+                            timeout: { type: 'number', default: 5000 },
+                            retries: { type: 'number', default: 3 }
+                        }
+                    }
+                }
+            }
+            const data = { options: {} }
+            expertComms.applySchemaDefaults(data, schema)
+            data.options.timeout.should.equal(5000)
+            data.options.retries.should.equal(3)
+        })
+
+        it('should apply defaults to deeply nested objects', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    level1: {
+                        type: 'object',
+                        properties: {
+                            level2: {
+                                type: 'object',
+                                properties: {
+                                    value: { type: 'string', default: 'deep' }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            const data = { level1: { level2: {} } }
+            expertComms.applySchemaDefaults(data, schema)
+            data.level1.level2.value.should.equal('deep')
+        })
+
+        it('should apply defaults inside array items', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    env: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                type: { type: 'string', default: 'json' },
+                                value: { type: 'string', default: '' }
+                            }
+                        }
+                    }
+                }
+            }
+            const data = { env: [{ name: 'VAR1' }, { name: 'VAR2', type: 'str' }] }
+            expertComms.applySchemaDefaults(data, schema)
+            data.env[0].type.should.equal('json')
+            data.env[0].value.should.equal('')
+            data.env[1].type.should.equal('str') // not overwritten
+            data.env[1].value.should.equal('')
+        })
+
+        it('should handle an empty array', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    items: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                enabled: { type: 'boolean', default: true }
+                            }
+                        }
+                    }
+                }
+            }
+            const data = { items: [] }
+            expertComms.applySchemaDefaults(data, schema)
+            data.items.should.have.length(0)
+        })
+
+        it('should apply defaults to nested objects inside array items', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    nodes: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                config: {
+                                    type: 'object',
+                                    properties: {
+                                        enabled: { type: 'boolean', default: true },
+                                        priority: { type: 'number', default: 0 }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            const data = { nodes: [{ config: {} }, { config: { enabled: false } }] }
+            expertComms.applySchemaDefaults(data, schema)
+            data.nodes[0].config.enabled.should.equal(true)
+            data.nodes[0].config.priority.should.equal(0)
+            data.nodes[1].config.enabled.should.equal(false) // not overwritten
+            data.nodes[1].config.priority.should.equal(0)
+        })
+
+        it('should not descend into nested object when property is missing from data', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    options: {
+                        type: 'object',
+                        properties: {
+                            timeout: { type: 'number', default: 5000 }
+                        }
+                    }
+                }
+            }
+            const data = {}
+            expertComms.applySchemaDefaults(data, schema)
+            Object.keys(data).should.have.length(0) // options not created
+        })
+
+        it('should return data unchanged for null or invalid schema', () => {
+            const data = { foo: 'bar' }
+            expertComms.applySchemaDefaults(data, null).should.deepEqual({ foo: 'bar' })
+            expertComms.applySchemaDefaults(data, 42).should.deepEqual({ foo: 'bar' })
+        })
+
+        it('should return data unchanged when data is not an object', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    x: { type: 'string', default: 'y' }
+                }
+            }
+            const result = expertComms.applySchemaDefaults('string-value', schema)
+            result.should.equal('string-value')
+        })
+
+        it('should not treat arrays as objects', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    x: { type: 'string', default: 'y' }
+                }
+            }
+            const data = [1, 2, 3]
+            expertComms.applySchemaDefaults(data, schema)
+            data.should.deepEqual([1, 2, 3])
+        })
+
+        it('should handle top-level array schema', () => {
+            const schema = {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    properties: {
+                        status: { type: 'string', default: 'pending' }
+                    }
+                }
+            }
+            const data = [{}, { status: 'done' }]
+            expertComms.applySchemaDefaults(data, schema)
+            data[0].status.should.equal('pending')
+            data[1].status.should.equal('done')
+        })
+    })
+
+    describe('validateAction', () => {
         it('should validate object type', () => {
             const schema = { type: 'object' }
             const valid = { foo: 'bar' }
             const invalid = 'not an object'
-            const invalidArray = []
 
-            expertComms.validateSchema(valid, schema).valid.should.be.true()
-            expertComms.validateSchema(invalid, schema).valid.should.be.false()
-            expertComms.validateSchema(invalidArray, schema).valid.should.be.false()
+            expertComms.validateActionParams(valid, schema).valid.should.be.true()
+            expertComms.validateActionParams(invalid, schema).valid.should.be.false()
         })
 
         it('should check required properties', () => {
@@ -1406,8 +1608,8 @@ describeMain('expertComms', function () {
             const valid = { foo: 'value1', bar: 'value2' }
             const missing = { foo: 'value1' }
 
-            expertComms.validateSchema(valid, schema).valid.should.be.true()
-            const result = expertComms.validateSchema(missing, schema)
+            expertComms.validateActionParams(valid, schema).valid.should.be.true()
+            const result = expertComms.validateActionParams(missing, schema)
             result.valid.should.be.false()
             result.error.should.containEql('bar')
         })
@@ -1424,8 +1626,8 @@ describeMain('expertComms', function () {
             const valid = { foo: 'test', bar: 123 }
             const invalid = { foo: 123, bar: 'test' }
 
-            expertComms.validateSchema(valid, schema).valid.should.be.true()
-            expertComms.validateSchema(invalid, schema).valid.should.be.false()
+            expertComms.validateActionParams(valid, schema).valid.should.be.true()
+            expertComms.validateActionParams(invalid, schema).valid.should.be.false()
         })
 
         it('should check enum values', () => {
@@ -1442,10 +1644,75 @@ describeMain('expertComms', function () {
             const valid = { view: 'install' }
             const invalid = { view: 'invalid' }
 
-            expertComms.validateSchema(valid, schema).valid.should.be.true()
-            const result = expertComms.validateSchema(invalid, schema)
+            expertComms.validateActionParams(valid, schema).valid.should.be.true()
+            const result = expertComms.validateActionParams(invalid, schema)
             result.valid.should.be.false()
-            result.error.should.containEql('invalid')
+            result.error.should.containEql('is not one of enum values')
+        })
+
+        it('should ignore additional properties', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    foo: { type: 'string' }
+                }
+            }
+
+            const data = { foo: 'test', extra: 'ignored' }
+            const result = expertComms.validateActionParams(data, schema)
+            result.valid.should.be.true()
+        })
+
+        it('should validate nested objects', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    id: { type: 'string', description: 'Tab ID — auto-generated if omitted' },
+                    label: { type: 'string', description: 'Tab label' },
+                    disabled: { type: 'boolean', description: 'Create as disabled' },
+                    info: { type: 'string', description: 'Tab notes' },
+                    env: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                name: { type: 'string', description: 'Environment variable name' },
+                                value: { type: 'string', description: 'Environment variable value' },
+                                type: {
+                                    type: 'string',
+                                    enum: ['str', 'num', 'bool', 'json', 'env', 'cred', 'jsonata'],
+                                    description: 'Environment variable type'
+                                }
+                            }
+                        },
+                        description: 'Environment variables'
+                    }
+                },
+                required: ['label']
+            }
+
+            const valid = {
+                label: 'My Tab',
+                env: [
+                    { name: 'VAR1', value: 'value1', type: 'str' },
+                    { name: 'VAR2', value: 'true', type: 'bool' }
+                ]
+            }
+            const invalid = {
+                label: 'My Tab',
+                env: [
+                    { name: 'VAR1', value: 'value1', type: 'integer' }, // invalid type
+                    { name: 'VAR2', value: 123, type: 'str' }, // value should be string
+                    'bad env entry' // not an object
+                ]
+            }
+
+            expertComms.validateActionParams(valid, schema).valid.should.be.true()
+            const result = expertComms.validateActionParams(invalid, schema)
+            result.valid.should.be.false()
+            result.error.should.containEql('env[0].type: is not one of enum values')
+            result.error.should.containEql('env[1].value: is not of a type(s) string')
+            result.error.should.containEql('env[2]: is not of a type(s) object')
         })
 
         it('should apply default values', () => {
@@ -1461,7 +1728,7 @@ describeMain('expertComms', function () {
             }
 
             const data = {}
-            const result = expertComms.validateSchema(data, schema)
+            const result = expertComms.validateActionParams(data, schema)
 
             result.valid.should.be.true()
             data.view.should.equal('install')

--- a/test/unit/resources/expertComms.test.js
+++ b/test/unit/resources/expertComms.test.js
@@ -1683,7 +1683,8 @@ describeMain('expertComms', function () {
                                     enum: ['str', 'num', 'bool', 'json', 'env', 'cred', 'jsonata'],
                                     description: 'Environment variable type'
                                 }
-                            }
+                            },
+                            required: ['name', 'value', 'type']
                         },
                         description: 'Environment variables'
                     }
@@ -1713,6 +1714,57 @@ describeMain('expertComms', function () {
             result.error.should.containEql('env[0].type: is not one of enum values')
             result.error.should.containEql('env[1].value: is not of a type(s) string')
             result.error.should.containEql('env[2]: is not of a type(s) object')
+        })
+
+        it('should allow empty env array but require all properties when element is present', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    label: { type: 'string' },
+                    env: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                name: { type: 'string' },
+                                value: { type: 'string' },
+                                type: {
+                                    type: 'string',
+                                    enum: ['str', 'num', 'bool', 'json', 'env', 'cred', 'jsonata']
+                                }
+                            },
+                            required: ['name', 'value', 'type']
+                        }
+                    }
+                },
+                required: ['label']
+            }
+
+            // empty env array is valid
+            expertComms.validateActionParams({ label: 'Tab', env: [] }, schema).valid.should.be.true()
+
+            // complete element is valid
+            expertComms.validateActionParams({ label: 'Tab', env: [{ name: 'A', value: '1', type: 'str' }] }, schema).valid.should.be.true()
+
+            // missing name
+            const missingName = expertComms.validateActionParams({ label: 'Tab', env: [{ value: '1', type: 'str' }] }, schema)
+            missingName.valid.should.be.false()
+            missingName.error.should.containEql('name')
+
+            // missing value
+            const missingValue = expertComms.validateActionParams({ label: 'Tab', env: [{ name: 'A', type: 'str' }] }, schema)
+            missingValue.valid.should.be.false()
+            missingValue.error.should.containEql('value')
+
+            // missing type
+            const missingType = expertComms.validateActionParams({ label: 'Tab', env: [{ name: 'A', value: '1' }] }, schema)
+            missingType.valid.should.be.false()
+            missingType.error.should.containEql('type')
+
+            // bad type
+            const badType = expertComms.validateActionParams({ label: 'Tab', env: [{ name: 'A', value: '1', type: 'invalid' }] }, schema)
+            badType.valid.should.be.false()
+            badType.error.should.containEql('type')
         })
 
         it('should apply default values', () => {


### PR DESCRIPTION
## Description

This pull request improves schema validation and default value handling for action parameters in the `expertComms` module. It replaces a custom schema validation implementation with the `jsonschema` library, adds robust recursive default application, and significantly expands unit tests to cover these behaviors. Additionally, it enhances schema definitions for environment variables in `expertAutomations`.

**Schema validation and default handling improvements:**

* Replaced the custom `validateSchema` method in `ExpertComms` with `validateActionParams`, which uses the `jsonschema` library for more robust and standards-compliant validation. This method now also applies default values recursively to nested objects and arrays before validation. (`resources/expertComms.js` [[1]](diffhunk://#diff-637659b6869108e05c4538455e7101b71e09643c68b841248750f09e14dbc35aL540-R541) [[2]](diffhunk://#diff-637659b6869108e05c4538455e7101b71e09643c68b841248750f09e14dbc35aL679-L736) [[3]](diffhunk://#diff-637659b6869108e05c4538455e7101b71e09643c68b841248750f09e14dbc35aR2); `package.json` [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R45)
* Added a new `applySchemaDefaults` method to recursively apply default values from a JSON schema to data, handling nested objects and arrays. (`resources/expertComms.js` [resources/expertComms.jsL679-L736](diffhunk://#diff-637659b6869108e05c4538455e7101b71e09643c68b841248750f09e14dbc35aL679-L736))

**Schema definition enhancements:**

* Updated the environment variable schema in `ExpertAutomations` to include descriptions and restrict the `type` property to a specific set of allowed values. (`resources/expertAutomations.js` [resources/expertAutomations.jsL151-R157](diffhunk://#diff-b89bcd54930b5abba7a5ccddc78ddc849b36e62d572f817a4aa31d49900cf09dL151-R157))

**Testing improvements:**

* Replaced and expanded unit tests for schema validation in `expertComms`. Added comprehensive tests for `applySchemaDefaults`, covering top-level, nested, and array defaults, and for `validateActionParams`, including required fields, type checks, enums, nested objects, and error messaging. (`test/unit/resources/expertComms.test.js` [[1]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3L890-R890) [[2]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3L1384-R1595) [[3]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3L1409-R1612) [[4]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3L1427-R1630) [[5]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3L1445-R1715) [[6]](diffhunk://#diff-44aa3180924534d14a42dc378e1782a9f0c8c781d5c874c830a639b86d32f8b3L1464-R1731)

These changes make schema validation more robust, ensure that default values are consistently applied, and improve test coverage for these critical behaviors.

## Related Issue(s)

closes #262

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

