### PR TITLE
fix: Revert jsonschema dependency and return to hand-rolled parameter validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
                 "@modelcontextprotocol/sdk": "^1.27.1",
                 "base64url": "^3.0.1",
                 "got": "^11.8.6",
-                "jsonschema": "^1.5.0",
                 "onnxruntime-web": "^1.22.0",
                 "semver": "^7.7.2",
                 "zod": "^3.25.76"
@@ -3128,15 +3127,6 @@
             },
             "bin": {
                 "json5": "lib/cli.js"
-            }
-        },
-        "node_modules/jsonschema": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
-            "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "base64url": "^3.0.1",
         "got": "^11.8.6",
-        "jsonschema": "^1.5.0",
         "onnxruntime-web": "^1.22.0",
         "semver": "^7.7.2",
         "zod": "^3.25.76"

--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -1,5 +1,4 @@
 import { ExpertAutomations } from './expertAutomations.js'
-import { validate as validateJsonSchema } from 'jsonschema'
 
 function debounce (func, wait) {
     let timeout
@@ -708,21 +707,61 @@ export class ExpertComms {
     validateActionParams (data, schema) {
         // apply defaults (including nested) before validation
         this.applySchemaDefaults(data, schema)
-        const result = validateJsonSchema(data, schema, { throwError: false, nestedErrors: true })
-        console.debug('Schema validation result:', { data, schema, result })
-        if (result.valid) {
-            return { valid: true }
-        } else {
-            let errorString
-            if (result.errors && result.errors.length > 0) {
-                errorString = result.errors.map(e => `- ${e.property || 'instance'}: ${e.message}`).join('\n')
-                errorString = `Data does not match schema:\n${errorString}`
+        const errors = []
+
+        const validate = (data, schema, path, errors) => {
+            if (schema.type === 'object') {
+                if (typeof data !== 'object' || Array.isArray(data) || data === null) {
+                    errors.push(path ? `${path}: is not of a type(s) object` : 'Data is not of type object')
+                    return
+                }
+                // check required properties
+                if (Array.isArray(schema.required)) {
+                    for (const reqProp of schema.required) {
+                        if (!(reqProp in data)) {
+                            const propPath = path ? `${path}.${reqProp}` : reqProp
+                            errors.push(`${propPath}: is required`)
+                        }
+                    }
+                }
+                // check properties
+                if (schema.properties) {
+                    for (const [propName, propSchema] of Object.entries(schema.properties)) {
+                        if (!(propName in data)) continue
+                        const propPath = path ? `${path}.${propName}` : propName
+                        validate(data[propName], propSchema, propPath, errors)
+                    }
+                }
+            } else if (schema.type === 'array') {
+                if (!Array.isArray(data)) {
+                    errors.push(path ? `${path}: is not of a type(s) array` : 'Data is not of type array')
+                    return
+                }
+                if (schema.items) {
+                    for (let i = 0; i < data.length; i++) {
+                        const itemPath = path ? `${path}[${i}]` : `[${i}]`
+                        validate(data[i], schema.items, itemPath, errors)
+                    }
+                }
+            } else if (schema.type) {
+                const actualType = typeof data
+                const allowedTypes = Array.isArray(schema.type) ? schema.type : [schema.type]
+                if (!allowedTypes.includes(actualType)) {
+                    errors.push(`${path}: is not of a type(s) ${allowedTypes.join(' or ')}`)
+                    return
+                }
             }
-            return {
-                valid: false,
-                error: errorString || 'Data does not match schema'
+            // check enum
+            if (schema.enum && !schema.enum.includes(data)) {
+                errors.push(`${path}: is not one of enum values: ${schema.enum.join(', ')}`)
             }
         }
+
+        validate(data, schema, '', errors)
+        if (errors.length > 0) {
+            return { valid: false, error: errors.join('; ') }
+        }
+        return { valid: true }
     }
 
     debug (...args) {

--- a/test/unit/resources/expertComms.test.js
+++ b/test/unit/resources/expertComms.test.js
@@ -887,7 +887,7 @@ describeMain('expertComms', function () {
             consoleWarnStub.calledOnce.should.be.true()
             eventSource.postMessage.calledOnce.should.be.true()
             const reply = eventSource.postMessage.firstCall.args[0]
-            reply.error.should.containEql('requires property "filter"')
+            reply.error.should.containEql('filter: is required')
 
             consoleWarnStub.restore()
         })


### PR DESCRIPTION
…idation

## Description

The selected `jsonschema` lib worked well however it does not come with a `dist` and would require a build step. 

This PR reverts the jsonschema dependency and returns to hand-rolled parameter validation (updated to recursively validate nested schema props)

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

