### PR TITLE
feat(actions): return node validation results from create/update actions

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1046,10 +1046,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
-        case UPDATE_NODE:
+        case UPDATE_NODE: {
             await this.updateNode(params.id, params.properties, params.patches)
-            result.node = this._formatNodes([this.RED.nodes.node(params.id)], params.options?.includeModuleConfig)[0] || null
+            const updatedNode = this.RED.nodes.node(params.id)
+            result.node = this._formatNodes([updatedNode], params.options?.includeModuleConfig)[0] || null
+            result.validation = this._getNodeValidation(updatedNode)
             result.success = true
+        }
             break
 
         case SHOW_WORKSPACE: {
@@ -1124,7 +1127,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
         case ADD_NODES: {
             this.addNodes(params.nodes, { generateIds: params.generateIds ?? false })
             const addedNodes = params.nodes.map(n => this.RED.nodes.node(n.id)).filter(Boolean)
+            if (this.RED.editor?.validateNode) {
+                addedNodes.forEach(n => this.RED.editor.validateNode(n))
+            }
             result.nodes = this._formatNodes(addedNodes, params.options?.includeModuleConfig)
+            result.validation = addedNodes.map(n => ({ id: n.id, ...this._getNodeValidation(n) })).filter(v => v.valid === false)
             result.success = true
         }
             break
@@ -1152,7 +1159,12 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
         case IMPORT_FLOW: {
             const imported = this.importFlow(params.flow, { addFlow: params.addFlowTab, generateIds: params.generateIds ?? true })
-            result.nodes = Array.isArray(imported) ? this._formatNodes(imported, params.options?.includeModuleConfig) : []
+            const importedNodes = Array.isArray(imported) ? imported : []
+            if (this.RED.editor?.validateNode) {
+                importedNodes.forEach(n => this.RED.editor.validateNode(n))
+            }
+            result.nodes = importedNodes.length > 0 ? this._formatNodes(importedNodes, params.options?.includeModuleConfig) : []
+            result.validation = importedNodes.map(n => ({ id: n.id, ...this._getNodeValidation(n) })).filter(v => v.valid === false)
             result.success = true
         }
             break
@@ -1170,5 +1182,22 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
     _formatNodes (nodes, includeModuleConfig = true) {
         return this.RED.nodes.createExportableNodeSet(nodes, { includeModuleConfig })
+    }
+
+    /**
+     * RED.editor.validateNode(node) is a side-effect function that sets:
+     *   - node.valid (boolean)
+     *   - node.validationErrors (string[] — property names or custom error messages)
+     * It checks each property against node._def.defaults validators: required fields,
+     * custom validators, config node refs, and credentials. For subflow instances it
+     * cascades into the subflow definition and all internal nodes.
+     */
+    _getNodeValidation (node) {
+        if (!node || typeof node.valid === 'undefined') return null
+        const result = { valid: node.valid }
+        if (Array.isArray(node.validationErrors) && node.validationErrors.length > 0) {
+            result.validationErrors = node.validationErrors
+        }
+        return result
     }
 }

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -806,6 +806,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('n1').returns(addedNode) // post-import lookup
                 mockRED.view.importNodes = sinon.stub()
                 mockRED.nodes.dirty = sinon.stub()
