### PR TITLE
feat(actions): add automation/get-node-types action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1195,18 +1195,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 return
             }
             const rawDefaults = def.defaults || {}
-            result.type = params.type
-            result.defaults = Object.fromEntries(
-                Object.entries(rawDefaults).map(([key, propDef]) => {
-                    if (propDef && typeof propDef === 'object') {
-                        const safe = Object.fromEntries(
-                            Object.entries(propDef).filter(([, v]) => typeof v !== 'function')
-                        )
-                        return [key, safe]
-                    }
-                    return [key, propDef]
-                })
-            )
+            result.nodeType = params.type
+            result.defaults = JSON.parse(JSON.stringify(rawDefaults, (key, value) =>
+                typeof value === 'function' ? value.toString() : value
+            ))
             result.label = typeof def.label === 'function' ? def.label.toString() : (def.label || params.type)
             result.category = def.category || null
             result.color = def.color || null

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -21,7 +21,7 @@ const SET_WIRES = 'automation/set-wires'
 const SET_LINKS = 'automation/set-links'
 const IMPORT_FLOW = 'automation/import-flow'
 const CLOSE_EDITOR_TRAY = 'automation/close-editor-tray'
-const GET_NODE_TYPE = 'automation/get-node-type'
+const GET_NODE_TYPES = 'automation/get-node-types'
 
 /**
  * @typedef {SELECT_NODES
@@ -44,7 +44,7 @@ const GET_NODE_TYPE = 'automation/get-node-type'
  *   |SET_LINKS
  *   |IMPORT_FLOW
  *   |CLOSE_EDITOR_TRAY
- *   |GET_NODE_TYPE} ExpertAutomationsActionsEnum
+ *   |GET_NODE_TYPES} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -314,14 +314,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
         [CLOSE_EDITOR_TRAY]: {
             params: null
         },
-        [GET_NODE_TYPE]: {
+        [GET_NODE_TYPES]: {
             params: {
                 type: 'object',
-                required: ['type'],
+                required: ['types'],
                 properties: {
-                    type: {
-                        type: 'string',
-                        description: 'Node type identifier to look up (e.g. "inject", "function", "worldmap")'
+                    types: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        minItems: 1,
+                        description: 'One or more node type identifiers to look up (e.g. ["inject", "function", "ui-text"])'
                     }
                 }
             }
@@ -482,7 +484,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {Object} [properties] - key-value pairs to merge into the node
      * @param {Array} [patches] - line-based partial edits: { property, op, start, end?, content? }
      */
