### PR TITLE
fix: ensure all nls message lookups are fully namespaced

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,12 @@
         /** @type {ExpertComms} */
         let FFExpertComms = null
         debug('Loading Node-RED Assistant Plugin...')
+
+        function nls (key) {
+            // Ensure the message key is properly namespaced
+            return plugin._('@flowfuse/nr-assistant/flowfuse-nr-assistant:' + key)
+        }
+
         const plugin = {
             type: 'assistant',
             name: 'Node-RED Assistant Plugin',
@@ -84,8 +90,8 @@
                             const menuEntry = {
                                 id: 'ff-assistant-explain-flows',
                                 icon: 'ff-assistant-menu-icon explain-flows',
-                                label: `<span>${plugin._('explain-flows.menu.label')}</span>`,
-                                sublabel: plugin._('explain-flows.menu.description'),
+                                label: `<span>${nls('explain-flows.menu.label')}</span>`,
+                                sublabel: nls('explain-flows.menu.description'),
                                 onselect: 'flowfuse-nr-assistant:explain-flows',
                                 shortcutSpan: $('<span class="red-ui-popover-key"></span>'),
                                 visible: true
@@ -114,7 +120,7 @@
             } else {
                 toolbarMenuButton.prependTo('.red-ui-header-toolbar') // add the button leftmost of the toolbar
             }
-            RED.popover.tooltip(toolbarMenuButtonAnchor, plugin._('name'))
+            RED.popover.tooltip(toolbarMenuButtonAnchor, nls('name'))
 
             /* NOTE: For the menu entries icons' property...
                If `.icon` is a URL (e.g. resource/xxx/icon.svg), the RED.menu API will add it as an <img> tag.
@@ -125,7 +131,7 @@
             debug('Building FlowFuse Expert menu')
 
             const ffAssistantMenu = [
-                { id: 'ff-assistant-title', label: plugin._('name'), visible: true }, // header
+                { id: 'ff-assistant-title', label: nls('name'), visible: true }, // header
                 null // separator
             ]
             RED.menu.init({ id: 'red-ui-header-button-ff-ai', options: ffAssistantMenu })
@@ -174,7 +180,7 @@
                 if (assistantOptions.standalone) {
                     RED.menu.addItem('red-ui-header-button-ff-ai', {
                         id: 'ff-assistant-login',
-                        label: `<span>${plugin._('login.menu.label')}</span>`,
+                        label: `<span>${nls('login.menu.label')}</span>`,
                         onselect: showLoginPrompt,
                         visible: !assistantOptions.enabled
                     })
@@ -182,8 +188,8 @@
                 RED.menu.addItem('red-ui-header-button-ff-ai', {
                     id: 'ff-assistant-function-builder',
                     icon: 'ff-assistant-menu-icon function',
-                    label: `<span>${plugin._('function-builder.menu.label')}</span>`,
-                    sublabel: plugin._('function-builder.menu.description'),
+                    label: `<span>${nls('function-builder.menu.label')}</span>`,
+                    sublabel: nls('function-builder.menu.description'),
                     onselect: 'flowfuse-nr-assistant:function-builder',
                     shortcutSpan: $('<span class="red-ui-popover-key"></span>'),
                     visible: assistantOptions.enabled
@@ -195,7 +201,7 @@
                     RED.menu.setVisible('ff-assistant-login', true)
                 }
                 RED.menu.setVisible('ff-assistant-function-builder', false)
-                console.warn(plugin._('errors.assistant-not-enabled'))
+                console.warn(nls('errors.assistant-not-enabled'))
                 return
             } else {
                 if (assistantOptions.standalone) {
@@ -468,7 +474,7 @@
                     return
                 }
                 if (!assistantOptions.enabled) {
-                    RED.notify(plugin._('errors.assistant-not-enabled'), 'warning')
+                    RED.notify(nls('errors.assistant-not-enabled'), 'warning')
                     return
                 }
                 const thisEditor = getMonacoEditorForModel(model)
@@ -553,7 +559,7 @@
                     return
                 }
                 if (!assistantOptions.enabled) {
-                    RED.notify(plugin._('errors.assistant-not-enabled'), 'warning')
+                    RED.notify(nls('errors.assistant-not-enabled'), 'warning')
                     return
                 }
                 const thisEditor = getMonacoEditorForModel(model)
@@ -615,7 +621,7 @@
                     return
                 }
                 if (!assistantOptions.enabled) {
-                    RED.notify(plugin._('errors.assistant-not-enabled'), 'warning')
+                    RED.notify(nls('errors.assistant-not-enabled'), 'warning')
                     return
                 }
                 const thisEditor = getMonacoEditorForModel(model)
@@ -677,7 +683,7 @@
                     return
                 }
                 if (!assistantOptions.enabled) {
-                    RED.notify(plugin._('errors.assistant-not-enabled'), 'warning')
+                    RED.notify(nls('errors.assistant-not-enabled'), 'warning')
                     return
                 }
                 const thisEditor = getMonacoEditorForModel(model)
@@ -739,7 +745,7 @@
                     return
                 }
                 if (!assistantOptions.enabled) {
-                    RED.notify(plugin._('errors.assistant-not-enabled'), 'warning')
+                    RED.notify(nls('errors.assistant-not-enabled'), 'warning')
                     return
                 }
                 const thisEditor = getMonacoEditorForModel(model)
@@ -1180,8 +1186,8 @@
             debug('doPrompt', promptOptions, uiOptions)
             getUserInput({
                 defaultInput: defaultInput || '',
-                title: uiOptions?.title || plugin._('name'),
-                explanation: uiOptions?.explanation || plugin._('name') + ' can help you write code.',
+                title: uiOptions?.title || nls('name'),
+                explanation: uiOptions?.explanation || nls('name') + ' can help you write code.',
                 description: uiOptions?.description || 'Enter a short description of what you want it to do.'
             }).then((prompt) => {
                 if (!prompt) {
@@ -1200,7 +1206,7 @@
                         // selection: selectedText // FUTURE: include the selected text in the context for features like "fix my code", "refactor this", "what is this?" etc
                     }
                 }
-                const busyNotification = showBusyNotification(plugin._('notifications.busy'), function () {
+                const busyNotification = showBusyNotification(nls('notifications.busy'), function () {
                     if (xhr) {
                         xhr.abort('abort')
                         xhr = null
@@ -1242,7 +1248,7 @@
         }
 
         function getUserInput ({ title, explanation, description, placeholder, defaultInput } = {
-            title: plugin._('name'),
+            title: nls('name'),
             explanation: 'The FlowFuse Expert can help you create things.',
             description: 'Enter a short description explaining what you want it to do.',
             placeholder: '',
@@ -1270,7 +1276,7 @@
                 const minHeight = 260 + (description ? 32 : 0) + (explanation ? 32 : 0)
                 const minWidth = 480
                 const dialogControl = dialog.dialog({
-                    title: title || plugin._('name'),
+                    title: title || nls('name'),
                     modal: true,
                     closeOnEscape: true,
                     height: minHeight,
@@ -1312,14 +1318,14 @@
         let previousFunctionBuilderPrompt
         function showFunctionBuilderPrompt (title) {
             if (!assistantOptions.enabled) {
-                RED.notify(plugin._('errors.assistant-not-enabled'), 'warning')
+                RED.notify(nls('errors.assistant-not-enabled'), 'warning')
                 return
             }
             getUserInput({
                 defaultInput: previousFunctionBuilderPrompt,
                 title: title || 'FlowFuse Expert : Create A Function Node',
-                explanation: plugin._('function-builder.dialog-input.explanation'),
-                description: plugin._('function-builder.dialog-input.description')
+                explanation: nls('function-builder.dialog-input.explanation'),
+                description: nls('function-builder.dialog-input.description')
             }).then((prompt) => {
                 /** @type {JQueryXHR} */
                 let xhr = null
@@ -1335,7 +1341,7 @@
                             modulesAllowed
                         }
                     }
