### PR TITLE
Support union types in schema

### DIFF
--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -711,56 +711,40 @@ export class ExpertComms {
         const errors = []
 
         const validate = (data, schema, path, errors) => {
-            if (schema.type === 'object') {
-                if (typeof data !== 'object' || Array.isArray(data) || data === null) {
-                    errors.push(path ? `${path}: is not of a type(s) object` : 'Data is not of type object')
-                    return
-                }
-                // check required properties
+            const allowedTypes = schema.type
+                ? (Array.isArray(schema.type) ? schema.type : [schema.type])
+                : null
+
+            let actualType = data === null ? 'null' : typeof data
+            if (Array.isArray(data)) actualType = 'array'
+
+            if (allowedTypes && !allowedTypes.includes(actualType)) {
+                errors.push(`${path}: is not of a type(s) ${allowedTypes.join(' or ')}`)
+                return
+            }
+
+            if (actualType === 'object' && allowedTypes?.includes('object')) {
                 if (Array.isArray(schema.required)) {
                     for (const reqProp of schema.required) {
                         if (!(reqProp in data)) {
-                            const propPath = path ? `${path}.${reqProp}` : reqProp
-                            errors.push(`${propPath}: is required`)
+                            errors.push(`${path ? `${path}.${reqProp}` : reqProp}: is required`)
                         }
                     }
                 }
-                // check properties
                 if (schema.properties) {
                     for (const [propName, propSchema] of Object.entries(schema.properties)) {
                         if (!(propName in data)) continue
-                        const propPath = path ? `${path}.${propName}` : propName
-                        validate(data[propName], propSchema, propPath, errors)
+                        validate(data[propName], propSchema, path ? `${path}.${propName}` : propName, errors)
                     }
                 }
-            } else if (schema.type === 'array') {
-                if (!Array.isArray(data)) {
-                    errors.push(path ? `${path}: is not of a type(s) array` : 'Data is not of type array')
-                    return
-                }
+            } else if (actualType === 'array' && allowedTypes?.includes('array')) {
                 if (schema.items) {
                     for (let i = 0; i < data.length; i++) {
-                        const itemPath = path ? `${path}[${i}]` : `[${i}]`
-                        validate(data[i], schema.items, itemPath, errors)
+                        validate(data[i], schema.items, path ? `${path}[${i}]` : `[${i}]`, errors)
                     }
-                }
-            } else if (schema.type) {
-                let actualType = typeof data
-                if (Array.isArray(data)) {
-                    actualType = 'array'
-                }
-                const allowedTypes = Array.isArray(schema.type) ? schema.type : [schema.type]
-                if (actualType === 'array') {
-                    for (let i = 0; i < data.length; i++) {
-                        const itemPath = path ? `${path}[${i}]` : `[${i}]`
-                        validate(data[i], schema.items, itemPath, errors)
-                    }
-                } else if (!allowedTypes.includes(actualType)) {
-                    errors.push(`${path}: is not of a type(s) ${allowedTypes.join(' or ')}`)
-                    return
                 }
             }
-            // check enum
+
             if (schema.enum && !schema.enum.includes(data)) {
                 errors.push(`${path}: is not one of enum values: ${schema.enum.join(', ')}`)
             }

--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -745,9 +745,17 @@ export class ExpertComms {
                     }
                 }
             } else if (schema.type) {
-                const actualType = typeof data
+                let actualType = typeof data
+                if (Array.isArray(data)) {
+                    actualType = 'array'
+                }
                 const allowedTypes = Array.isArray(schema.type) ? schema.type : [schema.type]
-                if (!allowedTypes.includes(actualType)) {
+                if (actualType === 'array') {
+                    for (let i = 0; i < data.length; i++) {
+                        const itemPath = path ? `${path}[${i}]` : `[${i}]`
+                        validate(data[i], schema.items, itemPath, errors)
+                    }
+                } else if (!allowedTypes.includes(actualType)) {
                     errors.push(`${path}: is not of a type(s) ${allowedTypes.join(' or ')}`)
                     return
                 }

--- a/test/unit/resources/expertComms.test.js
+++ b/test/unit/resources/expertComms.test.js
@@ -1767,6 +1767,128 @@ describeMain('expertComms', function () {
             badType.error.should.containEql('type')
         })
 
+        it('should accept union types (string or null)', () => {
+            const schema = { type: ['string', 'null'] }
+
+            expertComms.validateActionParams('hello', schema).valid.should.be.true()
+            expertComms.validateActionParams(null, schema).valid.should.be.true()
+
+            const invalid = expertComms.validateActionParams(123, schema)
+            invalid.valid.should.be.false()
+            invalid.error.should.containEql('is not of a type(s) string or null')
+        })
+
+        it('should accept union types (string or number)', () => {
+            const schema = { type: ['string', 'number'] }
+
+            expertComms.validateActionParams('hello', schema).valid.should.be.true()
+            expertComms.validateActionParams(42, schema).valid.should.be.true()
+
+            const invalid = expertComms.validateActionParams(true, schema)
+            invalid.valid.should.be.false()
+            invalid.error.should.containEql('is not of a type(s) string or number')
+        })
+
+        it('should allow nullable property inside nested object', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    label: { type: 'string' },
+                    info: { type: ['string', 'null'] }
+                },
+                required: ['label']
+            }
+
+            expertComms.validateActionParams({ label: 'Tab', info: 'notes' }, schema).valid.should.be.true()
+            expertComms.validateActionParams({ label: 'Tab', info: null }, schema).valid.should.be.true()
+
+            const invalid = expertComms.validateActionParams({ label: 'Tab', info: 123 }, schema)
+            invalid.valid.should.be.false()
+            invalid.error.should.containEql('info: is not of a type(s) string or null')
+        })
+
+        it('should validate root-level array schema', () => {
+            const schema = {
+                type: 'array',
+                items: { type: 'string' }
+            }
+
+            expertComms.validateActionParams(['a', 'b', 'c'], schema).valid.should.be.true()
+            expertComms.validateActionParams([], schema).valid.should.be.true()
+
+            const invalid = expertComms.validateActionParams(['a', 123, 'c'], schema)
+            invalid.valid.should.be.false()
+            invalid.error.should.containEql('[1]: is not of a type(s) string')
+
+            const notArray = expertComms.validateActionParams({ not: 'array' }, schema)
+            notArray.valid.should.be.false()
+            notArray.error.should.containEql('is not of a type(s) array')
+        })
+
+        it('should validate array-of-object-containing-array-of-object', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    groups: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                name: { type: 'string' },
+                                items: {
+                                    type: 'array',
+                                    items: {
+                                        type: 'object',
+                                        properties: { id: { type: 'number' } },
+                                        required: ['id']
+                                    }
+                                }
+                            },
+                            required: ['name']
+                        }
+                    }
+                }
+            }
+
+            const valid = {
+                groups: [
+                    { name: 'g1', items: [{ id: 1 }, { id: 2 }] },
+                    { name: 'g2', items: [] }
+                ]
+            }
+            expertComms.validateActionParams(valid, schema).valid.should.be.true()
+
+            const invalid = {
+                groups: [
+                    { name: 'g1', items: [{ id: 'not-a-number' }] },
+                    { items: [{ id: 3 }] } // missing name
+                ]
+            }
+            const result = expertComms.validateActionParams(invalid, schema)
+            result.valid.should.be.false()
+            result.error.should.containEql('groups[0].items[0].id: is not of a type(s) number')
+            result.error.should.containEql('groups[1].name: is required')
+        })
+
+        it('should accept array or null for nullable array field', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    tags: {
+                        type: ['array', 'null'],
+                        items: { type: 'string' }
+                    }
+                }
+            }
+
+            expertComms.validateActionParams({ tags: ['a', 'b'] }, schema).valid.should.be.true()
+            expertComms.validateActionParams({ tags: null }, schema).valid.should.be.true()
+
+            const invalid = expertComms.validateActionParams({ tags: ['a', 123] }, schema)
+            invalid.valid.should.be.false()
+            invalid.error.should.containEql('tags[1]: is not of a type(s) string')
+        })
+
         it('should apply default values', () => {
             const schema = {
                 type: 'object',
@@ -1784,6 +1906,56 @@ describeMain('expertComms', function () {
 
             result.valid.should.be.true()
             data.view.should.equal('install')
+        })
+
+        it('should apply default values to nested objects', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    options: {
+                        type: 'object',
+                        properties: {
+                            timeout: { type: 'number', default: 5000 }
+                        }
+                    }
+                }
+            }
+            const data = { options: {} }
+            const result = expertComms.validateActionParams(data, schema)
+            result.valid.should.be.true()
+            data.options.timeout.should.equal(5000)
+        })
+
+        it('should apply default values to nested objects inside array items', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    nodes: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                things: {
+                                    type: 'object',
+                                    properties: {
+                                        name: { type: 'string', default: 'default-name' },
+                                        enabled: { type: 'boolean', default: true }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            const data = { nodes: [{ things: {} }, { things: { enabled: false } }, { things: { name: 'custom-name' } }] }
+            const result = expertComms.validateActionParams(data, schema)
+            result.valid.should.be.true()
+            data.nodes[0].things.enabled.should.equal(true) // default applied
+            data.nodes[0].things.name.should.equal('default-name') // default applied
+            data.nodes[1].things.enabled.should.equal(false) // not overwritten
+            data.nodes[1].things.name.should.equal('default-name') // default applied
+            data.nodes[2].things.enabled.should.equal(true) // default applied
+            data.nodes[2].things.name.should.equal('custom-name') // not overwritten
         })
     })
 


### PR DESCRIPTION
## Description

This pull request enhances the JSON schema validation logic in `ExpertComms` to better support union types (e.g., fields that can be either `"string"` or `"null"`), and improves the handling of nested structures and default values. It also adds comprehensive unit tests to cover these scenarios, ensuring robust validation for complex schemas.

**Validation logic improvements:**

* Updated the `validate` function in `expertComms.js` to support union types for the `type` property, allowing schema definitions like `{ type: ['string', 'null'] }` and improving type checks for objects and arrays.

**Expanded test coverage:**

* Added unit tests for union type validation, including combinations like `"string"` or `"null"`, `"string"` or `"number"`, and nullable array fields. Also tested correct error messages for type mismatches.
* Added tests for validation of root-level arrays and for deeply nested array/object structures, ensuring correct handling of required fields and type errors in nested data.
* Added tests to verify that default values are correctly applied to nested objects and to nested objects inside array items, ensuring defaults are set without overwriting user-provided values.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

