### PR TITLE
Complete agent inFlight loop by passing back correlationId and userProperties

### DIFF
--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -81,6 +81,10 @@ export class ExpertComms {
      */
     targetOrigin = '*'
 
+    messageTransactionId = null
+
+    messageUserProperties = null
+
     /**
      * Define supported actions and their parameter schemas
      */
@@ -310,7 +314,15 @@ export class ExpertComms {
                 return
             }
 
-            const { type, action, params, target, source, scope } = event.data || {}
+            const { type, action, params, target, source, scope, userProperties, transactionId } = event.data || {}
+
+            if (userProperties) {
+                this.messageUserProperties = userProperties
+            }
+
+            if (transactionId) {
+                this.messageTransactionId = transactionId
+            }
 
             // Ensure scope and source match expected values
             if (target !== this.MESSAGE_SOURCE || source !== this.MESSAGE_TARGET || scope !== this.MESSAGE_SCOPE) {
@@ -795,8 +807,18 @@ export class ExpertComms {
                 ...payload,
                 source: this.MESSAGE_SOURCE,
                 scope: this.MESSAGE_SCOPE,
-                target: this.MESSAGE_TARGET
+                target: this.MESSAGE_TARGET,
+
+                // if transactionId and userProperties are present, it means that the response is for an agent tool call
+                // that is getting executed tool calls are executed sequentially and awaited for, and
+                // there should be no risk of overlap
+                transactionId: this.messageTransactionId,
+                userProperties: this.messageUserProperties
             }, this.targetOrigin)
+
+            // clear message transactionId and userProperties
+            this.messageTransactionId = null
+            this.messageUserProperties = null
         } else {
             console.warn('Unable to post message, target window not available', payload)
         }


### PR DESCRIPTION
## Description

Passes back `correlationId` and `userProperties` when given on a tool call request.

Tool calls / inFlight requests are received sequentially from the agent so storing them on the comms module makes sense.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6974

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

