### PR TITLE
feat(automation): add automation/manage-groups action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -25,6 +25,7 @@ const GET_NODE_TYPES = 'automation/get-node-types'
 const GET_PALETTE = 'automation/get-palette'
 const LIST_CONFIG_NODES = 'automation/list-config-nodes'
 const OPEN_PALETTE_MANAGER = 'automation/open-palette-manager'
+const MANAGE_GROUPS = 'automation/manage-groups'
 
 /**
  * @typedef {SELECT_NODES
@@ -50,7 +51,8 @@ const OPEN_PALETTE_MANAGER = 'automation/open-palette-manager'
  *   |GET_NODE_TYPES
  *   |GET_PALETTE
  *   |LIST_CONFIG_NODES
- *   |OPEN_PALETTE_MANAGER} ExpertAutomationsActionsEnum
+ *   |OPEN_PALETTE_MANAGER
+ *   |MANAGE_GROUPS} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -376,6 +378,61 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         description: 'Optional package name or search term to pre-filter the palette manager'
                     }
                 }
+            }
+        },
+        [MANAGE_GROUPS]: {
+            params: {
+                type: 'object',
+                properties: {
+                    operations: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                op: {
+                                    type: 'string',
+                                    enum: ['create', 'update', 'manage-members', 'delete'],
+                                    description: 'Operation to perform'
+                                },
+                                id: {
+                                    type: 'string',
+                                    description: 'Group ID (required for update, manage-members, and delete)'
+                                },
+                                nodeIds: {
+                                    type: 'array',
+                                    items: { type: 'string' },
+                                    description: 'Node IDs: required for create and manage-members'
+                                },
+                                name: {
+                                    type: 'string',
+                                    description: 'Group display name (optional for create and update)'
+                                },
+                                mode: {
+                                    type: 'string',
+                                    enum: ['add', 'remove'],
+                                    description: 'manage-members only — "add" moves nodes into the group, "remove" takes them out'
+                                },
+                                style: {
+                                    type: 'object',
+                                    description: 'Visual style: stroke/border-color, fill, color, stroke-opacity, fill-opacity, label, label-position',
+                                    properties: {
+                                        stroke: { type: 'string' },
+                                        'border-color': { type: 'string' },
+                                        fill: { type: 'string' },
+                                        color: { type: 'string' },
+                                        'stroke-opacity': { type: 'number' },
+                                        'fill-opacity': { type: 'number' },
+                                        label: { type: 'boolean' },
+                                        'label-position': { type: 'string', enum: ['nw', 'n', 'ne', 'sw', 's', 'se'] }
+                                    }
+                                }
+                            },
+                            required: ['op']
+                        },
+                        description: 'Array of group operations to execute sequentially'
+                    }
+                },
+                required: ['operations']
             }
         }
     })
@@ -821,7 +878,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {string} id - workspace ID to show
      */
     showWorkspace (id) {
-        if (!this.hasWorkspace(id)) throw new Error(`Workspace ${id} not found`)
+        this._assertWorkspaceExists(id)
         this.RED.workspaces.show(id)
     }
 
@@ -831,9 +888,24 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @returns {boolean} true if the workspace exists, false otherwise
      */
     hasWorkspace (id) {
-        const ws = this.RED.nodes.workspace(id)
-        if (ws) return true
-        return false
+        return !!this.RED.nodes.workspace(id)
+    }
+
+    /**
+     * Throw if the workspace does not exist.
+     * @param {string} id - workspace ID
+     */
+    _assertWorkspaceExists (id) {
+        if (!this.hasWorkspace(id)) throw new Error(`Workspace ${id} not found`)
+    }
+
+    /**
+     * Throw if the workspace tab is locked. No-op when tabId is falsy (e.g. config nodes).
+     * @param {string|null|undefined} tabId - workspace tab ID
+     */
+    _assertWorkspaceNotLocked (tabId) {
+        if (!tabId) return
+        if (this.RED.workspaces.isLocked(tabId)) throw new Error(`Workspace ${tabId} is locked`)
     }
 
     closeSearch () { this.RED.search.hide() }
@@ -918,9 +990,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
         // Validate all target tabs exist and are not locked
         const uniqueZs = [...new Set(prepared.map(n => n.z).filter(Boolean))]
         for (const z of uniqueZs) {
-            if (!this.hasWorkspace(z)) throw new Error(`Workspace tab ${z} not found`)
-            const ws = this.RED.nodes.workspace(z)
-            if (ws.locked) throw new Error(`Workspace tab ${z} is locked`)
+            this._assertWorkspaceExists(z)
+            this._assertWorkspaceNotLocked(z)
         }
         // Pre-import: reject if any node ID already exists on the canvas
         if (!generateIds) {
@@ -964,9 +1035,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         })
         // Check if any node's workspace is locked
         for (const node of nodes) {
-            if (node.z && this.RED.workspaces.isLocked(node.z)) {
-                throw new Error(`Cannot remove node ${node.id} — workspace ${node.z} is locked`)
-            }
+            this._assertWorkspaceNotLocked(node.z)
         }
         const allRemovedLinks = []
         for (const node of nodes) {
@@ -998,9 +1067,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             throw new Error('Source and target nodes must be on the same tab')
         }
         // Check workspace is not locked
