### PR TITLE
feat(actions): add automation/open-palette-manager action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -24,6 +24,7 @@ const CLOSE_EDITOR_TRAY = 'automation/close-editor-tray'
 const GET_NODE_TYPES = 'automation/get-node-types'
 const GET_PALETTE = 'automation/get-palette'
 const LIST_CONFIG_NODES = 'automation/list-config-nodes'
+const OPEN_PALETTE_MANAGER = 'automation/open-palette-manager'
 
 /**
  * @typedef {SELECT_NODES
@@ -48,7 +49,8 @@ const LIST_CONFIG_NODES = 'automation/list-config-nodes'
  *   |CLOSE_EDITOR_TRAY
  *   |GET_NODE_TYPES
  *   |GET_PALETTE
- *   |LIST_CONFIG_NODES} ExpertAutomationsActionsEnum
+ *   |LIST_CONFIG_NODES
+ *   |OPEN_PALETTE_MANAGER} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -355,6 +357,23 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     tabId: {
                         type: 'string',
                         description: 'Scope filter: "global" for config nodes not attached to any tab, a tab ID for config nodes scoped to that tab, or omit to return all'
+                    }
+                }
+            }
+        },
+        [OPEN_PALETTE_MANAGER]: {
+            params: {
+                type: 'object',
+                properties: {
+                    view: {
+                        type: 'string',
+                        enum: ['nodes', 'install'],
+                        default: 'install',
+                        description: 'Which tab to show in the palette manager'
+                    },
+                    filter: {
+                        type: 'string',
+                        description: 'Optional package name or search term to pre-filter the palette manager'
                     }
                 }
             }
@@ -1335,6 +1354,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
             result.data = { configNodes: this._formatNodes(configNodes, false) }
             result.success = true
         }
+            break
+        case OPEN_PALETTE_MANAGER:
+            this.RED.actions.invoke('core:manage-palette', {
+                view: params?.view || 'install',
+                filter: params?.filter || ''
+            })
+            result.success = true
             break
         default:
             result.handled = false

--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -570,6 +570,18 @@ export class ExpertComms {
                 this.postReply({ type, error: err?.message, correlationId }, event)
             }
             return
+        case 'core:manage-palette': {
+            // Delegate to automation for centralised handling
+            const result = { handled: false, success: false, noReply: false, correlationId }
+            try {
+                await this.nrAutomations.invokeAction('automation/open-palette-manager', { event, params }, result)
+                this.postReply({ type, action, success: true, ...result }, event)
+            } catch (err) {
+                result.error = err.message
+                this.postReply({ type, action, ...result, success: false }, event)
+            }
+            return
+        }
         default: {
             const result = { handled: false, success: false, noReply: false, correlationId }
             try {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -95,7 +95,8 @@ describeMain('expertAutomations', () => {
                 'automation/close-editor-tray',
                 'automation/get-node-types',
                 'automation/get-palette',
-                'automation/list-config-nodes'
+                'automation/list-config-nodes',
+                'automation/open-palette-manager'
             ]
             supportedActions.should.only.have.keys(...expectedKeys)
         })
@@ -2092,6 +2093,38 @@ describeMain('expertAutomations', () => {
                 result.palette['node-red'].plugins.should.have.length(1)
                 result.palette['node-red'].nodes.should.have.length(1)
                 result.palette['node-red-contrib-test'].nodes.should.have.length(1)
+            })
+        })
+        describe('automation/open-palette-manager', () => {
+            beforeEach(() => {
+                mockRED.actions = { invoke: sinon.stub() }
+            })
+            it('should open palette manager with default install view when no view param given', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/open-palette-manager', { params: {} }, result)
+                mockRED.actions.invoke.calledOnce.should.be.true()
+                mockRED.actions.invoke.calledWith('core:manage-palette', { view: 'install', filter: '' }).should.be.true()
+                result.should.have.property('success', true)
+                result.should.have.property('handled', true)
+            })
+            it('should pass view param through to RED.actions.invoke', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/open-palette-manager', { params: { view: 'nodes' } }, result)
+                mockRED.actions.invoke.calledWith('core:manage-palette', { view: 'nodes', filter: '' }).should.be.true()
+                result.should.have.property('success', true)
+            })
+            it('should pass filter param through to RED.actions.invoke', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/open-palette-manager', { params: { filter: 'node-red-contrib-s7' } }, result)
+                mockRED.actions.invoke.calledWith('core:manage-palette', { view: 'install', filter: 'node-red-contrib-s7' }).should.be.true()
+                result.should.have.property('success', true)
+            })
+            it('should succeed even without params', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/open-palette-manager', {}, result)
+                mockRED.actions.invoke.calledOnce.should.be.true()
+                mockRED.actions.invoke.calledWith('core:manage-palette', { view: 'install', filter: '' }).should.be.true()
+                result.should.have.property('success', true)
             })
         })
     })

--- a/test/unit/resources/expertComms.test.js
+++ b/test/unit/resources/expertComms.test.js
@@ -892,7 +892,7 @@ describeMain('expertComms', function () {
             consoleWarnStub.restore()
         })
 
-        it('should handle valid core:manage-palette action', () => {
+        it('should handle valid core:manage-palette action', async () => {
             const eventSource = { postMessage: sinon.stub() }
             const event = {
                 source: eventSource,
@@ -912,7 +912,7 @@ describeMain('expertComms', function () {
 
             mockRED.actions.invoke.returns(true)
 
-            messageHandler(event)
+            await messageHandler(event)
 
             mockRED.actions.invoke.calledOnce.should.be.true()
             mockRED.actions.invoke.firstCall.args[0].should.equal('core:manage-palette')
@@ -1039,7 +1039,7 @@ describeMain('expertComms', function () {
             reply.should.have.property('acknowledged', true)
         })
 
-        it('should handle errors in action invocation', () => {
+        it('should handle errors in action invocation', async () => {
             const eventSource = { postMessage: sinon.stub() }
             const event = {
                 source: eventSource,
@@ -1059,7 +1059,7 @@ describeMain('expertComms', function () {
             const error = new Error('Action failed')
             mockRED.actions.invoke.throws(error)
 
-            messageHandler(event)
+            await messageHandler(event)
 
             eventSource.postMessage.calledOnce.should.be.true()
             const reply = eventSource.postMessage.firstCall.args[0]


### PR DESCRIPTION
Closes #313

## Summary

- Adds `automation/open-palette-manager` action to `expertAutomations.js` with `view` and `filter` parameters
- `core:manage-palette` postMessage route now delegates to this new action instead of using the generic native action fallback
- Backward compatible: existing callers of `core:manage-palette` continue to work unchanged

## Test plan

- Existing `core:manage-palette` tests updated to cover the new delegation path
- New tests for `automation/open-palette-manager`: default view, view param passthrough, filter param passthrough, no-params case