+                mockRED.editor = { validateNode: sinon.stub().callsFake(n => { n.valid = true }) }
                 const nodes = [{ id: 'n1', type: 'inject', z: 'tab1', x: 100, y: 200 }]
                 const result = {}
                 await expertAutomations.invokeAction('automation/add-nodes', {
@@ -823,6 +824,28 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('handled', true)
                 result.should.have.property('nodes').which.is.an.Array().with.lengthOf(1)
                 result.nodes[0].should.equal(addedNode)
+                result.should.have.property('validation').which.is.an.Array().with.lengthOf(0)
+            })
+            it('should return validation errors for invalid added nodes', async () => {
+                const addedNode = { id: 'n1', type: 'inject', z: 'tab1', x: 100, y: 200 }
+                mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: { repeat: { value: '' } } })
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', type: 'tab' })
+                mockRED.nodes.node = sinon.stub()
+                mockRED.nodes.node.withArgs('n1').onFirstCall().returns(null)
+                mockRED.nodes.node.withArgs('n1').returns(addedNode)
+                mockRED.view.importNodes = sinon.stub()
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.editor = { validateNode: sinon.stub().callsFake(n => { n.valid = false; n.validationErrors = ['repeat'] }) }
+                const nodes = [{ id: 'n1', type: 'inject', z: 'tab1', x: 100, y: 200 }]
+                const result = {}
+                await expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes }
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('validation').which.is.an.Array().with.lengthOf(1)
+                result.validation[0].should.have.property('id', 'n1')
+                result.validation[0].should.have.property('valid', false)
+                result.validation[0].should.have.property('validationErrors').which.deepEqual(['repeat'])
             })
             it('should throw if node type is unknown', async () => {
                 mockRED.nodes.getType = sinon.stub().returns(null)
@@ -1130,7 +1153,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('n1').returns(mockNode)
                 mockRED.nodes.dirty = sinon.stub()
                 mockRED.history = { push: sinon.stub() }
-                mockRED.editor = { validateNode: sinon.stub() }
+                mockRED.editor = { validateNode: sinon.stub().callsFake(n => { n.valid = true }) }
                 mockRED.view.redraw = sinon.stub()
                 const result = {}
                 await expertAutomations.invokeAction('automation/update-node', {
@@ -1149,6 +1172,21 @@ describeMain('expertAutomations', () => {
                 mockRED.view.redraw.calledOnce.should.be.true()
                 result.should.have.property('success', true)
                 result.should.have.property('node', mockNode)
+                result.should.have.property('validation').which.deepEqual({ valid: true })
+            })
+            it('should return validation errors after update', async () => {
+                const mockNode = { id: 'n1', repeat: 'bad', changed: false }
+                mockRED.nodes.node.withArgs('n1').returns(mockNode)
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.history = { push: sinon.stub() }
+                mockRED.editor = { validateNode: sinon.stub().callsFake(n => { n.valid = false; n.validationErrors = ['repeat'] }) }
+                mockRED.view.redraw = sinon.stub()
+                const result = {}
+                await expertAutomations.invokeAction('automation/update-node', {
+                    params: { id: 'n1', properties: { repeat: 'bad' } }
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('validation').which.deepEqual({ valid: false, validationErrors: ['repeat'] })
             })
             it('should capture old values correctly before applying changes', async () => {
                 const mockNode = { id: 'n1', name: 'original', x: 100, changed: true }
@@ -1638,6 +1676,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.dirty = sinon.stub()
                 mockRED._ = sinon.stub().returns('error')
                 mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().returns(false) }
+                mockRED.editor = { validateNode: sinon.stub().callsFake(n => { n.valid = true }) }
             })
             it('should import flow JSON string', async () => {
                 const flowJson = JSON.stringify([{ id: 'n1', type: 'inject' }])
@@ -1650,6 +1689,20 @@ describeMain('expertAutomations', () => {
                 args[1].should.have.property('touchImport', true)
                 result.should.have.property('success', true)
                 result.should.have.property('nodes').which.is.an.Array().with.lengthOf(1)
+                result.should.have.property('validation').which.is.an.Array().with.lengthOf(0)
+            })
+            it('should return validation errors for invalid imported nodes', async () => {
+                mockRED.editor = { validateNode: sinon.stub().callsFake(n => { n.valid = false; n.validationErrors = ['repeat'] }) }
+                const flowJson = JSON.stringify([{ id: 'n1', type: 'inject' }])
+                const result = {}
+                await expertAutomations.invokeAction('automation/import-flow', {
+                    params: { flow: flowJson }
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('validation').which.is.an.Array().with.lengthOf(1)
+                result.validation[0].should.have.property('id', 'n1')
+                result.validation[0].should.have.property('valid', false)
+                result.validation[0].should.have.property('validationErrors').which.deepEqual(['repeat'])
             })
             it('should import flow array and validate via redOps.validateFlow', async () => {
                 sinon.stub(expertAutomations.redOps, 'validateFlow').returns([{ id: 'n1', type: 'inject' }])


### PR DESCRIPTION
## Summary

- After `UPDATE_NODE`, `ADD_NODES`, and `IMPORT_FLOW` actions, return a `validation` field with the node's validity state
- `UPDATE_NODE` returns `validation: { valid, validationErrors? }` for the single updated node
- `ADD_NODES` and `IMPORT_FLOW` return `validation: [{ id, valid, validationErrors? }]` containing only invalid nodes (empty array if all valid)
- Added `_getNodeValidation()` helper with documentation on how Node-RED's `RED.editor.validateNode()` works internally

### How Node-RED validates nodes

`RED.editor.validateNode(node)` is a side-effect function that mutates the node object directly:
- Sets `node.valid` (boolean)
- Sets `node.validationErrors` (string array -- property names or custom error messages)
- Checks each property against `node._def.defaults` validators: required fields, custom validators, config node refs, credentials
- For subflow instances, cascades into the subflow definition and all internal nodes

The `_getNodeValidation()` helper reads these properties back into a compact object for the action response.

## Test plan

- [x] All 302 tests pass (3 new tests added)
- [x] Verified UPDATE_NODE returns `validation: { valid: true }` on success and `{ valid: false, validationErrors: ['prop'] }` on failure
- [x] Verified ADD_NODES returns empty validation array when all nodes are valid, array with invalid entries when not
- [x] Verified IMPORT_FLOW same pattern as ADD_NODES
- [x] Verified `validationErrors` uses array type matching Node-RED's actual implementation

Closes #287