### PR TITLE
feat(actions): add automation/list-config-nodes action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1313,7 +1313,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 if (params?.tabId && params.tabId !== 'global' && configNode.z !== params.tabId) return
                 configNodes.push(configNode)
             })
-            result.configNodes = this._formatNodes(configNodes, false)
+            result.data = { configNodes: this._formatNodes(configNodes, false) }
             result.success = true
         }
             break

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -23,6 +23,7 @@ const IMPORT_FLOW = 'automation/import-flow'
 const CLOSE_EDITOR_TRAY = 'automation/close-editor-tray'
 const GET_NODE_TYPE = 'automation/get-node-type'
 const LIST_NODE_PACKAGES = 'automation/list-node-packages'
+const LIST_CONFIG_NODES = 'automation/list-config-nodes'
 
 /**
  * @typedef {SELECT_NODES
@@ -46,7 +47,8 @@ const LIST_NODE_PACKAGES = 'automation/list-node-packages'
  *   |IMPORT_FLOW
  *   |CLOSE_EDITOR_TRAY
  *   |GET_NODE_TYPE
- *   |LIST_NODE_PACKAGES} ExpertAutomationsActionsEnum
+ *   |LIST_NODE_PACKAGES
+ *   |LIST_CONFIG_NODES} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -336,6 +338,17 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         type: 'array',
                         items: { type: 'string' },
                         description: 'Module names that have pre-built schemas, used to set hasSchema flag on each package'
+                    }
+                }
+            }
+        },
+        [LIST_CONFIG_NODES]: {
+            params: {
+                type: 'object',
+                properties: {
+                    type: {
+                        type: 'string',
+                        description: 'Optional filter by config node type (e.g. "ui-base", "mqtt-broker")'
                     }
                 }
             }
@@ -1282,6 +1295,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 packages[ns.module].nodeCount += (Array.isArray(ns.types) ? ns.types.length : 0)
             }
             result.packages = Object.values(packages)
+            result.success = true
+        }
+            break
+        case LIST_CONFIG_NODES: {
+            const configNodes = []
+            this.RED.nodes.eachConfig(configNode => {
+                if (params?.type && configNode.type !== params.type) return
+                configNodes.push(configNode)
+            })
+            result.configNodes = this._formatNodes(configNodes, false)
             result.success = true
         }
             break

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -349,6 +349,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     type: {
                         type: 'string',
                         description: 'Optional filter by config node type (e.g. "ui-base", "mqtt-broker")'
+                    },
+                    tabId: {
+                        type: 'string',
+                        description: 'Scope filter: "global" for config nodes not attached to any tab, a tab ID for config nodes scoped to that tab, or omit to return all'
                     }
                 }
             }
@@ -1302,6 +1306,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
             const configNodes = []
             this.RED.nodes.eachConfig(configNode => {
                 if (params?.type && configNode.type !== params.type) return
+                if (params?.tabId === 'global' && configNode.z) return
+                if (params?.tabId && params.tabId !== 'global' && configNode.z !== params.tabId) return
                 configNodes.push(configNode)
             })
             result.configNodes = this._formatNodes(configNodes, false)

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1159,7 +1159,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         case SHOW_WORKSPACE: {
             this.showWorkspace(params.id)
             const ws = this.RED.nodes.workspace(params.id)
-            result.data = ws ? { id: ws.id, label: typeof ws.label === 'function' ? ws.label() : ws.label } : null
+            result.data = this._summarizeWorkspace(ws)
             result.success = true
         }
             break
@@ -1179,19 +1179,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
             result.success = true
             break
 
-        case LIST_WORKSPACES: {
-            const workspaceIds = this.RED.nodes.getWorkspaceOrder()
-            const tabs = workspaceIds.map(id => this.RED.nodes.workspace(id))
-            const sanitized = tabs.map(t => ({ id: t.id, label: typeof t.label === 'function' ? t.label() : t.label, disabled: t.disabled, info: t.info, locked: t.locked, contentsChanged: t.contentsChanged }))
-            const selectedWorkspaces = this.RED.workspaces.selection() || []
-            sanitized.forEach(t => {
-                t.hidden = this.RED.workspaces.isHidden(t.id)
-                t.isActiveWorkspace = this.RED.workspaces.active() === t.id
-                t.isSelected = t.isActiveWorkspace || selectedWorkspaces.includes(t.id)
-            })
-            result.workspaces = sanitized
+        case LIST_WORKSPACES:
+            result.workspaces = this._listWorkspaces()
             result.success = true
-        }
             break
 
         case CLOSE_SEARCH:
@@ -1218,7 +1208,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
         case REMOVE_TAB:
             this.removeTab(params.id)
-            result.data = { removed: params.id }
+            result.data = {
+                removed: params.id,
+                remainingTabs: this._listWorkspaces()
+            }
             result.success = true
             break
 
@@ -1353,6 +1346,27 @@ export class ExpertAutomations extends ExpertActionsInterface {
             result.validationErrors = node.validationErrors
         }
         return result
+    }
+
+    _listWorkspaces () {
+        return this.RED.nodes.getWorkspaceOrder().map(id => this._summarizeWorkspace(this.RED.nodes.workspace(id)))
+    }
+
+    _summarizeWorkspace (ws) {
+        if (!ws) return null
+        const selectedWorkspaces = this.RED.workspaces.selection() || []
+        const isActiveWorkspace = this.RED.workspaces.active() === ws.id
+        return {
+            id: ws.id,
+            label: typeof ws.label === 'function' ? ws.label() : ws.label,
+            disabled: ws.disabled,
+            info: ws.info,
+            locked: ws.locked,
+            contentsChanged: ws.contentsChanged,
+            hidden: this.RED.workspaces.isHidden(ws.id),
+            isActiveWorkspace,
+            isSelected: isActiveWorkspace || selectedWorkspaces.includes(ws.id)
+        }
     }
 
     _summarizeNode (node) {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -92,7 +92,8 @@ describeMain('expertAutomations', () => {
                 'automation/import-flow',
                 'automation/close-editor-tray',
                 'automation/get-node-type',
-                'automation/list-node-packages'
+                'automation/list-node-packages',
+                'automation/list-config-nodes'
             ]
             supportedActions.should.only.have.keys(...expectedKeys)
         })
@@ -1774,6 +1775,79 @@ describeMain('expertAutomations', () => {
                 }, result)
                 mockRED.view.importNodes.calledOnce.should.be.true()
                 result.should.have.property('success', true)
+            })
+        })
+
+        describe('automation/list-config-nodes', () => {
+            beforeEach(() => {
+                expertAutomations.init(mockExpertComms, mockRED)
+                mockRED.nodes.eachConfig = sinon.stub()
+                mockRED.nodes.createExportableNodeSet = sinon.stub().callsFake((nodes) => nodes || [])
+            })
+
+            it('should return all config nodes', async () => {
+                const configNodes = [
+                    { id: 'cfg1', type: 'ui-base', name: 'Dashboard' },
+                    { id: 'cfg2', type: 'ui-theme', name: 'Default Theme' },
+                    { id: 'cfg3', type: 'mqtt-broker', name: 'Local MQTT' }
+                ]
+                mockRED.nodes.eachConfig.callsFake(cb => configNodes.forEach(cb))
+                const result = {}
+                await expertAutomations.invokeAction('automation/list-config-nodes', {
+                    params: {}
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(3)
+            })
+
+            it('should filter config nodes by type', async () => {
+                const configNodes = [
+                    { id: 'cfg1', type: 'ui-base', name: 'Dashboard' },
+                    { id: 'cfg2', type: 'ui-theme', name: 'Default Theme' },
+                    { id: 'cfg3', type: 'mqtt-broker', name: 'Local MQTT' }
+                ]
+                mockRED.nodes.eachConfig.callsFake(cb => configNodes.forEach(cb))
+                const result = {}
+                await expertAutomations.invokeAction('automation/list-config-nodes', {
+                    params: { type: 'mqtt-broker' }
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
+                result.configNodes[0].should.have.property('type', 'mqtt-broker')
+            })
+
+            it('should return empty array when no config nodes exist', async () => {
+                mockRED.nodes.eachConfig.callsFake(() => {})
+                const result = {}
+                await expertAutomations.invokeAction('automation/list-config-nodes', {
+                    params: {}
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(0)
+            })
+
+            it('should return empty array when type filter matches nothing', async () => {
+                const configNodes = [
+                    { id: 'cfg1', type: 'ui-base', name: 'Dashboard' }
+                ]
+                mockRED.nodes.eachConfig.callsFake(cb => configNodes.forEach(cb))
+                const result = {}
+                await expertAutomations.invokeAction('automation/list-config-nodes', {
+                    params: { type: 'nonexistent-type' }
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(0)
+            })
+
+            it('should work with no params', async () => {
+                const configNodes = [
+                    { id: 'cfg1', type: 'ui-base', name: 'Dashboard' }
+                ]
+                mockRED.nodes.eachConfig.callsFake(cb => configNodes.forEach(cb))
+                const result = {}
+                await expertAutomations.invokeAction('automation/list-config-nodes', {}, result)
+                result.should.have.property('success', true)
+                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
             })
         })
     })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1015,16 +1015,24 @@ describeMain('expertAutomations', () => {
         })
         describe('removeTab action', () => {
             it('should remove an existing tab', async () => {
-                const mockWs = { id: 'tab1', type: 'tab' }
+                const mockWs = { id: 'tab1', type: 'tab', locked: false, disabled: false }
                 mockRED.nodes.workspace = sinon.stub().withArgs('tab1').returns(mockWs)
-                mockRED.workspaces = { delete: sinon.stub() }
+                mockRED.nodes.getWorkspaceOrder = sinon.stub().returns([])
+                mockRED.workspaces = {
+                    delete: sinon.stub(),
+                    selection: sinon.stub().returns([]),
+                    active: sinon.stub().returns(null),
+                    isHidden: sinon.stub().returns(false)
+                }
                 const result = {}
                 await expertAutomations.invokeAction('automation/remove-tab', {
                     params: { id: 'tab1' }
                 }, result)
                 mockRED.workspaces.delete.calledWith(mockWs).should.be.true()
                 result.should.have.property('success', true)
-                result.should.have.property('data').which.deepEqual({ removed: 'tab1' })
+                result.should.have.property('data')
+                result.data.should.have.property('removed', 'tab1')
+                result.data.should.have.property('remainingTabs').which.is.an.Array()
             })
             it('should throw if tab not found', async () => {
                 mockRED.nodes.workspace = sinon.stub().returns(null)
@@ -1702,15 +1710,24 @@ describeMain('expertAutomations', () => {
         })
         describe('showWorkspace action', () => {
             it('should navigate to the specified workspace', async () => {
-                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', label: 'My Tab', type: 'tab' })
-                mockRED.workspaces = { show: sinon.stub() }
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', label: 'My Tab', type: 'tab', locked: false, disabled: false })
+                mockRED.workspaces = {
+                    show: sinon.stub(),
+                    selection: sinon.stub().returns([]),
+                    active: sinon.stub().returns('tab1'),
+                    isHidden: sinon.stub().returns(false)
+                }
                 const result = {}
                 await expertAutomations.invokeAction('automation/show-workspace', {
                     params: { id: 'tab1' }
                 }, result)
                 mockRED.workspaces.show.calledWith('tab1').should.be.true()
                 result.should.have.property('success', true)
-                result.should.have.property('data').which.deepEqual({ id: 'tab1', label: 'My Tab' })
+                result.should.have.property('data')
+                result.data.should.have.property('id', 'tab1')
+                result.data.should.have.property('label', 'My Tab')
+                result.data.should.have.property('isActiveWorkspace', true)
+                result.data.should.have.property('locked', false)
             })
             it('should throw if workspace does not exist', async () => {
                 mockRED.nodes.workspace = sinon.stub().returns(null)

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1853,7 +1853,7 @@ describeMain('expertAutomations', () => {
                     params: {}
                 }, result)
                 result.should.have.property('success', true)
-                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(3)
+                result.data.should.have.property('configNodes').which.is.an.Array().with.lengthOf(3)
             })
 
             it('should filter config nodes by type', async () => {
@@ -1868,8 +1868,8 @@ describeMain('expertAutomations', () => {
                     params: { type: 'mqtt-broker' }
                 }, result)
                 result.should.have.property('success', true)
-                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
-                result.configNodes[0].should.have.property('type', 'mqtt-broker')
+                result.data.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
+                result.data.configNodes[0].should.have.property('type', 'mqtt-broker')
             })
 
             it('should return empty array when no config nodes exist', async () => {
@@ -1879,7 +1879,7 @@ describeMain('expertAutomations', () => {
                     params: {}
                 }, result)
                 result.should.have.property('success', true)
-                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(0)
+                result.data.should.have.property('configNodes').which.is.an.Array().with.lengthOf(0)
             })
 
             it('should return empty array when type filter matches nothing', async () => {
@@ -1892,7 +1892,7 @@ describeMain('expertAutomations', () => {
                     params: { type: 'nonexistent-type' }
                 }, result)
                 result.should.have.property('success', true)
-                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(0)
+                result.data.should.have.property('configNodes').which.is.an.Array().with.lengthOf(0)
             })
 
             it('should work with no params', async () => {
@@ -1903,7 +1903,7 @@ describeMain('expertAutomations', () => {
                 const result = {}
                 await expertAutomations.invokeAction('automation/list-config-nodes', {}, result)
                 result.should.have.property('success', true)
-                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
+                result.data.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
             })
 
             it('should return only global config nodes when tabId is "global"', async () => {
@@ -1917,8 +1917,8 @@ describeMain('expertAutomations', () => {
                     params: { tabId: 'global' }
                 }, result)
                 result.should.have.property('success', true)
-                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
-                result.configNodes[0].should.have.property('id', 'cfg1')
+                result.data.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
+                result.data.configNodes[0].should.have.property('id', 'cfg1')
             })
 
             it('should return only config nodes scoped to a specific tab', async () => {
@@ -1933,8 +1933,8 @@ describeMain('expertAutomations', () => {
                     params: { tabId: 'tab1' }
                 }, result)
                 result.should.have.property('success', true)
-                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
-                result.configNodes[0].should.have.property('id', 'cfg2')
+                result.data.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
+                result.data.configNodes[0].should.have.property('id', 'cfg2')
             })
 
             it('should combine type and tabId filters', async () => {
@@ -1949,8 +1949,8 @@ describeMain('expertAutomations', () => {
                     params: { type: 'mqtt-broker', tabId: 'global' }
                 }, result)
                 result.should.have.property('success', true)
-                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
-                result.configNodes[0].should.have.property('id', 'cfg2')
+                result.data.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
+                result.data.configNodes[0].should.have.property('id', 'cfg2')
             })
         })
 

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1849,6 +1849,53 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', true)
                 result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
             })
+
+            it('should return only global config nodes when tabId is "global"', async () => {
+                const configNodes = [
+                    { id: 'cfg1', type: 'ui-base', name: 'Dashboard' },
+                    { id: 'cfg2', type: 'mqtt-broker', name: 'Scoped Broker', z: 'tab1' }
+                ]
+                mockRED.nodes.eachConfig.callsFake(cb => configNodes.forEach(cb))
+                const result = {}
+                await expertAutomations.invokeAction('automation/list-config-nodes', {
+                    params: { tabId: 'global' }
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
+                result.configNodes[0].should.have.property('id', 'cfg1')
+            })
+
+            it('should return only config nodes scoped to a specific tab', async () => {
+                const configNodes = [
+                    { id: 'cfg1', type: 'ui-base', name: 'Dashboard' },
+                    { id: 'cfg2', type: 'mqtt-broker', name: 'Scoped Broker', z: 'tab1' },
+                    { id: 'cfg3', type: 'mqtt-broker', name: 'Other Broker', z: 'tab2' }
+                ]
+                mockRED.nodes.eachConfig.callsFake(cb => configNodes.forEach(cb))
+                const result = {}
+                await expertAutomations.invokeAction('automation/list-config-nodes', {
+                    params: { tabId: 'tab1' }
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
+                result.configNodes[0].should.have.property('id', 'cfg2')
+            })
+
+            it('should combine type and tabId filters', async () => {
+                const configNodes = [
+                    { id: 'cfg1', type: 'ui-base', name: 'Dashboard' },
+                    { id: 'cfg2', type: 'mqtt-broker', name: 'Global Broker' },
+                    { id: 'cfg3', type: 'mqtt-broker', name: 'Scoped Broker', z: 'tab1' }
+                ]
+                mockRED.nodes.eachConfig.callsFake(cb => configNodes.forEach(cb))
+                const result = {}
+                await expertAutomations.invokeAction('automation/list-config-nodes', {
+                    params: { type: 'mqtt-broker', tabId: 'global' }
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('configNodes').which.is.an.Array().with.lengthOf(1)
+                result.configNodes[0].should.have.property('id', 'cfg2')
+            })
         })
     })
 })


### PR DESCRIPTION
## Summary

- Adds `automation/list-config-nodes` action using `RED.nodes.eachConfig()` to enumerate global config node instances
- Supports optional `type` parameter to filter by config node type (e.g. `ui-base`, `mqtt-broker`)
- Supports optional `tabId` parameter to get either global config nodes (when tabId is set to `global`) or the config nodes on a given tab. When not passed, returns all config nodes.

Closes #298
Depends on #297

## Test plan

- Verify all config nodes are returned when no type filter is provided
- Verify type filter correctly narrows results to matching config node type
- Verify empty array returned when no config nodes exist or filter matches nothing
- Verify action works with no params object