### PR TITLE
fix(actions): allow config nodes in add-nodes without z property

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -244,10 +244,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
                                 type: { type: 'string', description: 'Node type identifier' },
                                 x: { type: 'number', description: 'Canvas x position' },
                                 y: { type: 'number', description: 'Canvas y position' },
-                                z: { type: 'string', description: 'Tab (workspace) ID' }
+                                z: { type: 'string', description: 'Tab (workspace) ID — required for non-config nodes, omit for config nodes' }
                             },
                             additionalProperties: true,
-                            required: ['id', 'type', 'z']
+                            required: ['id', 'type']
                         },
                         description: 'Array of node objects to add to the canvas'
                     },

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -822,7 +822,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * Add one or more nodes to the live NR4 canvas.
      * Delegates to RED.view.importNodes which handles node initialisation,
      * history (undo/redo) and view updates internally.
-     * @param {Object[]} nodes - array of raw node objects (must include id, type, z)
+     * @param {Object[]} nodes - array of raw node objects (must include id, type; z required for non-config nodes)
      * @param {Object} [options]
      * @param {boolean} [options.generateIds=false] - regenerate node IDs during import
      */
@@ -832,13 +832,14 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const prepared = nodes.map(rawNode => {
             if (!rawNode.id) throw new Error('Node is missing required property: id')
             if (!rawNode.type) throw new Error('Node is missing required property: type')
-            if (!rawNode.z) throw new Error('Node is missing required property: z')
             const def = this.RED.nodes.getType(rawNode.type)
             if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
+            const isConfigNode = def.category === 'config'
+            if (!isConfigNode && !rawNode.z) throw new Error('Node is missing required property: z')
             return { ...rawNode }
         })
         // Validate all target tabs exist and are not locked
-        const uniqueZs = [...new Set(prepared.map(n => n.z))]
+        const uniqueZs = [...new Set(prepared.map(n => n.z).filter(Boolean))]
         for (const z of uniqueZs) {
             if (!this.hasWorkspace(z)) throw new Error(`Workspace tab ${z} not found`)
             const ws = this.RED.nodes.workspace(z)

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -973,7 +973,7 @@ describeMain('expertAutomations', () => {
                 }, result)
                 mockRED.view.importNodes.calledOnce.should.be.true()
                 result.should.have.property('success', true)
-                result.should.have.property('nodes').which.is.an.Array().with.lengthOf(1)
+                result.should.have.property('data').which.is.an.Array().with.lengthOf(1)
             })
             it('should throw if node is missing required property id', async () => {
                 const result = {}

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -947,11 +947,29 @@ describeMain('expertAutomations', () => {
                 opts.generateIds.should.equal(true)
                 result.should.have.property('success', true)
             })
-            it('should throw if node is missing required property z', async () => {
+            it('should throw if non-config node is missing required property z', async () => {
+                mockRED.nodes.getType = sinon.stub().returns({ category: 'function', inputs: 1, outputs: 1, defaults: {} })
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes: [{ id: 'n1', type: 'inject' }] }
                 }, result)).rejectedWith(/missing required property: z/)
+            })
+            it('should accept config nodes without z property', async () => {
+                const configNode = { id: 'cfg1', type: 'ui-base', name: 'Dashboard' }
+                mockRED.nodes.getType = sinon.stub().returns({ category: 'config', inputs: 0, outputs: 0, defaults: { name: { value: '' } } })
+                mockRED.nodes.node = sinon.stub()
+                mockRED.nodes.node.withArgs('cfg1').onFirstCall().returns(null)
+                mockRED.nodes.node.withArgs('cfg1').returns(configNode)
+                mockRED.view.importNodes = sinon.stub()
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.editor = { validateNode: sinon.stub().callsFake(n => { n.valid = true }) }
+                const result = {}
+                await expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [configNode] }
+                }, result)
+                mockRED.view.importNodes.calledOnce.should.be.true()
+                result.should.have.property('success', true)
+                result.should.have.property('nodes').which.is.an.Array().with.lengthOf(1)
             })
             it('should throw if node is missing required property id', async () => {
                 const result = {}


### PR DESCRIPTION
## Summary

- Config nodes (category `config`) like `ui-base`, `ui-theme`, `ui-page`, `ui-group` are global in Node-RED and have no `z` (tab) assignment
- The `addNodes` guard unconditionally required `z`, rejecting all config node creation
- Check the node definition's category via `RED.nodes.getType()` before enforcing `z`
- Filter `undefined` from the workspace validation loop so config nodes don't trigger `hasWorkspace(undefined)`

Closes #296

## Test plan

- Existing test updated: "should throw if non-config node is missing required property z" verifies non-config nodes still require `z`
- New test: "should accept config nodes without z property" verifies config nodes pass through to `importNodes` without `z`
- All 303 tests pass