-        if (sourceNode.z && this.RED.workspaces.isLocked(sourceNode.z)) {
-            throw new Error(`Cannot modify wires — workspace ${sourceNode.z} is locked`)
-        }
+        this._assertWorkspaceNotLocked(sourceNode.z)
         // Validate output port exists on source
         const port = output ?? 0
         if (port >= (sourceNode.outputs || 0)) {
@@ -1069,12 +1136,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
             throw new Error(`Source node ${source} is a link call in dynamic mode and cannot have static links`)
         }
         // Check workspace locks for both nodes
-        if (sourceNode.z && this.RED.workspaces.isLocked(sourceNode.z)) {
-            throw new Error(`Cannot modify links — workspace ${sourceNode.z} is locked`)
-        }
-        if (targetNode.z && targetNode.z !== sourceNode.z && this.RED.workspaces.isLocked(targetNode.z)) {
-            throw new Error(`Cannot modify links — workspace ${targetNode.z} is locked`)
-        }
+        this._assertWorkspaceNotLocked(sourceNode.z)
+        if (targetNode.z !== sourceNode.z) this._assertWorkspaceNotLocked(targetNode.z)
         const isBidirectional = sourceNode.type === 'link out'
         const sourceLinks = sourceNode.links || []
         const targetLinks = targetNode.links || []
@@ -1362,6 +1425,57 @@ export class ExpertAutomations extends ExpertActionsInterface {
             })
             result.success = true
             break
+        case MANAGE_GROUPS: {
+            const operations = params.operations
+            if (!Array.isArray(operations) || operations.length === 0) {
+                throw new Error('operations array is required and must not be empty')
+            }
+            const results = []
+            for (const entry of operations) {
+                const op = entry.op
+                if (!op) throw new Error('op is required for each manage-groups operation')
+                switch (op) {
+                case 'create': {
+                    const group = this.createGroup(entry.nodeIds, entry.name, { style: entry.style, env: entry.env, id: entry.id })
+                    results.push({ op: 'create', ...this._summarizeGroup(group) })
+                    break
+                }
+                case 'update': {
+                    if (!entry.id) throw new Error('id is required for update')
+                    const group = this.updateGroup(entry.id, {
+                        name: entry.name,
+                        style: entry.style,
+                        env: entry.env
+                    })
+                    results.push({ op: 'update', ...this._summarizeGroup(group) })
+                    break
+                }
+                case 'manage-members': {
+                    if (!entry.id) throw new Error('id is required for manage-members')
+                    if (!entry.nodeIds || entry.nodeIds.length === 0) throw new Error('nodeIds is required for manage-members')
+                    const mode = entry.mode
+                    if (mode !== 'add' && mode !== 'remove') throw new Error('mode must be "add" or "remove"')
+                    const group = this.updateGroup(entry.id, {
+                        nodeIds: entry.nodeIds,
+                        remove: mode === 'remove'
+                    })
+                    results.push({ op: 'manage-members', mode, ...this._summarizeGroup(group) })
+                    break
+                }
+                case 'delete': {
+                    if (!entry.id) throw new Error('id is required for delete')
+                    this.deleteGroup(entry.id)
+                    results.push({ op: 'delete', deleted: entry.id })
+                    break
+                }
+                default:
+                    throw new Error(`Unknown manage-groups op: ${op}`)
+                }
+            }
+            result.data = results
+            result.success = true
+            break
+        }
         default:
             result.handled = false
             result.success = false
@@ -1411,6 +1525,185 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
     }
 
