### PR TITLE
fix(actions): add-nodes respects z, update-node redraws correctly

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -555,6 +555,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (this.RED.editor?.validateNode) {
             this.RED.editor.validateNode(node)
         }
+        this.RED.view.updateActive()
         this.RED.view.redraw()
         this.RED.sidebar?.info?.refresh()
 
@@ -909,7 +910,25 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 throw new Error(`Node ID(s) already exist: ${existing.map(n => n.id).join(', ')} — use generateIds: true to auto-assign new IDs`)
             }
         }
-        this.RED.view.importNodes(prepared, { generateIds, addFlow: false, notify: false, touchImport: true, applyNodeDefaults: true })
+        // importNodes places nodes on the active tab regardless of z — switch to each
+        // target tab before importing so nodes land on the correct workspace.
+        const originalActiveId = this.RED.workspaces.active()
+        const configNodes = prepared.filter(n => !n.z)
+        const byTab = new Map()
+        for (const node of prepared.filter(n => n.z)) {
+            if (!byTab.has(node.z)) byTab.set(node.z, [])
+            byTab.get(node.z).push(node)
+        }
+        if (configNodes.length > 0) {
+            this.RED.view.importNodes(configNodes, { generateIds, addFlow: false, notify: false, touchImport: true, applyNodeDefaults: true })
+        }
+        for (const [tabId, tabNodes] of byTab) {
+            this.RED.workspaces.show(tabId)
+            this.RED.view.importNodes(tabNodes, { generateIds, addFlow: false, notify: false, touchImport: true, applyNodeDefaults: true })
+        }
+        if (originalActiveId) {
+            this.RED.workspaces.show(originalActiveId)
+        }
         this.RED.nodes.dirty(true)
     }
 

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -28,7 +28,9 @@ describeMain('expertAutomations', () => {
                 addFlowTab: sinon.stub(),
                 reveal: sinon.stub(),
                 select: sinon.stub(),
-                state: sinon.stub().returns(1) // default to default state
+                state: sinon.stub().returns(1), // default to default state
+                updateActive: sinon.stub(),
+                redraw: sinon.stub()
             },
             nodes: {
                 node: sinon.stub(),
@@ -1226,6 +1228,7 @@ describeMain('expertAutomations', () => {
                 historyArg.should.have.property('changes').which.deepEqual({ name: 'old' })
                 historyArg.should.have.property('changed', false)
                 mockRED.nodes.dirty.calledWith(true).should.be.true()
+                mockRED.view.updateActive.calledOnce.should.be.true()
                 mockRED.view.redraw.calledOnce.should.be.true()
                 result.should.have.property('success', true)
                 result.should.have.property('data').which.is.an.Object()


### PR DESCRIPTION
Fixes #310

## Summary

- `addNodes`: groups nodes by their target tab (`z`) and switches to each tab before calling `importNodes`, then restores the original active tab. Previously all nodes landed on the active tab regardless of the specified `z`.
- `updateNode`: adds `updateActive()` before `redraw()` so that changing a node's `z` property (moving it to a different tab) is reflected immediately on the canvas. Aligns with the pattern used by `removeNodes` and `setWires`.

## Test plan

- Verify nodes are added to the correct tab when `z` is specified
- Verify moving a node to a different tab via `update-node` removes it from the current tab's canvas immediately