-                    const busyNotification = showBusyNotification(plugin._('notifications.busy'), function () {
+                    const busyNotification = showBusyNotification(nls('notifications.busy'), function () {
                         if (xhr) {
                             xhr.abort('abort')
                             xhr = null
@@ -1435,7 +1441,7 @@
 
             // set the default dialog options
             const defaultOptions = {
-                title: title || plugin._('name'),
+                title: title || nls('name'),
                 modal: true,
                 resizable: true,
                 width,
@@ -1462,19 +1468,19 @@
 
         function explainSelectedNodes () {
             if (!assistantOptions.enabled) {
-                RED.notify(plugin._('errors.assistant-not-enabled'), 'warning')
+                RED.notify(nls('errors.assistant-not-enabled'), 'warning')
                 return
             }
             const selection = RED.view.selection()
             if (!selection || !selection.nodes || selection.nodes.length === 0) {
-                RED.notify(plugin._('explain-flows.errors.no-nodes-selected'), 'warning')
+                RED.notify(nls('explain-flows.errors.no-nodes-selected'), 'warning')
                 return
             }
 
             const { flow: nodes, nodeCount: totalNodeCount } = FFAssistantUtils.cleanFlow(selection.nodes)
 
             if (totalNodeCount > 100) { // TODO: increase or make configurable
-                RED.notify(plugin._('explain-flows.errors.too-many-nodes-selected'), 'warning')
+                RED.notify(nls('explain-flows.errors.too-many-nodes-selected'), 'warning')
                 return
             }
 
@@ -1488,7 +1494,7 @@
                 flowName: '', // FUTURE: include the parent flow name in the context to aid with the explanation
                 userContext: '' // FUTURE: include user textual input context for more personalized explanations
             }
-            const busyNotification = showBusyNotification(plugin._('notifications.busy'), function () {
+            const busyNotification = showBusyNotification(nls('notifications.busy'), function () {
                 if (xhr) {
                     xhr.abort('abort')
                     xhr = null
@@ -1512,7 +1518,7 @@
                         let dlg = null
                         const options = {
                             buttons: [{
-                                text: plugin._('explain-flows.dialog-result.close-button'),
+                                text: nls('explain-flows.dialog-result.close-button'),
                                 // icon: 'ui-icon-close',
                                 class: 'primary',
                                 click: function () {
@@ -1526,14 +1532,14 @@
                             if (isHttpsOrLocalhost && navigator.clipboard && navigator.clipboard.writeText) {
                                 options.buttons.unshift(
                                     {
-                                        text: plugin._('explain-flows.dialog-result.copy-button'),
+                                        text: nls('explain-flows.dialog-result.copy-button'),
                                         // icon: 'ui-icon-copy',
                                         click: function () {
                                             navigator.clipboard.writeText(text).then(() => {
                                                 showNotification('Copied to clipboard', { type: 'success' })
                                             }).catch((err) => {
                                                 console.warn('Failed to copy to clipboard', err)
-                                                showNotification(plugin._('errors.copy-failed'), { type: 'error' })
+                                                showNotification(nls('errors.copy-failed'), { type: 'error' })
                                             })
                                         }
                                     }
@@ -1543,13 +1549,13 @@
                             if (!isLocked) {
                                 options.buttons.unshift(
                                     {
-                                        text: plugin._('explain-flows.dialog-result.comment-node-button'),
+                                        text: nls('explain-flows.dialog-result.comment-node-button'),
                                         // icon: 'ui-icon-comment',
                                         // class: 'primary',
                                         click: function () {
                                             const commentNode = {
                                                 type: 'comment',
-                                                name: plugin._('explain-flows.dialog-result.comment-node-name'),
+                                                name: nls('explain-flows.dialog-result.comment-node-name'),
                                                 info: text
                                             }
                                             importFlow(commentNode, false, 'Drop the generated comment node onto the workspace')
@@ -1563,10 +1569,10 @@
                             showNotification('Sorry, no explanation could be generated.', { type: 'warning' })
                             return
                         }
-                        dlg = showMessage(plugin._('explain-flows.dialog-result.title'), RED.utils.renderMarkdown(text), 'html', options)
+                        dlg = showMessage(nls('explain-flows.dialog-result.title'), RED.utils.renderMarkdown(text), 'html', options)
                     } catch (error) {
                         console.warn('Error rendering reply', error)
-                        showNotification(plugin._('errors.something-went-wrong'), { type: 'error' })
+                        showNotification(nls('errors.something-went-wrong'), { type: 'error' })
                     }
                 },
                 error: (jqXHR, textStatus, errorThrown) => {
@@ -1589,7 +1595,7 @@
         // eslint-disable-next-line no-unused-vars
         function showFlowBuilderPrompt (title) {
             if (!assistantOptions.enabled) {
-                RED.notify(plugin._('errors.assistant-not-enabled'), 'warning')
+                RED.notify(nls('errors.assistant-not-enabled'), 'warning')
                 return
             }
             getUserInput({
@@ -1611,7 +1617,7 @@
                             modulesAllowed
                         }
                     }
-                    const busyNotification = showBusyNotification(plugin._('notifications.busy'), function () {
+                    const busyNotification = showBusyNotification(nls('notifications.busy'), function () {
                         if (xhr) {
                             xhr.abort('abort')
                             xhr = null
@@ -1656,7 +1662,7 @@
          * @returns {{close: () => {}}} - The notification object
          */
         function showBusyNotification (message, onCancel, context, poop) {
-            message = message || plugin._('notifications.busy')
+            message = message || nls('notifications.busy')
             const busyMessage = $('<div>')
             $('<span>').text(message).appendTo(busyMessage)
             $('<i>').addClass('fa fa-spinner fa-spin fa-fw').appendTo(busyMessage)
@@ -1797,7 +1803,7 @@
                 return null
             }
             if (!assistantOptions.enabled) {
-                node.warnIfNotEnabled && RED.notify(plugin._('errors.assistant-not-enabled'), 'warning')
+                node.warnIfNotEnabled && RED.notify(nls('errors.assistant-not-enabled'), 'warning')
                 return null
             }
             const editor = getMonacoEditorForModel(model)


### PR DESCRIPTION
Some of the nls messages used by the assistant were not resolving. Node-RED attempts to ensure the `plugin._()` function is able to implicitly add the plugins catalog namespace to any key passed to it - but that isn't quite working for this plugin.

Whilst that's something for NR to resolve, in the meantime, the fix for the plugin is to always use fully qualified message keys - which is what this PR does.