-    async updateNode (id, properties, patches, codeProperties) {
+    async updateNode (id, properties, patches) {
         const hasProperties = properties !== undefined && properties !== null
         const hasPatches = Array.isArray(patches) && patches.length > 0
         if (hasProperties && Object.keys(properties).length === 0) {
@@ -514,30 +516,6 @@ export class ExpertAutomations extends ExpertActionsInterface {
             Object.assign(node, properties)
         }
 
-        // Syntax-check changed properties that contain JavaScript code.
-        // Auto-detects for built-in function nodes; callers can extend via codeProperties param.
-        const codeErrors = {}
-        const jsProps = new Set(Array.isArray(codeProperties) ? codeProperties : [])
-        if (node.type === 'function') {
-            jsProps.add('func')
-            jsProps.add('initialize')
-            jsProps.add('finalize')
-        }
-        for (const key of jsProps) {
-            if (!changes[key]) continue
-            const newVal = node[key]
-            if (typeof newVal === 'string' && newVal.includes('\n')) {
-                try {
-                    // eslint-disable-next-line no-new-func, no-unused-vars
-                    const _syntaxCheck = new Function(newVal)
-                } catch (err) {
-                    if (err instanceof SyntaxError) {
-                        codeErrors[key] = err.message
-                    }
-                }
-            }
-        }
-
         const wasChanged = node.changed
         this.RED.history.push({ t: 'edit', node, changes, changed: wasChanged, dirty: this.RED.nodes.dirty() })
         node.changed = true
@@ -552,8 +530,6 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (this.RED.view.state() !== this.RED.state?.DEFAULT) {
             await this.closeEditorTray()
         }
-
-        return Object.keys(codeErrors).length > 0 ? codeErrors : null
     }
 
     async closeEditorTray () {
@@ -1108,15 +1084,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 }
             }
-            const codeErrors = await this.updateNode(params.id, params.properties, params.patches, params.codeProperties)
+            await this.updateNode(params.id, params.properties, params.patches)
             const updatedNode = this.RED.nodes.node(params.id)
             result.data = this._summarizeNode(updatedNode)
             result.validation = this._getNodeValidation(updatedNode)
-            if (codeErrors) {
-                if (!result.validation) result.validation = {}
-                result.validation.valid = false
-                result.validation.codeErrors = codeErrors
-            }
             if (Object.keys(preUpdateLineCounts).length > 0) {
                 result.preUpdateLineCounts = preUpdateLineCounts
             }
@@ -1229,27 +1200,27 @@ export class ExpertAutomations extends ExpertActionsInterface {
             result.closed = await this.closeEditorTray()
             result.success = true
             break
-        case GET_NODE_TYPE: {
-            const def = this.RED.nodes.getType(params.type)
-            if (!def) {
-                result.success = false
-                result.error = `Node type "${params.type}" is not installed in this Node-RED instance`
-                return
-            }
-            const rawDefaults = def.defaults || {}
-            result.data = {
-                nodeType: params.type,
-                defaults: JSON.parse(JSON.stringify(rawDefaults, (key, value) =>
-                    typeof value === 'function' ? value.toString() : value
-                )),
-                label: typeof def.label === 'function' ? def.label.toString() : (def.label || params.type),
-                category: def.category || null,
-                color: typeof def.color === 'function' ? def.color.call({}) : (def.color || null),
-                inputs: def.inputs ?? 0,
-                outputs: def.outputs ?? 0
+        case GET_NODE_TYPES:
+            result.data = {}
+            for (const type of params.types) {
+                const def = this.RED.nodes.getType(type)
+                if (!def) {
+                    result.data[type] = { installed: false }
+                    continue
+                }
+                const rawDefaults = def.defaults || {}
+                result.data[type] = {
+                    defaults: JSON.parse(JSON.stringify(rawDefaults, (key, value) =>
+                        typeof value === 'function' ? value.toString() : value
+                    )),
+                    label: typeof def.label === 'function' ? def.label.toString() : (def.label || type),
+                    category: def.category || null,
+                    color: typeof def.color === 'function' ? def.color.call({}) : (def.color || null),
+                    inputs: def.inputs ?? 0,
+                    outputs: def.outputs ?? 0
+                }
             }
             result.success = true
-        }
             break
         default:
             result.handled = false

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -507,6 +507,24 @@ export class ExpertAutomations extends ExpertActionsInterface {
             Object.assign(node, properties)
         }
 
+        // Syntax-check all changed string properties that look like code (multi-line).
+        // new Function() compiles as a function body — same context Node-RED uses for function nodes.
+        // This catches syntax errors synchronously before the runtime does, and works for any node type.
+        const codeErrors = {}
+        for (const key of Object.keys(changes)) {
+            const newVal = key.includes('.') ? undefined : node[key] // skip deep paths; node[key] covers top-level
+            if (typeof newVal === 'string' && newVal.includes('\n')) {
+                try {
+                    // eslint-disable-next-line no-new-func, no-unused-vars
+                    const _syntaxCheck = new Function(newVal)
+                } catch (err) {
+                    if (err instanceof SyntaxError) {
+                        codeErrors[key] = err.message
+                    }
+                }
+            }
+        }
+
         const wasChanged = node.changed
         this.RED.history.push({ t: 'edit', node, changes, changed: wasChanged, dirty: this.RED.nodes.dirty() })
         node.changed = true
@@ -521,6 +539,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (this.RED.view.state() !== this.RED.state?.DEFAULT) {
             await this.closeEditorTray()
         }
+
+        return Object.keys(codeErrors).length > 0 ? codeErrors : null
     }
 
     async closeEditorTray () {
@@ -1061,10 +1081,32 @@ export class ExpertAutomations extends ExpertActionsInterface {
             break
 
         case UPDATE_NODE: {
-            await this.updateNode(params.id, params.properties, params.patches)
+            // Capture pre-patch line counts so the agent can see what it was working with
+            const preUpdateLineCounts = {}
+            if (Array.isArray(params.patches) && params.patches.length > 0) {
+                const currentNode = this.RED.nodes.node(params.id)
+                if (currentNode) {
+                    const patchedTopLevel = [...new Set(params.patches.map(p => p.property.split('.')[0]))]
+                    for (const prop of patchedTopLevel) {
+                        const val = currentNode[prop]
+                        if (typeof val === 'string') {
+                            preUpdateLineCounts[prop] = val.split('\n').length
+                        }
+                    }
+                }
+            }
+            const codeErrors = await this.updateNode(params.id, params.properties, params.patches)
             const updatedNode = this.RED.nodes.node(params.id)
             result.node = this._formatNodes([updatedNode], params.options?.includeModuleConfig)[0] || null
             result.validation = this._getNodeValidation(updatedNode)
+            if (codeErrors) {
+                if (!result.validation) result.validation = {}
+                result.validation.valid = false
+                result.validation.codeErrors = codeErrors
+            }
+            if (Object.keys(preUpdateLineCounts).length > 0) {
+                result.preUpdateLineCounts = preUpdateLineCounts
+            }
             result.success = true
         }
             break

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -21,6 +21,7 @@ const SET_WIRES = 'automation/set-wires'
 const SET_LINKS = 'automation/set-links'
 const IMPORT_FLOW = 'automation/import-flow'
 const CLOSE_EDITOR_TRAY = 'automation/close-editor-tray'
+const GET_NODE_TYPE = 'automation/get-node-type'
 
 /**
  * @typedef {SELECT_NODES
@@ -42,7 +43,8 @@ const CLOSE_EDITOR_TRAY = 'automation/close-editor-tray'
  *   |SET_WIRES
  *   |SET_LINKS
  *   |IMPORT_FLOW
- *   |CLOSE_EDITOR_TRAY} ExpertAutomationsActionsEnum
+ *   |CLOSE_EDITOR_TRAY
+ *   |GET_NODE_TYPE} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -311,6 +313,18 @@ export class ExpertAutomations extends ExpertActionsInterface {
         },
         [CLOSE_EDITOR_TRAY]: {
             params: null
+        },
+        [GET_NODE_TYPE]: {
+            params: {
+                type: 'object',
+                required: ['type'],
+                properties: {
+                    type: {
+                        type: 'string',
+                        description: 'Node type identifier to look up (e.g. "inject", "function", "worldmap")'
+                    }
+                }
+            }
         }
     })
 
@@ -1172,6 +1186,23 @@ export class ExpertAutomations extends ExpertActionsInterface {
         case CLOSE_EDITOR_TRAY:
             result.closed = await this.closeEditorTray()
             result.success = true
+            break
+        case GET_NODE_TYPE: {
+            const def = this.RED.nodes.getType(params.type)
+            if (!def) {
+                result.success = false
+                result.error = new Error(`Node type "${params.type}" is not installed in this Node-RED instance`)
+                return
+            }
+            result.type = params.type
+            result.defaults = def.defaults || {}
+            result.label = typeof def.label === 'function' ? def.label.toString() : (def.label || params.type)
+            result.category = def.category || null
+            result.color = def.color || null
+            result.inputs = def.inputs ?? 0
+            result.outputs = def.outputs ?? 0
+            result.success = true
+        }
             break
         default:
             result.handled = false

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1244,15 +1244,17 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 return
             }
             const rawDefaults = def.defaults || {}
-            result.nodeType = params.type
-            result.defaults = JSON.parse(JSON.stringify(rawDefaults, (key, value) =>
-                typeof value === 'function' ? value.toString() : value
-            ))
-            result.label = typeof def.label === 'function' ? def.label.toString() : (def.label || params.type)
-            result.category = def.category || null
-            result.color = typeof def.color === 'function' ? def.color.call({}) : (def.color || null)
-            result.inputs = def.inputs ?? 0
-            result.outputs = def.outputs ?? 0
+            result.data = {
+                nodeType: params.type,
+                defaults: JSON.parse(JSON.stringify(rawDefaults, (key, value) =>
+                    typeof value === 'function' ? value.toString() : value
+                )),
+                label: typeof def.label === 'function' ? def.label.toString() : (def.label || params.type),
+                category: def.category || null,
+                color: typeof def.color === 'function' ? def.color.call({}) : (def.color || null),
+                inputs: def.inputs ?? 0,
+                outputs: def.outputs ?? 0
+            }
             result.success = true
         }
             break

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1070,27 +1070,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
             break
 
         case UPDATE_NODE: {
-            // Capture pre-patch line counts so the agent can see what it was working with
-            const preUpdateLineCounts = {}
-            if (Array.isArray(params.patches) && params.patches.length > 0) {
-                const currentNode = this.RED.nodes.node(params.id)
-                if (currentNode) {
-                    const patchedTopLevel = [...new Set(params.patches.map(p => p.property.split('.')[0]))]
-                    for (const prop of patchedTopLevel) {
-                        const val = currentNode[prop]
-                        if (typeof val === 'string') {
-                            preUpdateLineCounts[prop] = val.split('\n').length
-                        }
-                    }
-                }
-            }
             await this.updateNode(params.id, params.properties, params.patches)
             const updatedNode = this.RED.nodes.node(params.id)
             result.data = this._summarizeNode(updatedNode)
             result.validation = this._getNodeValidation(updatedNode)
-            if (Object.keys(preUpdateLineCounts).length > 0) {
-                result.preUpdateLineCounts = preUpdateLineCounts
-            }
             result.success = true
         }
             break

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1183,7 +1183,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
             result.closed = await this.closeEditorTray()
             result.success = true
             break
-        case GET_NODE_TYPES:
+        case GET_NODE_TYPES: {
+            const nrEncode = (value) => {
+                if (typeof value === 'function') return { __enc__: true, type: 'function', data: value.toString() }
+                if (typeof value === 'bigint') return { __enc__: true, type: 'bigint', data: value.toString() }
+                if (typeof value === 'number' && (isNaN(value) || !isFinite(value))) return { __enc__: true, type: 'number', data: String(value) }
+                if (value instanceof RegExp) return { __enc__: true, type: 'regexp', data: value.toString() }
+                if (value instanceof Set) return { __enc__: true, type: 'set', data: Array.from(value), length: value.size }
+                if (value instanceof Map) return { __enc__: true, type: 'map', data: Object.fromEntries(value.entries()), length: value.size }
+                return value
+            }
             result.data = {}
             for (const type of params.types) {
                 const def = this.RED.nodes.getType(type)
@@ -1191,20 +1200,18 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     result.data[type] = { installed: false }
                     continue
                 }
-                const rawDefaults = def.defaults || {}
                 result.data[type] = {
-                    defaults: JSON.parse(JSON.stringify(rawDefaults, (key, value) =>
-                        typeof value === 'function' ? value.toString() : value
-                    )),
-                    label: typeof def.label === 'function' ? def.label.toString() : (def.label || type),
+                    defaults: JSON.parse(JSON.stringify(def.defaults || {}, (key, value) => nrEncode(value))),
+                    label: def.label ? nrEncode(def.label) : type,
                     category: def.category || null,
-                    color: typeof def.color === 'function' ? def.color.call({}) : (def.color || null),
+                    color: def.color ? nrEncode(def.color) : null,
                     inputs: def.inputs ?? 0,
                     outputs: def.outputs ?? 0
                 }
             }
             result.success = true
             break
+        }
         default:
             result.handled = false
             result.success = false

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1191,11 +1191,22 @@ export class ExpertAutomations extends ExpertActionsInterface {
             const def = this.RED.nodes.getType(params.type)
             if (!def) {
                 result.success = false
-                result.error = new Error(`Node type "${params.type}" is not installed in this Node-RED instance`)
+                result.error = `Node type "${params.type}" is not installed in this Node-RED instance`
                 return
             }
+            const rawDefaults = def.defaults || {}
             result.type = params.type
-            result.defaults = def.defaults || {}
+            result.defaults = Object.fromEntries(
+                Object.entries(rawDefaults).map(([key, propDef]) => {
+                    if (propDef && typeof propDef === 'object') {
+                        const safe = Object.fromEntries(
+                            Object.entries(propDef).filter(([, v]) => typeof v !== 'function')
+                        )
+                        return [key, safe]
+                    }
+                    return [key, propDef]
+                })
+            )
             result.label = typeof def.label === 'function' ? def.label.toString() : (def.label || params.type)
             result.category = def.category || null
             result.color = def.color || null

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1250,7 +1250,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             ))
             result.label = typeof def.label === 'function' ? def.label.toString() : (def.label || params.type)
             result.category = def.category || null
-            result.color = def.color || null
+            result.color = typeof def.color === 'function' ? def.color.call({}) : (def.color || null)
             result.inputs = def.inputs ?? 0
             result.outputs = def.outputs ?? 0
             result.success = true

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -475,7 +475,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {Object} [properties] - key-value pairs to merge into the node
      * @param {Array} [patches] - line-based partial edits: { property, op, start, end?, content? }
      */
-    async updateNode (id, properties, patches) {
+    async updateNode (id, properties, patches, codeProperties) {
         const hasProperties = properties !== undefined && properties !== null
         const hasPatches = Array.isArray(patches) && patches.length > 0
         if (hasProperties && Object.keys(properties).length === 0) {
@@ -507,12 +507,18 @@ export class ExpertAutomations extends ExpertActionsInterface {
             Object.assign(node, properties)
         }
 
-        // Syntax-check all changed string properties that look like code (multi-line).
-        // new Function() compiles as a function body — same context Node-RED uses for function nodes.
-        // This catches syntax errors synchronously before the runtime does, and works for any node type.
+        // Syntax-check changed properties that contain JavaScript code.
+        // Auto-detects for built-in function nodes; callers can extend via codeProperties param.
         const codeErrors = {}
-        for (const key of Object.keys(changes)) {
-            const newVal = key.includes('.') ? undefined : node[key] // skip deep paths; node[key] covers top-level
+        const jsProps = new Set(Array.isArray(codeProperties) ? codeProperties : [])
+        if (node.type === 'function') {
+            jsProps.add('func')
+            jsProps.add('initialize')
+            jsProps.add('finalize')
+        }
+        for (const key of jsProps) {
+            if (!changes[key]) continue
+            const newVal = node[key]
             if (typeof newVal === 'string' && newVal.includes('\n')) {
                 try {
                     // eslint-disable-next-line no-new-func, no-unused-vars
@@ -1095,7 +1101,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 }
             }
-            const codeErrors = await this.updateNode(params.id, params.properties, params.patches)
+            const codeErrors = await this.updateNode(params.id, params.properties, params.patches, params.codeProperties)
             const updatedNode = this.RED.nodes.node(params.id)
             result.node = this._formatNodes([updatedNode], params.options?.includeModuleConfig)[0] || null
             result.validation = this._getNodeValidation(updatedNode)

--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -588,12 +588,9 @@ export class ExpertComms {
                 }
                 this.postReply({ type, action, success: true, ...result }, event)
             } catch (err) {
-                try {
-                    result.error = err.message
-                    this.postReply({ type, action, ...result, success: false }, event)
-                } catch (_) {
-                    this.postReply({ type, action, correlationId, success: false, error: err.message }, event)
-                }
+                result.error = err.message
+                result.exception = err
+                this.postReply({ type, action, ...result, success: false }, event)
             }
         }
         }

--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -588,8 +588,12 @@ export class ExpertComms {
                 }
                 this.postReply({ type, action, success: true, ...result }, event)
             } catch (err) {
-                result.error = err.message
-                this.postReply({ type, action, ...result, success: false }, event)
+                try {
+                    result.error = err.message
+                    this.postReply({ type, action, ...result, success: false }, event)
+                } catch (_) {
+                    this.postReply({ type, action, correlationId, success: false, error: err.message }, event)
+                }
             }
         }
         }

--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -589,7 +589,6 @@ export class ExpertComms {
                 this.postReply({ type, action, success: true, ...result }, event)
             } catch (err) {
                 result.error = err.message
-                result.exception = err
                 this.postReply({ type, action, ...result, success: false }, event)
             }
         }

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1855,20 +1855,57 @@ describeMain('expertAutomations', () => {
                 result.data.function.should.not.have.property('installed')
                 result.data.should.have.property('not-installed').which.deepEqual({ installed: false })
             })
-            it('should resolve function-typed color without throwing', async () => {
+            it('should encode function-typed label, color, and defaults using __enc__ format', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({
                     inputs: 1,
                     outputs: 1,
                     category: 'function',
-                    defaults: {},
-                    color: function () { return '#aabbcc' }
+                    defaults: {
+                        name: { value: '', validate: function isValid (v) { return v.length > 0 } }
+                    },
+                    label: function myLabel () { return 'My Node' },
+                    color: function myColor () { return '#aabbcc' }
                 })
                 const result = {}
                 await expertAutomations.invokeAction('automation/get-node-types', {
                     params: { types: ['function'] }
                 }, result)
                 result.should.have.property('success', true)
-                result.data.function.should.have.property('color', '#aabbcc')
+                result.data.function.label.should.have.property('__enc__', true)
+                result.data.function.label.should.have.property('type', 'function')
+                result.data.function.label.should.have.property('data').which.is.a.String()
+                result.data.function.color.should.have.property('__enc__', true)
+                result.data.function.color.should.have.property('type', 'function')
+                result.data.function.color.should.have.property('data').which.is.a.String()
+                result.data.function.defaults.name.validate.should.have.property('__enc__', true)
+                result.data.function.defaults.name.validate.should.have.property('type', 'function')
+                result.data.function.defaults.name.validate.should.have.property('data').which.is.a.String()
+            })
+            it('should encode Set, Map, RegExp, and non-finite numbers in defaults', async () => {
+                mockRED.nodes.getType = sinon.stub().returns({
+                    inputs: 1,
+                    outputs: 1,
+                    category: 'function',
+                    defaults: {
+                        tags: { value: new Set(['a', 'b']) },
+                        meta: { value: new Map([['k', 'v']]) },
+                        pattern: { value: /foo/i },
+                        ratio: { value: Infinity }
+                    }
+                })
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-node-types', {
+                    params: { types: ['function'] }
+                }, result)
+                result.should.have.property('success', true)
+                result.data.function.defaults.tags.value.should.have.property('__enc__', true)
+                result.data.function.defaults.tags.value.should.have.property('type', 'set')
+                result.data.function.defaults.meta.value.should.have.property('__enc__', true)
+                result.data.function.defaults.meta.value.should.have.property('type', 'map')
+                result.data.function.defaults.pattern.value.should.have.property('__enc__', true)
+                result.data.function.defaults.pattern.value.should.have.property('type', 'regexp')
+                result.data.function.defaults.ratio.value.should.have.property('__enc__', true)
+                result.data.function.defaults.ratio.value.should.have.property('type', 'number')
             })
         })
     })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -91,7 +91,7 @@ describeMain('expertAutomations', () => {
                 'automation/set-links',
                 'automation/import-flow',
                 'automation/close-editor-tray',
-                'automation/get-node-type'
+                'automation/get-node-types'
             ]
             supportedActions.should.only.have.keys(...expectedKeys)
         })