+    /**
+     * Create a group containing the specified nodes.
+     * Uses Node-RED's core:group-selection action after selecting the target nodes.
+     * @param {string[]} nodeIds - IDs of nodes to group
+     * @param {string} [name] - optional group display name
+     * @param {object} [opts]
+     * @param {object} [opts.style] - visual style overrides
+     * @param {Array}  [opts.env]   - environment variables for nodes inside the group
+     * @param {string} [opts.id]    - explicit group ID; auto-generated if omitted
+     * @returns {object} the created group node
+     */
+    createGroup (nodeIds, name, { style, env, id } = {}) {
+        if (!nodeIds || nodeIds.length === 0) {
+            throw new Error('nodeIds is required and must not be empty')
+        }
+        const nodes = nodeIds.map(id => {
+            const n = this.RED.nodes.node(id)
+            if (!n) throw new Error(`Node ${id} not found`)
+            return n
+        })
+        const tabs = new Set(nodes.map(n => n.z).filter(Boolean))
+        if (tabs.size > 1) {
+            throw new Error('All nodes must be on the same tab to form a group')
+        }
+        const tabId = tabs.size === 1 ? [...tabs][0] : null
+        this._assertWorkspaceNotLocked(tabId)
+
+        // Snapshot existing group IDs so we can identify the newly created one
+        const existingGroupIds = new Set()
+        this.RED.nodes.eachGroup(g => existingGroupIds.add(g.id))
+
+        this.RED.view.select({ nodes })
+        this._verifySelection(nodes)
+        this.RED.actions.invoke('core:group-selection')
+
+        const newGroups = []
+        this.RED.nodes.eachGroup(g => {
+            if (!existingGroupIds.has(g.id)) newGroups.push(g)
+        })
+
+        if (newGroups.length === 0) {
+            throw new Error('Group creation failed: core:group-selection did not create a new group')
+        }
+
+        const newGroup = newGroups[0]
+        const missingIds = nodeIds.filter(nid => !newGroup.nodes?.some(n => (n.id || n) === nid))
+        if (missingIds.length > 0) {
+            throw new Error(`Group created but missing nodes: ${missingIds.join(', ')}`)
+        }
+
+        // Rename to the requested ID if one was provided and differs from the auto-generated one
+        if (id !== undefined && id !== newGroup.id) {
+            if (this.RED.nodes.node(id) || this.RED.nodes.group(id)) {
+                throw new Error(`Group ID ${id} is already in use`)
+            }
+            const oldId = newGroup.id
+            this.RED.nodes.remove(oldId)
+            newGroup.id = id
+            ;(newGroup.nodes || []).forEach(n => {
+                const nodeRef = typeof n === 'object' ? n : this.RED.nodes.node(n)
+                if (nodeRef && nodeRef.g === oldId) nodeRef.g = id
+            })
+            this.RED.nodes.add(newGroup)
+        }
+
+        const changes = {}
+        if (name) {
+            changes.name = newGroup.name
+            newGroup.name = name
+        }
+        if (style) {
+            changes.style = { ...newGroup.style }
+            newGroup.style = Object.assign({}, newGroup.style || {}, style)
+        }
+        if (env !== undefined) {
+            changes.env = newGroup.env
+            newGroup.env = env
+        }
+        if (Object.keys(changes).length > 0) {
+            newGroup.changed = true
+            newGroup.dirty = true
+            this.RED.history.push({ t: 'edit', node: newGroup, changes, changed: false, dirty: this.RED.nodes.dirty() })
+        }
+
+        this.RED.nodes.dirty(true)
+        this.RED.view.redraw()
+        return newGroup
+    }
+
+    /**
+     * Update an existing group: rename, add/remove nodes, change style.
+     * @param {string} id - group ID
+     * @param {object} updates - { name?, addNodeIds?, removeNodeIds?, style? }
+     * @returns {object} the updated group node
+     */
+    updateGroup (id, { name, nodeIds, remove, style, env } = {}) {
+        let group = this.RED.nodes.group(id)
+        if (!group) throw new Error(`Group ${id} not found`)
+        this._assertWorkspaceNotLocked(group.z)
+
+        if (nodeIds && nodeIds.length > 0) {
+            if (remove) {
+                const nodes = nodeIds.map(nodeId => {
+                    const node = this.RED.nodes.node(nodeId)
+                    if (!node) throw new Error(`Node ${nodeId} not found`)
+                    if (node.g !== group.id) throw new Error(`Node ${nodeId} is not in group ${id}`)
+                    return node
+                })
+                this.RED.view.select({ nodes })
+                this._verifySelection(nodes)
+                this.RED.actions.invoke('core:remove-selection-from-group')
+            } else {
+                const existingGroupIds = new Set()
+                this.RED.nodes.eachGroup(g => existingGroupIds.add(g.id))
+
+                const newNodes = nodeIds.map(nodeId => {
+                    const node = this.RED.nodes.node(nodeId)
+                    if (!node) throw new Error(`Node ${nodeId} not found`)
+                    if (node.z !== group.z) throw new Error(`Node ${nodeId} is on tab ${node.z} but group is on tab ${group.z}`)
+                    return node
+                })
+                this.RED.view.select({ nodes: [group, ...newNodes] })
+                this._verifySelection([group, ...newNodes])
+                this.RED.actions.invoke('core:merge-selection-to-group')
+
+                const newGroups = []
+                this.RED.nodes.eachGroup(g => {
+                    if (!existingGroupIds.has(g.id)) newGroups.push(g)
+                })
+                if (newGroups.length === 0) {
+                    throw new Error('Add nodes failed: core:merge-selection-to-group did not create a new group')
+                }
+                group = newGroups[0]
+            }
+        }
+
+        const changes = {}
+
+        if (name !== undefined) {
+            changes.name = group.name
+            group.name = name
+        }
+
+        if (style) {
+            changes.style = { ...group.style }
+            group.style = Object.assign({}, group.style || {}, style)
+        }
+
+        if (env !== undefined) {
+            changes.env = group.env
+            group.env = env
+        }
+
+        if (Object.keys(changes).length > 0) {
+            group.changed = true
+            group.dirty = true
+            this.RED.history.push({ t: 'edit', node: group, changes, changed: false, dirty: this.RED.nodes.dirty() })
+        }
+
+        this.RED.nodes.dirty(true)
+        this.RED.view.redraw()
+        return group
+    }
+
+    /**
+     * Delete a group (ungroup its nodes).
+     * @param {string} id - group ID
+     */
+    deleteGroup (id) {
+        const group = this.RED.nodes.group(id)
+        if (!group) throw new Error(`Group ${id} not found`)
+        this._assertWorkspaceNotLocked(group.z)
+        this.RED.view.select({ nodes: [group] })
+        this._verifySelection([group])
+        this.RED.actions.invoke('core:ungroup-selection')
+        this.RED.nodes.dirty(true)
+        this.RED.view.redraw()
+    }
+
     _summarizeNode (node) {
         if (!node) return null
         const s = { id: node.id }
@@ -1421,6 +1714,37 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (node.y !== undefined) s.y = node.y
         if (node.z !== undefined) s.z = node.z
         if (node.valid !== undefined) s.valid = node.valid
+        return s
+    }
+
+    /**
+     * Defensive check: verify the view selection contains exactly the expected nodes.
+     * Guards against editor states where RED.view.select() is silently ignored,
+     * which would cause core actions to act on unintended nodes.
+     * @param {object[]} expectedNodes
+     */
+    _verifySelection (expectedNodes) {
+        const selection = this.RED.view.selection()
+        const selectedNodes = selection?.nodes || []
+        const expectedIds = expectedNodes.map(n => n.id)
+        const selectedIds = selectedNodes.map(n => n.id)
+        const expectedSet = new Set(expectedIds)
+        const selectedSet = new Set(selectedIds)
+        if (selectedSet.size !== expectedSet.size || ![...expectedSet].every(id => selectedSet.has(id))) {
+            throw new Error(
+                `Selection mismatch: expected [${expectedIds.join(', ')}] but selection is [${selectedIds.join(', ')}] — editor may be in an unexpected state`
+            )
+        }
+    }
+
+    _summarizeGroup (group) {
+        if (!group) return null
+        const s = { id: group.id, type: 'group' }
+        if (group.name !== undefined) s.name = group.name
+        if (group.z !== undefined) s.z = group.z
+        if (Array.isArray(group.nodes)) s.nodeCount = group.nodes.length
+        if (group.style !== undefined) s.style = group.style
+        if (Array.isArray(group.env) && group.env.length > 0) s.env = group.env
         return s
     }
 }

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -44,7 +44,8 @@ describeMain('expertAutomations', () => {
             state: { DEFAULT: 1 },
             workspaces: {
                 active: sinon.stub().returns('active-tab'),
-                show: sinon.stub()
+                show: sinon.stub(),
+                isLocked: sinon.stub().returns(false)
             }
         }
     }
