### PR TITLE
ci: Replace PAT with GitHub Application token in `Projects automations` workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -4,7 +4,21 @@ on:
     types:
       - opened
 jobs:
-  add_to_product_board:
+  generate_token:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.generate_token.outputs.token }}
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.GH_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_BOT_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+
+  add_issue_to_relevant_boards:
+    needs: generate_token
     uses: flowfuse/.github/.github/workflows/project-automation.yml@main
     secrets:
-      token: ${{ secrets.PROJECT_ACCESS_TOKEN }}
+      token: ${{ needs.generate_token.outputs.token }}


### PR DESCRIPTION
## Description

This pull request replaces Personal Access Token with a token generated on the fly using GitHub Application.

## Related Issue(s)

https://github.com/FlowFuse/engineering/issues/22

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