@@ -1811,6 +1811,64 @@ describeMain('expertAutomations', () => {
                 await should(expertAutomations.invokeAction('automation/import-flow', {
                     params: { flow: flowArray }
                 }, {})).rejectedWith(/importNodes failed: duplicate node id/)
+            })
+        })
+
+        describe('getNodeTypes action', () => {
+            it('should return type info for installed types', async () => {
+                mockRED.nodes.getType = sinon.stub()
+                mockRED.nodes.getType.withArgs('function').returns({ inputs: 1, outputs: 1, category: 'function', defaults: { name: { value: '' } } })
+                mockRED.nodes.getType.withArgs('inject').returns({ inputs: 0, outputs: 1, category: 'input', defaults: {} })
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-node-types', {
+                    params: { types: ['function', 'inject'] }
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('data')
+                result.data.should.have.property('function')
+                result.data.function.should.have.property('inputs', 1)
+                result.data.function.should.have.property('outputs', 1)
+                result.data.function.should.have.property('category', 'function')
+                result.data.function.should.have.property('defaults')
+                result.data.should.have.property('inject')
+                result.data.inject.should.have.property('inputs', 0)
+            })
+            it('should mark types not installed with installed: false', async () => {
+                mockRED.nodes.getType = sinon.stub().returns(null)
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-node-types', {
+                    params: { types: ['unknown-type'] }
+                }, result)
+                result.should.have.property('success', true)
+                result.data.should.have.property('unknown-type').which.deepEqual({ installed: false })
+            })
+            it('should handle a mix of installed and not installed types', async () => {
+                mockRED.nodes.getType = sinon.stub()
+                mockRED.nodes.getType.withArgs('function').returns({ inputs: 1, outputs: 1, category: 'function', defaults: {} })
+                mockRED.nodes.getType.withArgs('not-installed').returns(null)
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-node-types', {
+                    params: { types: ['function', 'not-installed'] }
+                }, result)
+                result.should.have.property('success', true)
+                result.data.should.have.property('function')
+                result.data.function.should.not.have.property('installed')
+                result.data.should.have.property('not-installed').which.deepEqual({ installed: false })
+            })
+            it('should resolve function-typed color without throwing', async () => {
+                mockRED.nodes.getType = sinon.stub().returns({
+                    inputs: 1,
+                    outputs: 1,
+                    category: 'function',
+                    defaults: {},
+                    color: function () { return '#aabbcc' }
+                })
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-node-types', {
+                    params: { types: ['function'] }
+                }, result)
+                result.should.have.property('success', true)
+                result.data.function.should.have.property('color', '#aabbcc')
             })
         })
     })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -90,7 +90,8 @@ describeMain('expertAutomations', () => {
                 'automation/set-wires',
                 'automation/set-links',
                 'automation/import-flow',
-                'automation/close-editor-tray'
+                'automation/close-editor-tray',
+                'automation/get-node-type'
             ]
             supportedActions.should.only.have.keys(...expectedKeys)
         })


### PR DESCRIPTION
## Summary

- Add `automation/get-node-type` action that calls `RED.nodes.getType(type)` at runtime
- Returns `defaults`, `label`, `category`, `color`, `inputs`, `outputs` for any installed node type
- Returns `success: false` with a descriptive error if the type is not installed
- Add action to the supported actions list and update tests

## Test plan

- Existing test suite passes (302 tests)
- `should have supported actions` test updated to include `automation/get-node-type`

Closes #290