@@ -96,7 +97,8 @@ describeMain('expertAutomations', () => {
                 'automation/get-node-types',
                 'automation/get-palette',
                 'automation/list-config-nodes',
-                'automation/open-palette-manager'
+                'automation/open-palette-manager',
+                'automation/manage-groups'
             ]
             supportedActions.should.only.have.keys(...expectedKeys)
         })
@@ -423,7 +425,7 @@ describeMain('expertAutomations', () => {
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/remove-nodes', {
                     params: { ids: ['n1'] }
-                }, result)).rejectedWith(/workspace locked-tab is locked/)
+                }, result)).rejectedWith(/Workspace locked-tab is locked/)
                 mockRED.nodes.remove.called.should.be.false()
             })
         })
@@ -533,7 +535,7 @@ describeMain('expertAutomations', () => {
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/set-wires', {
                     params: { mode: 'add', source: 'n1', target: 'n2' }
-                }, result)).rejectedWith(/workspace tab1 is locked/)
+                }, result)).rejectedWith(/Workspace tab1 is locked/)
             })
             it('should throw if source output port does not exist', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1', outputs: 1 })
@@ -713,7 +715,7 @@ describeMain('expertAutomations', () => {
                 mockRED.workspaces.isLocked.withArgs('tab1').returns(true)
                 await should(expertAutomations.invokeAction('automation/set-links', {
                     params: { mode: 'add', source: 'lo1', target: 'li1' }
-                }, {})).rejectedWith(/workspace tab1 is locked/)
+                }, {})).rejectedWith(/Workspace tab1 is locked/)
             })
             it('should throw if target workspace is locked (cross-tab)', async () => {
                 mockRED.nodes.node.withArgs('lo1').returns({ id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: [] })
@@ -721,7 +723,7 @@ describeMain('expertAutomations', () => {
                 mockRED.workspaces.isLocked.withArgs('tab2').returns(true)
                 await should(expertAutomations.invokeAction('automation/set-links', {
                     params: { mode: 'add', source: 'lo1', target: 'li1' }
-                }, {})).rejectedWith(/workspace tab2 is locked/)
+                }, {})).rejectedWith(/Workspace tab2 is locked/)
             })
             it('should throw if adding a link that already exists', async () => {
                 const linkOut = { id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: ['li1'] }
@@ -900,7 +902,7 @@ describeMain('expertAutomations', () => {
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes: [{ id: 'n1', type: 'inject', z: 'nonexistent' }] }
-                }, result)).rejectedWith(/Workspace tab nonexistent not found/)
+                }, result)).rejectedWith(/Workspace nonexistent not found/)
             })
             it('should throw if any target tab does not exist (mixed z)', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
@@ -913,15 +915,16 @@ describeMain('expertAutomations', () => {
                 ]
                 await should(expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes }
-                }, result)).rejectedWith(/Workspace tab tab2 not found/)
+                }, result)).rejectedWith(/Workspace tab2 not found/)
             })
             it('should throw if target tab is locked', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
-                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', type: 'tab', locked: true })
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', type: 'tab' })
+                mockRED.workspaces.isLocked = sinon.stub().withArgs('tab1').returns(true)
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1' }] }
-                }, result)).rejectedWith(/Workspace tab tab1 is locked/)
+                }, result)).rejectedWith(/Workspace tab1 is locked/)
             })
             it('should throw if node IDs already exist on the canvas', async () => {
                 mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
@@ -2125,6 +2128,428 @@ describeMain('expertAutomations', () => {
                 mockRED.actions.invoke.calledOnce.should.be.true()
                 mockRED.actions.invoke.calledWith('core:manage-palette', { view: 'install', filter: '' }).should.be.true()
                 result.should.have.property('success', true)
+            })
+        })
+
+        describe('automation/manage-groups', () => {
+            function setupGroupMocks () {
+                mockRED.nodes.group = sinon.stub().returns(null)
+                mockRED.nodes.eachGroup = sinon.stub()
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.view.select = sinon.stub()
+                mockRED.view.selection = sinon.stub().callsFake(() => mockRED.view.select.lastCall?.args[0] || { nodes: [] })
+                mockRED.view.redraw = sinon.stub()
+                mockRED.actions = { invoke: sinon.stub() }
+                mockRED.history = { push: sinon.stub() }
+                mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().returns(false) }
+            }
+
+            it('should create a group from a list of nodes', async () => {
+                setupGroupMocks()
+                const nodeA = { id: 'n1', type: 'inject', z: 'tab1' }
+                const nodeB = { id: 'n2', type: 'function', z: 'tab1' }
+                mockRED.nodes.node = sinon.stub().callsFake(id => ({ n1: nodeA, n2: nodeB }[id] || null))
+                const createdGroup = { id: 'g1', type: 'group', z: 'tab1', nodes: [nodeA, nodeB] }
+                mockRED.nodes.eachGroup
+                    .onFirstCall().callsFake(() => {})
+                    .onSecondCall().callsFake(fn => fn(createdGroup))
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'create', nodeIds: ['n1', 'n2'], name: 'My Group' }] }
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('data').which.is.an.Array().with.lengthOf(1)
+                result.data[0].should.have.property('op', 'create')
+                result.data[0].should.have.property('id', 'g1')
+                result.data[0].should.have.property('type', 'group')
+                result.data[0].should.have.property('name', 'My Group')
+                mockRED.view.select.calledOnce.should.be.true()
+                mockRED.actions.invoke.calledWith('core:group-selection').should.be.true()
+                mockRED.history.push.calledOnce.should.be.true()
+            })
+
+            it('should create a group with an explicit id when provided', async () => {
+                setupGroupMocks()
+                const nodeA = { id: 'n1', type: 'inject', z: 'tab1', g: undefined }
+                const nodeB = { id: 'n2', type: 'function', z: 'tab1', g: undefined }
+                mockRED.nodes.node = sinon.stub().callsFake(id => ({ n1: nodeA, n2: nodeB }[id] || null))
+                // group created with auto-generated id 'g-auto', nodes have g set to it
+                const createdGroup = { id: 'g-auto', type: 'group', z: 'tab1', nodes: [nodeA, nodeB] }
+                nodeA.g = 'g-auto'
+                nodeB.g = 'g-auto'
+                mockRED.nodes.eachGroup
+                    .onFirstCall().callsFake(() => {})
+                    .onSecondCall().callsFake(fn => fn(createdGroup))
+                // group() returns null for both IDs (neither exists before creation)
+                mockRED.nodes.group = sinon.stub().returns(null)
+                mockRED.nodes.remove = sinon.stub()
+                mockRED.nodes.add = sinon.stub()
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'create', nodeIds: ['n1', 'n2'], id: 'my-group-id' }] }
+                }, result)
+                result.should.have.property('success', true)
+                result.data[0].should.have.property('id', 'my-group-id')
+                mockRED.nodes.remove.calledWith('g-auto').should.be.true()
+                mockRED.nodes.add.calledOnce.should.be.true()
+                createdGroup.id.should.equal('my-group-id')
+                nodeA.g.should.equal('my-group-id')
+                nodeB.g.should.equal('my-group-id')
+            })
+
+            it('should throw if explicit id for create is already in use', async () => {
+                setupGroupMocks()
+                const nodeA = { id: 'n1', type: 'inject', z: 'tab1' }
+                mockRED.nodes.node = sinon.stub().callsFake(id => ({ n1: nodeA }[id] || null))
+                const createdGroup = { id: 'g-auto', type: 'group', z: 'tab1', nodes: [nodeA] }
+                mockRED.nodes.eachGroup
+                    .onFirstCall().callsFake(() => {})
+                    .onSecondCall().callsFake(fn => fn(createdGroup))
+                // group() returns a group for the requested ID — already in use
+                mockRED.nodes.group = sinon.stub().callsFake(id => id === 'taken-id' ? { id: 'taken-id' } : null)
+                mockRED.nodes.remove = sinon.stub()
+                mockRED.nodes.add = sinon.stub()
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'create', nodeIds: ['n1'], id: 'taken-id' }] }
+                }, result)).rejectedWith(/already in use/)
+            })
+
+            it('should throw if selection does not match after select (unexpected editor state)', async () => {
+                setupGroupMocks()
+                const nodeA = { id: 'n1', z: 'tab1' }
+                mockRED.nodes.node = sinon.stub().returns(nodeA)
+                mockRED.nodes.eachGroup.callsFake(() => {})
+                // Simulate editor ignoring the select call (returns empty selection)
+                mockRED.view.selection = sinon.stub().returns({ nodes: [] })
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'create', nodeIds: ['n1'] }] }
+                }, result)).rejectedWith(/Selection mismatch/)
+            })
+
+            it('should throw if workspace is locked for create', async () => {
+                setupGroupMocks()
+                const nodeA = { id: 'n1', z: 'tab1' }
+                mockRED.nodes.node = sinon.stub().returns(nodeA)
+                mockRED.workspaces.isLocked.withArgs('tab1').returns(true)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'create', nodeIds: ['n1'] }] }
+                }, result)).rejectedWith(/tab1 is locked/)
+            })
+
+            it('should throw if group creation produced no new group', async () => {
+                setupGroupMocks()
+                const nodeA = { id: 'n1', z: 'tab1' }
+                mockRED.nodes.node = sinon.stub().returns(nodeA)
+                mockRED.nodes.eachGroup
+                    .onFirstCall().callsFake(() => {})
+                    .onSecondCall().callsFake(() => {})
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'create', nodeIds: ['n1'] }] }
+                }, result)).rejectedWith(/did not create a new group/)
+            })
+
+            it('should throw if new group is missing some of the requested nodes', async () => {
+                setupGroupMocks()
+                const nodeA = { id: 'n1', z: 'tab1' }
+                const nodeB = { id: 'n2', z: 'tab1' }
+                mockRED.nodes.node = sinon.stub().callsFake(id => ({ n1: nodeA, n2: nodeB }[id] || null))
+                const partialGroup = { id: 'g1', type: 'group', z: 'tab1', nodes: [nodeA] }
+                mockRED.nodes.eachGroup
+                    .onFirstCall().callsFake(() => {})
+                    .onSecondCall().callsFake(fn => fn(partialGroup))
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'create', nodeIds: ['n1', 'n2'] }] }
+                }, result)).rejectedWith(/missing nodes: n2/)
+            })
+
+            it('should apply style and env when creating a group', async () => {
+                setupGroupMocks()
+                const nodeA = { id: 'n1', z: 'tab1' }
+                mockRED.nodes.node = sinon.stub().returns(nodeA)
+                const createdGroup = { id: 'g1', type: 'group', z: 'tab1', nodes: [nodeA], style: {} }
+                mockRED.nodes.eachGroup
+                    .onFirstCall().callsFake(() => {})
+                    .onSecondCall().callsFake(fn => fn(createdGroup))
+                const env = [{ name: 'HOST', value: 'localhost', type: 'str' }]
+                const style = { stroke: '#ff0000', fill: 'none' }
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'create', nodeIds: ['n1'], style, env }] }
+                }, result)
+                result.should.have.property('success', true)
+                createdGroup.style.should.have.property('stroke', '#ff0000')
+                createdGroup.style.should.have.property('fill', 'none')
+                createdGroup.env.should.deepEqual(env)
+                mockRED.history.push.calledOnce.should.be.true()
+            })
+
+            it('should throw if nodeIds is empty for create', async () => {
+                setupGroupMocks()
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'create', nodeIds: [] }] }
+                }, result)).rejectedWith(/nodeIds is required/)
+            })
+
+            it('should throw if nodes are on different tabs for create', async () => {
+                setupGroupMocks()
+                mockRED.nodes.node = sinon.stub().callsFake(id => ({
+                    n1: { id: 'n1', z: 'tab1' },
+                    n2: { id: 'n2', z: 'tab2' }
+                }[id] || null))
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'create', nodeIds: ['n1', 'n2'] }] }
+                }, result)).rejectedWith(/same tab/)
+            })
+
+            it('should throw if a node is not found for create', async () => {
+                setupGroupMocks()
+                mockRED.nodes.node = sinon.stub().returns(null)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'create', nodeIds: ['missing'] }] }
+                }, result)).rejectedWith(/Node missing not found/)
+            })
+
+            it('should update a group name', async () => {
+                setupGroupMocks()
+                const group = { id: 'g1', type: 'group', z: 'tab1', name: 'Old', nodes: [], changed: false }
+                mockRED.nodes.group = sinon.stub().withArgs('g1').returns(group)
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'update', id: 'g1', name: 'New Name' }] }
+                }, result)
+                result.should.have.property('success', true)
+                group.name.should.equal('New Name')
+                group.changed.should.be.true()
+                result.data[0].should.have.property('op', 'update')
+                result.data[0].should.have.property('id', 'g1')
+            })
+
+            it('should update a group style', async () => {
+                setupGroupMocks()
+                const group = { id: 'g1', type: 'group', z: 'tab1', nodes: [], changed: false, style: { stroke: '#000' } }
+                mockRED.nodes.group = sinon.stub().withArgs('g1').returns(group)
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'update', id: 'g1', style: { fill: '#ff0000' } }] }
+                }, result)
+                group.style.should.deepEqual({ stroke: '#000', fill: '#ff0000' })
+                result.data[0].should.have.property('style').which.deepEqual({ stroke: '#000', fill: '#ff0000' })
+            })
+
+            it('should replace group env vars', async () => {
+                setupGroupMocks()
+                const group = { id: 'g1', type: 'group', z: 'tab1', nodes: [], changed: false, env: [] }
+                mockRED.nodes.group = sinon.stub().withArgs('g1').returns(group)
+                const env = [{ name: 'HOST', value: 'localhost', type: 'str' }]
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'update', id: 'g1', env }] }
+                }, result)
+                group.env.should.deepEqual(env)
+                group.changed.should.be.true()
+            })
+
+            it('should add nodes to a group via manage-members', async () => {
+                setupGroupMocks()
+                const nodeC = { id: 'n3', z: 'tab1' }
+                const group = { id: 'g1', type: 'group', z: 'tab1', nodes: [], changed: false }
+                const mergedGroup = { id: 'g2', type: 'group', z: 'tab1', nodes: [group.nodes[0], nodeC], changed: false }
+                mockRED.nodes.group = sinon.stub().withArgs('g1').returns(group)
+                mockRED.nodes.node = sinon.stub().withArgs('n3').returns(nodeC)
+                mockRED.nodes.eachGroup
+                    .onFirstCall().callsFake(fn => fn(group))
+                    .onSecondCall().callsFake(fn => { fn(group); fn(mergedGroup) })
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'manage-members', id: 'g1', nodeIds: ['n3'], mode: 'add' }] }
+                }, result)
+                result.should.have.property('success', true)
+                mockRED.view.select.calledOnce.should.be.true()
+                mockRED.view.select.firstCall.args[0].nodes.should.deepEqual([group, nodeC])
+                mockRED.actions.invoke.calledWith('core:merge-selection-to-group').should.be.true()
+                result.data[0].should.have.property('op', 'manage-members')
+                result.data[0].should.have.property('mode', 'add')
+                result.data[0].should.have.property('id', 'g2')
+            })
+
+            it('should remove nodes from a group via manage-members', async () => {
+                setupGroupMocks()
+                const nodeA = { id: 'n1', z: 'tab1', g: 'g1' }
+                const group = { id: 'g1', type: 'group', z: 'tab1', nodes: [nodeA], changed: false }
+                mockRED.nodes.group = sinon.stub().withArgs('g1').returns(group)
+                mockRED.nodes.node = sinon.stub().withArgs('n1').returns(nodeA)
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'manage-members', id: 'g1', nodeIds: ['n1'], mode: 'remove' }] }
+                }, result)
+                result.should.have.property('success', true)
+                mockRED.view.select.calledOnce.should.be.true()
+                mockRED.view.select.firstCall.args[0].nodes.should.deepEqual([nodeA])
+                mockRED.actions.invoke.calledWith('core:remove-selection-from-group').should.be.true()
+                result.data[0].should.have.property('op', 'manage-members')
+                result.data[0].should.have.property('mode', 'remove')
+                result.data[0].should.have.property('id', 'g1')
+            })
+
+            it('should throw if node being removed is not in the group', async () => {
+                setupGroupMocks()
+                const nodeA = { id: 'n1', z: 'tab1', g: 'other-group' }
+                const group = { id: 'g1', type: 'group', z: 'tab1', nodes: [] }
+                mockRED.nodes.group = sinon.stub().withArgs('g1').returns(group)
+                mockRED.nodes.node = sinon.stub().withArgs('n1').returns(nodeA)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'manage-members', id: 'g1', nodeIds: ['n1'], mode: 'remove' }] }
+                }, result)).rejectedWith(/n1 is not in group g1/)
+            })
+
+            it('should throw if workspace is locked for update', async () => {
+                setupGroupMocks()
+                const group = { id: 'g1', z: 'tab1' }
+                mockRED.nodes.group = sinon.stub().withArgs('g1').returns(group)
+                mockRED.workspaces.isLocked.withArgs('tab1').returns(true)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'update', id: 'g1', name: 'X' }] }
+                }, result)).rejectedWith(/tab1 is locked/)
+            })
+
+            it('should throw if group not found for update', async () => {
+                setupGroupMocks()
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'update', id: 'missing' }] }
+                }, result)).rejectedWith(/Group missing not found/)
+            })
+
+            it('should throw if id is missing for update', async () => {
+                setupGroupMocks()
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'update' }] }
+                }, result)).rejectedWith(/id is required for update/)
+            })
+
+            it('should throw if node being added is on a different tab', async () => {
+                setupGroupMocks()
+                const group = { id: 'g1', type: 'group', z: 'tab1', nodes: [] }
+                mockRED.nodes.group = sinon.stub().withArgs('g1').returns(group)
+                mockRED.nodes.node = sinon.stub().withArgs('n99').returns({ id: 'n99', z: 'tab2' })
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'manage-members', id: 'g1', nodeIds: ['n99'], mode: 'add' }] }
+                }, result)).rejectedWith(/tab2/)
+            })
+
+            it('should throw if id is missing for manage-members', async () => {
+                setupGroupMocks()
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'manage-members', nodeIds: ['n1'], mode: 'add' }] }
+                }, result)).rejectedWith(/id is required for manage-members/)
+            })
+
+            it('should throw if mode is invalid for manage-members', async () => {
+                setupGroupMocks()
+                const group = { id: 'g1', type: 'group', z: 'tab1', nodes: [] }
+                mockRED.nodes.group = sinon.stub().withArgs('g1').returns(group)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'manage-members', id: 'g1', nodeIds: ['n1'], mode: 'remove-all' }] }
+                }, result)).rejectedWith(/mode must be "add" or "remove"/)
+            })
+
+            it('should delete a group', async () => {
+                setupGroupMocks()
+                const group = { id: 'g1', type: 'group' }
+                mockRED.nodes.group = sinon.stub().withArgs('g1').returns(group)
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'delete', id: 'g1' }] }
+                }, result)
+                result.should.have.property('success', true)
+                result.data[0].should.deepEqual({ op: 'delete', deleted: 'g1' })
+                mockRED.history.push.called.should.be.false()
+                mockRED.view.select.calledOnce.should.be.true()
+                mockRED.actions.invoke.calledWith('core:ungroup-selection').should.be.true()
+            })
+
+            it('should throw if workspace is locked for delete', async () => {
+                setupGroupMocks()
+                const group = { id: 'g1', type: 'group', z: 'tab1' }
+                mockRED.nodes.group = sinon.stub().withArgs('g1').returns(group)
+                mockRED.workspaces.isLocked.withArgs('tab1').returns(true)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'delete', id: 'g1' }] }
+                }, result)).rejectedWith(/tab1 is locked/)
+            })
+
+            it('should throw if group not found for delete', async () => {
+                setupGroupMocks()
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'delete', id: 'missing' }] }
+                }, result)).rejectedWith(/Group missing not found/)
+            })
+
+            it('should throw if id is missing for delete', async () => {
+                setupGroupMocks()
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'delete' }] }
+                }, result)).rejectedWith(/id is required for delete/)
+            })
+
+            it('should throw on unknown op', async () => {
+                setupGroupMocks()
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'explode' }] }
+                }, result)).rejectedWith(/Unknown manage-groups op: explode/)
+            })
+
+            it('should throw if operations array is empty', async () => {
+                setupGroupMocks()
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [] }
+                }, result)).rejectedWith(/operations array is required/)
+            })
+
+            it('should execute multiple operations sequentially', async () => {
+                setupGroupMocks()
+                const nodeA = { id: 'n1', z: 'tab1' }
+                const nodeB = { id: 'n2', z: 'tab1' }
+                mockRED.nodes.node = sinon.stub().callsFake(id => ({ n1: nodeA, n2: nodeB }[id] || null))
+                const createdGroup = { id: 'g1', type: 'group', z: 'tab1', nodes: [nodeA, nodeB] }
+                const existingGroup = { id: 'g2', type: 'group', z: 'tab1', nodes: [], changed: false }
+                mockRED.nodes.eachGroup
+                    .onFirstCall().callsFake(() => {})
+                    .onSecondCall().callsFake(fn => fn(createdGroup))
+                mockRED.nodes.group = sinon.stub().callsFake(id => ({ g2: existingGroup }[id] || null))
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: {
+                        operations: [
+                            { op: 'create', nodeIds: ['n1', 'n2'] },
+                            { op: 'update', id: 'g2', name: 'Renamed' }
+                        ]
+                    }
+                }, result)
+                result.should.have.property('success', true)
+                result.data.should.have.lengthOf(2)
+                result.data[0].should.have.property('op', 'create')
+                result.data[1].should.have.property('op', 'update')
+                existingGroup.name.should.equal('Renamed')
             })
         })
     })


