### PR TITLE
ci: Pin internal GitHub Actions reusable workflows to the new tagging approach

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    uses: 'flowfuse/github-actions-workflows/.github/workflows/build_node_package.yml@v0.76.0'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/build_node_package.yml@build_node_package/v1'
     with:
       node: '[
               {"version": "16", "tests": true, "lint": false},
@@ -29,7 +29,7 @@ jobs:
     if: |
       ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
       ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
-    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.76.0'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@publish_node_package/v1'
     with:
       package_name: nr-assistant
       publish_package: true
@@ -45,7 +45,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.GH_BOT_APP_ID }}
+          client-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_APP_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: nr-launcher

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         run: |
           echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-      - uses: flowfuse/github-actions-workflows/actions/update-nr-flows@v0.76.0
+      - uses: flowfuse/github-actions-workflows/actions/update-nr-flows@update-nr-flows/v1
         with:
           package: '@flowfuse/nr-assistant'
           version: ${{ steps.getVersion.outputs.version }}

--- a/.github/workflows/sast-scan.yml
+++ b/.github/workflows/sast-scan.yml
@@ -16,4 +16,4 @@ concurrency:
 jobs:
   scan:
     name: SAST Scan
-    uses : flowfuse/github-actions-workflows/.github/workflows/sast_scan.yaml@v0.76.0
+    uses : flowfuse/github-actions-workflows/.github/workflows/sast_scan.yaml@sast_scan/v1


### PR DESCRIPTION
## Description

This pull request updates all internally maintained GitHub Actions reusable workflows to the new tagging solution.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

