### PR TITLE
Rename to/from parameters to source/target for consistency

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -216,11 +216,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 type: 'object',
                 properties: {
                     mode: { type: 'string', enum: ['add', 'remove'], description: 'Whether to add or remove a wire' },
-                    from: { type: 'string', description: 'Source node ID' },
+                    source: { type: 'string', description: 'Source node ID' },
                     output: { type: 'number', description: 'Source output port index (0-based)' },
-                    to: { type: 'string', description: 'Target node ID' }
+                    target: { type: 'string', description: 'Target node ID' }
                 },
-                required: ['mode', 'from', 'to']
+                required: ['mode', 'source', 'target']
             }
         },
         [IMPORT_FLOW]: {
@@ -556,16 +556,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * Add or remove a single wire between two nodes.
      * @param {object} params
      * @param {'add'|'remove'} params.mode
-     * @param {string} params.from - Source node ID
+     * @param {string} params.source - Source node ID
      * @param {number} [params.output] - Source output port index (0-based, defaults to 0)
-     * @param {string} params.to - Target node ID
+     * @param {string} params.target - Target node ID
      */
-    setWires ({ mode, from, output, to }) {
-        if (from === to) throw new Error('Cannot wire a node to itself')
-        const sourceNode = this.RED.nodes.node(from)
-        if (!sourceNode) throw new Error(`Source node ${from} not found`)
-        const targetNode = this.RED.nodes.node(to)
-        if (!targetNode) throw new Error(`Target node ${to} not found`)
+    setWires ({ mode, source, output, target }) {
+        if (source === target) throw new Error('Cannot wire a node to itself')
+        const sourceNode = this.RED.nodes.node(source)
+        if (!sourceNode) throw new Error(`Source node ${source} not found`)
+        const targetNode = this.RED.nodes.node(target)
+        if (!targetNode) throw new Error(`Target node ${target} not found`)
         // Source and target must be on the same tab
         if (sourceNode.z !== targetNode.z) {
             throw new Error('Source and target nodes must be on the same tab')
@@ -577,30 +577,30 @@ export class ExpertAutomations extends ExpertActionsInterface {
         // Validate output port exists on source
         const port = output ?? 0
         if (port >= (sourceNode.outputs || 0)) {
-            throw new Error(`Source node ${from} does not have output port ${port}`)
+            throw new Error(`Source node ${source} does not have output port ${port}`)
         }
         // Validate target accepts inputs
         const targetDef = this.RED.nodes.getType(targetNode.type)
         if (targetDef && targetDef.inputs === 0) {
-            throw new Error(`Target node ${to} (${targetNode.type}) does not accept inputs`)
+            throw new Error(`Target node ${target} (${targetNode.type}) does not accept inputs`)
         }
-        const existingLinks = this.RED.nodes.getNodeLinks(from)
+        const existingLinks = this.RED.nodes.getNodeLinks(source)
         const wasDirty = this.RED.nodes.dirty()
         if (mode === 'add') {
             // Check wire doesn't already exist
             const duplicate = existingLinks.find(l =>
-                l.source?.id === from && l.sourcePort === port && l.target?.id === to
+                l.source?.id === source && l.sourcePort === port && l.target?.id === target
             )
-            if (duplicate) throw new Error(`Wire already exists from ${from} port ${port} to ${to}`)
+            if (duplicate) throw new Error(`Wire already exists from ${source} port ${port} to ${target}`)
             const link = { source: sourceNode, sourcePort: port, target: targetNode }
             this.RED.nodes.addLink(link)
             this.RED.history.push({ t: 'add', links: [link], dirty: wasDirty })
         } else {
             const link = existingLinks.find(l =>
-                l.source?.id === from && l.sourcePort === port && l.target?.id === to
+                l.source?.id === source && l.sourcePort === port && l.target?.id === target
             )
             if (!link) {
-                throw new Error(`Wire not found from ${from} port ${port} to ${to}`)
+                throw new Error(`Wire not found from ${source} port ${port} to ${target}`)
             }
             this.RED.nodes.removeLink(link)
             this.RED.history.push({ t: 'delete', links: [link], dirty: wasDirty })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -420,7 +420,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('n2').returns(target)
                 const result = {}
                 await expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', from: 'n1', to: 'n2' }
+                    params: { mode: 'add', source: 'n1', target: 'n2' }
                 }, result)
                 mockRED.nodes.addLink.calledOnce.should.be.true()
                 mockRED.history.push.calledOnce.should.be.true()
@@ -443,7 +443,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.getNodeLinks.returns([existingLink])
                 const result = {}
                 await expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'remove', from: 'n1', to: 'n2' }
+                    params: { mode: 'remove', source: 'n1', target: 'n2' }
                 }, result)
                 mockRED.nodes.removeLink.calledWith(existingLink).should.be.true()
                 mockRED.history.push.calledOnce.should.be.true()
@@ -460,7 +460,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('n2').returns(target)
                 const result = {}
                 await expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', from: 'n1', output: 2, to: 'n2' }
+                    params: { mode: 'add', source: 'n1', output: 2, target: 'n2' }
                 }, result)
                 const linkArg = mockRED.nodes.addLink.firstCall.args[0]
                 linkArg.should.have.property('sourcePort', 2)