### PR DESCRIPTION
## Summary

Adds `automation/manage-groups` action with an operations array supporting four ops:

- `create`: groups a list of node IDs together (all must be on the same tab); uses `core:group-selection` internally. Accepts optional `name`, `style`, `env`, and explicit `id`.
- `update`: changes group metadata — `name`, `style`, `env`. Does not touch member nodes.
- `manage-members`: adds or removes nodes from an existing group using `mode: "add" | "remove"`.
- `delete`: disbands the group container via `core:ungroup-selection`; member nodes are kept in place.

Groups cannot be created via `add_nodes` — that action returns a clear error directing to `manage_groups`.

Defensive `_verifySelection` check applied to all four operations: after `RED.view.select()`, the actual canvas selection is verified against the expected nodes and throws if they don't match, guarding against silent selection failures in unexpected editor states.

## Test plan

- create: valid group, optional name/style/env, explicit id, id already in use, empty nodeIds, mixed-tab nodes, node not found, workspace locked, selection mismatch
- update: rename, style change, env replace, group not found, missing id, workspace locked
- manage-members: add nodes, remove nodes, invalid mode, missing id, node not in group, node on wrong tab
- delete: valid delete, group not found, missing id, workspace locked
- unknown op and empty operations array
- multiple operations in a single call

Closes #317