@@ -470,7 +470,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.returns(null)
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', from: 'missing', to: 'n2' }
+                    params: { mode: 'add', source: 'missing', target: 'n2' }
                 }, result)).rejectedWith(/Source node missing not found/)
             })
             it('should throw if target node not found', async () => {
@@ -478,14 +478,14 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('n2').returns(null)
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', from: 'n1', to: 'n2' }
+                    params: { mode: 'add', source: 'n1', target: 'n2' }
                 }, result)).rejectedWith(/Target node n2 not found/)
             })
             it('should throw if wiring a node to itself', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1', outputs: 1 })
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', from: 'n1', to: 'n1' }
+                    params: { mode: 'add', source: 'n1', target: 'n1' }
                 }, result)).rejectedWith(/Cannot wire a node to itself/)
             })
             it('should throw if source and target are on different tabs', async () => {
@@ -493,7 +493,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('n2').returns({ id: 'n2', z: 'tab2', type: 'debug' })
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', from: 'n1', to: 'n2' }
+                    params: { mode: 'add', source: 'n1', target: 'n2' }
                 }, result)).rejectedWith(/Source and target nodes must be on the same tab/)
             })
             it('should throw if workspace is locked', async () => {
@@ -502,7 +502,7 @@ describeMain('expertAutomations', () => {
                 mockRED.workspaces.isLocked.withArgs('tab1').returns(true)
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', from: 'n1', to: 'n2' }
+                    params: { mode: 'add', source: 'n1', target: 'n2' }
                 }, result)).rejectedWith(/workspace tab1 is locked/)
             })
             it('should throw if source output port does not exist', async () => {
@@ -510,7 +510,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('n2').returns({ id: 'n2', z: 'tab1', type: 'debug' })
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', from: 'n1', output: 5, to: 'n2' }
+                    params: { mode: 'add', source: 'n1', output: 5, target: 'n2' }
                 }, result)).rejectedWith(/does not have output port 5/)
             })
             it('should throw if source node has no outputs', async () => {
@@ -518,7 +518,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('n2').returns({ id: 'n2', z: 'tab1', type: 'debug' })
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', from: 'n1', to: 'n2' }
+                    params: { mode: 'add', source: 'n1', target: 'n2' }
                 }, result)).rejectedWith(/does not have output port 0/)
             })
             it('should throw if target node does not accept inputs', async () => {
@@ -527,7 +527,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.getType.withArgs('inject').returns({ inputs: 0, outputs: 1 })
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', from: 'n1', to: 'n2' }
+                    params: { mode: 'add', source: 'n1', target: 'n2' }
                 }, result)).rejectedWith(/does not accept inputs/)
             })
             it('should throw if adding a wire that already exists', async () => {
@@ -540,7 +540,7 @@ describeMain('expertAutomations', () => {
                 ])
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', from: 'n1', to: 'n2' }
+                    params: { mode: 'add', source: 'n1', target: 'n2' }
                 }, result)).rejectedWith(/Wire already exists from n1 port 0 to n2/)
             })
             it('should throw if removing a wire that does not exist', async () => {
@@ -551,7 +551,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.getNodeLinks.returns([])
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'remove', from: 'n1', output: 0, to: 'n2' }
+                    params: { mode: 'remove', source: 'n1', output: 0, target: 'n2' }
                 }, result)).rejectedWith(/Wire not found from n1 port 0 to n2/)
             })
         })


### PR DESCRIPTION
## Description

This pull request standardizes the parameter names for wiring operations in the `ExpertAutomations` resource, replacing the ambiguous `from`/`to` with clearer `source`/`target` terminology. This aligns with incoming PR #264

**Parameter renaming and schema updates:**

* Changed all references of `from` and `to` to `source` and `target` in the `setWires` API parameter schema, required fields, and method signature in `resources/expertAutomations.js`. [[1]](diffhunk://#diff-b89bcd54930b5abba7a5ccddc78ddc849b36e62d572f817a4aa31d49900cf09dL219-R223) [[2]](diffhunk://#diff-b89bcd54930b5abba7a5ccddc78ddc849b36e62d572f817a4aa31d49900cf09dL559-R568)
* Updated all error messages and internal variable usage in `setWires` to use `source` and `target` instead of `from` and `to`.

**Test updates:**

* Refactored all unit tests in `test/unit/resources/expertAutomations.test.js` to use the new `source` and `target` parameter names in test cases for adding and removing wires, as well as for error scenarios. [[1]](diffhunk://#diff-e7d4959cdf64517d5730ac48875efaee722475ceccf92228d6c086bf67ee6af1L423-R423) [[2]](diffhunk://#diff-e7d4959cdf64517d5730ac48875efaee722475ceccf92228d6c086bf67ee6af1L446-R446) [[3]](diffhunk://#diff-e7d4959cdf64517d5730ac48875efaee722475ceccf92228d6c086bf67ee6af1L463-R463) [[4]](diffhunk://#diff-e7d4959cdf64517d5730ac48875efaee722475ceccf92228d6c086bf67ee6af1L473-R496) [[5]](diffhunk://#diff-e7d4959cdf64517d5730ac48875efaee722475ceccf92228d6c086bf67ee6af1L505-R521) [[6]](diffhunk://#diff-e7d4959cdf64517d5730ac48875efaee722475ceccf92228d6c086bf67ee6af1L530-R530) [[7]](diffhunk://#diff-e7d4959cdf64517d5730ac48875efaee722475ceccf92228d6c086bf67ee6af1L543-R543) [[8]](diffhunk://#diff-e7d4959cdf64517d5730ac48875efaee722475ceccf92228d6c086bf67ee6af1L554-R554)

## Related Issue(s)

closes #267

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

