### PR TITLE
feat(automation): hard-reject group type in add-nodes, update-node, and remove-nodes

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1260,6 +1260,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
             break
 
         case UPDATE_NODE: {
+            if (this.RED.nodes.group(params.id)) {
+                result.error = 'Groups cannot be modified via update-node. Use automation/manage-groups instead.'
+                result.success = false
+                break
+            }
             await this.updateNode(params.id, params.properties, params.patches)
             const updatedNode = this.RED.nodes.node(params.id)
             result.data = this._summarizeNode(updatedNode)
@@ -1331,6 +1336,12 @@ export class ExpertAutomations extends ExpertActionsInterface {
             break
 
         case ADD_NODES: {
+            const groupNodes = (params.nodes || []).filter(n => n.type === 'group')
+            if (groupNodes.length > 0) {
+                result.error = 'Groups cannot be created via add-nodes. Use automation/manage-groups instead.'
+                result.success = false
+                break
+            }
             this.addNodes(params.nodes, { generateIds: params.generateIds ?? false })
             const addedNodes = params.nodes.map(n => this.RED.nodes.node(n.id)).filter(Boolean)
             if (this.RED.editor?.validateNode) {
@@ -1342,10 +1353,17 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
-        case REMOVE_NODES:
+        case REMOVE_NODES: {
+            const groupIds = (params.ids || []).filter(id => !!this.RED.nodes.group(id))
+            if (groupIds.length > 0) {
+                result.error = `Groups cannot be removed via remove-nodes. Use automation/manage-groups with op: delete instead. Group IDs: ${groupIds.join(', ')}`
+                result.success = false
+                break
+            }
             this.removeNodes(params.ids)
             result.data = { removed: params.ids }
             result.success = true
+        }
             break
 
         case SET_WIRES:

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1265,7 +1265,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
         case UPDATE_NODE: {
             if (this.RED.nodes.group(params.id)) {
-                result.error = 'Groups cannot be modified via update-node. Use automation/manage-groups instead.'
+                result.error = `Node ${params.id} is a group — group nodes cannot be updated via this action`
+                result.errorCode = 'GROUP_OPERATION_REQUIRED'
                 result.success = false
                 break
             }
@@ -1342,7 +1343,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
         case ADD_NODES: {
             const groupNodes = (params.nodes || []).filter(n => n.type === 'group')
             if (groupNodes.length > 0) {
-                result.error = 'Groups cannot be created via add-nodes. Use automation/manage-groups instead.'
+                result.error = `Nodes [${groupNodes.map(n => n.id).join(', ')}] are group nodes — group nodes cannot be added via this action`
+                result.errorCode = 'GROUP_OPERATION_REQUIRED'
                 result.success = false
                 break
             }
@@ -1360,7 +1362,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
         case REMOVE_NODES: {
             const groupIds = (params.ids || []).filter(id => !!this.RED.nodes.group(id))
             if (groupIds.length > 0) {
-                result.error = `Groups cannot be removed via remove-nodes. Use automation/manage-groups with op: delete instead. Group IDs: ${groupIds.join(', ')}`
+                result.error = `IDs [${groupIds.join(', ')}] are group nodes — group nodes cannot be removed via this action`
+                result.errorCode = 'GROUP_OPERATION_REQUIRED'
                 result.success = false
                 break
             }

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -601,6 +601,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (hasProperties && Object.keys(properties).length === 0) {
             throw new Error('"properties" must not be empty')
         }
+        if (hasProperties && 'g' in properties) {
+            throw new Error(`Node ${id}: "g" cannot be set directly — group membership must be managed via a dedicated action`)
+        }
         if (!hasProperties && !hasPatches) {
             throw new Error('At least one of "properties" or "patches" must be provided')
         }
@@ -985,6 +988,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const prepared = nodes.map(rawNode => {
             if (!rawNode.id) throw new Error('Node is missing required property: id')
             if (!rawNode.type) throw new Error('Node is missing required property: type')
+            if (rawNode.g !== undefined) throw new Error(`Node ${rawNode.id}: "g" cannot be set directly — group membership must be managed via a dedicated action`)
             const def = this.RED.nodes.getType(rawNode.type)
             if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
             const isConfigNode = def.category === 'config'

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -27,6 +27,11 @@ const LIST_CONFIG_NODES = 'automation/list-config-nodes'
 const OPEN_PALETTE_MANAGER = 'automation/open-palette-manager'
 const MANAGE_GROUPS = 'automation/manage-groups'
 
+const ERROR_CODES = Object.freeze({
+    GROUP_OPERATION_REQUIRED: 'GROUP_OPERATION_REQUIRED',
+    FORBIDDEN_PROPERTY: 'FORBIDDEN_PROPERTY'
+})
+
 /**
  * @typedef {SELECT_NODES
  *   |GET_NODES
@@ -601,9 +606,6 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (hasProperties && Object.keys(properties).length === 0) {
             throw new Error('"properties" must not be empty')
         }
-        if (hasProperties && 'g' in properties) {
-            throw new Error(`Node ${id}: "g" cannot be set directly — group membership must be managed via a dedicated action`)
-        }
         if (!hasProperties && !hasPatches) {
             throw new Error('At least one of "properties" or "patches" must be provided')
         }
@@ -988,7 +990,6 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const prepared = nodes.map(rawNode => {
             if (!rawNode.id) throw new Error('Node is missing required property: id')
             if (!rawNode.type) throw new Error('Node is missing required property: type')
-            if (rawNode.g !== undefined) throw new Error(`Node ${rawNode.id}: "g" cannot be set directly — group membership must be managed via a dedicated action`)
             const def = this.RED.nodes.getType(rawNode.type)
             if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
             const isConfigNode = def.category === 'config'
@@ -1270,7 +1271,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
         case UPDATE_NODE: {
             if (this.RED.nodes.group(params.id)) {
                 result.error = `Node ${params.id} is a group — group nodes cannot be updated via this action`
-                result.errorCode = 'GROUP_OPERATION_REQUIRED'
+                result.errorCode = ERROR_CODES.GROUP_OPERATION_REQUIRED
+                result.success = false
+                break
+            }
+            if (params.properties && 'g' in params.properties) {
+                result.error = `Node ${params.id}: "g" cannot be set directly — group membership must be managed via a dedicated action`
+                result.errorCode = ERROR_CODES.FORBIDDEN_PROPERTY
                 result.success = false
                 break
             }
@@ -1348,7 +1355,14 @@ export class ExpertAutomations extends ExpertActionsInterface {
             const groupNodes = (params.nodes || []).filter(n => n.type === 'group')
             if (groupNodes.length > 0) {
                 result.error = `Nodes [${groupNodes.map(n => n.id).join(', ')}] are group nodes — group nodes cannot be added via this action`
-                result.errorCode = 'GROUP_OPERATION_REQUIRED'
+                result.errorCode = ERROR_CODES.GROUP_OPERATION_REQUIRED
+                result.success = false
+                break
+            }
+            const gNode = (params.nodes || []).find(n => n.g !== undefined)
+            if (gNode) {
+                result.error = `Node ${gNode.id}: "g" cannot be set directly — group membership must be managed via a dedicated action`
+                result.errorCode = ERROR_CODES.FORBIDDEN_PROPERTY
                 result.success = false
                 break
             }
@@ -1367,7 +1381,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             const groupIds = (params.ids || []).filter(id => !!this.RED.nodes.group(id))
             if (groupIds.length > 0) {
                 result.error = `IDs [${groupIds.join(', ')}] are group nodes — group nodes cannot be removed via this action`
-                result.errorCode = 'GROUP_OPERATION_REQUIRED'
+                result.errorCode = ERROR_CODES.GROUP_OPERATION_REQUIRED
                 result.success = false
                 break
             }

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -279,6 +279,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         type: 'array',
                         items: { type: 'string' },
                         description: 'IDs of nodes to remove from the canvas'
+                    },
+                    reconnectWires: {
+                        type: 'boolean',
+                        description: 'If true, reconnects wires around removed nodes (pass-through). Default: false'
                     }
                 },
                 required: ['ids']
@@ -1033,9 +1037,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
     /**
      * Remove one or more nodes from the live NR4 canvas by ID.
+     * Delegates to Node-RED's core:delete-selection action to ensure all internal data
+     * structures (including group membership arrays) are properly cleaned up.
      * @param {string[]} ids - node IDs to remove
+     * @param {object} [options]
+     * @param {boolean} [options.reconnectWires=false] - reconnect wires around removed nodes
      */
-    removeNodes (ids) {
+    removeNodes (ids, { reconnectWires = false } = {}) {
         // Resolve all nodes once and check for missing
         const nodes = ids.map(id => {
             const node = this.RED.nodes.node(id)
@@ -1046,15 +1054,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
         for (const node of nodes) {
             this._assertWorkspaceNotLocked(node.z)
         }
-        const allRemovedLinks = []
-        for (const node of nodes) {
-            const removed = this.RED.nodes.remove(node.id)
-            allRemovedLinks.push(...(removed.links || []))
+        this.RED.view.select({ nodes })
+        this._verifySelection(nodes)
+        if (reconnectWires) {
+            this.RED.actions.invoke('core:delete-selection-and-reconnect')
+        } else {
+            this.RED.actions.invoke('core:delete-selection')
         }
-        this.RED.history.push({ t: 'delete', nodes, links: allRemovedLinks, dirty: this.RED.nodes.dirty() })
-        this.RED.nodes.dirty(true)
-        this.RED.view.updateActive()
-        this.RED.view.redraw()
     }
 
     /**
@@ -1385,7 +1391,14 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 result.success = false
                 break
             }
-            this.removeNodes(params.ids)
+            const groupedNodes = (params.ids || []).map(id => this.RED.nodes.node(id)).filter(n => n && n.g)
+            if (groupedNodes.length > 0) {
+                result.error = `Node ${groupedNodes[0].id}: cannot be removed while it is a member of a group — group membership must be managed via a dedicated action first`
+                result.errorCode = ERROR_CODES.FORBIDDEN_PROPERTY
+                result.success = false
+                break
+            }
+            this.removeNodes(params.ids, { reconnectWires: params.reconnectWires ?? false })
             result.data = { removed: params.ids }
             result.success = true
         }

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -363,45 +363,34 @@ describeMain('expertAutomations', () => {
         })
         describe('removeNodes action', () => {
             beforeEach(() => {
-                mockRED.nodes.remove = sinon.stub().returns({ nodes: [], links: [] })
                 mockRED.nodes.dirty = sinon.stub()
-                mockRED.history = { push: sinon.stub() }
-                mockRED.view.updateActive = sinon.stub()
-                mockRED.view.redraw = sinon.stub()
+                mockRED.actions = { invoke: sinon.stub() }
+                mockRED.view.select = sinon.stub()
+                mockRED.view.selection = sinon.stub().callsFake(() => mockRED.view.select.lastCall?.args[0] || { nodes: [] })
                 mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().returns(false) }
             })
-            it('should remove nodes by ID string and push history', async () => {
+            it('should remove nodes by delegating to core:delete-selection', async () => {
                 const mockNode = { id: 'n1' }
                 mockRED.nodes.node.withArgs('n1').returns(mockNode)
                 const result = {}
                 await expertAutomations.invokeAction('automation/remove-nodes', {
                     params: { ids: ['n1'] }
                 }, result)
-                mockRED.nodes.remove.calledWith('n1').should.be.true()
-                mockRED.history.push.calledOnce.should.be.true()
-                const historyArg = mockRED.history.push.firstCall.args[0]
-                historyArg.should.have.property('t', 'delete')
-                historyArg.should.have.property('nodes').which.is.an.Array().with.lengthOf(1)
-                historyArg.nodes[0].should.equal(mockNode)
-                mockRED.nodes.dirty.calledWith(true).should.be.true()
-                mockRED.view.updateActive.calledOnce.should.be.true()
-                mockRED.view.redraw.calledOnce.should.be.true()
+                mockRED.view.select.calledWith({ nodes: [mockNode] }).should.be.true()
+                mockRED.actions.invoke.calledWith('core:delete-selection').should.be.true()
                 result.should.have.property('success', true)
                 result.should.have.property('handled', true)
                 result.should.have.property('data').which.deepEqual({ removed: ['n1'] })
             })
-            it('should collect removed links for history', async () => {
+            it('should use core:delete-selection-and-reconnect when reconnectWires is true', async () => {
                 const mockNode = { id: 'n1' }
-                const mockLink = { source: { id: 'n1' }, target: { id: 'n2' } }
                 mockRED.nodes.node.withArgs('n1').returns(mockNode)
-                mockRED.nodes.remove.returns({ nodes: [], links: [mockLink] })
                 const result = {}
                 await expertAutomations.invokeAction('automation/remove-nodes', {
-                    params: { ids: ['n1'] }
+                    params: { ids: ['n1'], reconnectWires: true }
                 }, result)
-                const historyArg = mockRED.history.push.firstCall.args[0]
-                historyArg.should.have.property('links').which.is.an.Array().with.lengthOf(1)
-                historyArg.links[0].should.equal(mockLink)
+                mockRED.actions.invoke.calledWith('core:delete-selection-and-reconnect').should.be.true()
+                result.should.have.property('success', true)
             })
             it('should throw if any node ID does not exist', async () => {
                 mockRED.nodes.node.returns(null)
@@ -409,7 +398,7 @@ describeMain('expertAutomations', () => {
                 await should(expertAutomations.invokeAction('automation/remove-nodes', {
                     params: { ids: ['nonexistent'] }
                 }, result)).rejectedWith(/Node nonexistent not found/)
-                mockRED.nodes.remove.called.should.be.false()
+                mockRED.actions.invoke.called.should.be.false()
             })
             it('should throw without removing anything if mix of valid and invalid IDs', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1' })
@@ -418,7 +407,7 @@ describeMain('expertAutomations', () => {
                 await should(expertAutomations.invokeAction('automation/remove-nodes', {
                     params: { ids: ['n1', 'bad'] }
                 }, result)).rejectedWith(/Node bad not found/)
-                mockRED.nodes.remove.called.should.be.false()
+                mockRED.actions.invoke.called.should.be.false()
             })
             it('should throw if node workspace is locked', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'locked-tab' })
@@ -427,7 +416,7 @@ describeMain('expertAutomations', () => {
                 await should(expertAutomations.invokeAction('automation/remove-nodes', {
                     params: { ids: ['n1'] }
                 }, result)).rejectedWith(/Workspace locked-tab is locked/)
-                mockRED.nodes.remove.called.should.be.false()
+                mockRED.actions.invoke.called.should.be.false()
             })
             it('should reject group IDs and return GROUP_OPERATION_REQUIRED error', async () => {
                 mockRED.nodes.group.withArgs('g1').returns({ id: 'g1', type: 'group' })
@@ -438,7 +427,19 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', false)
                 result.should.have.property('errorCode', 'GROUP_OPERATION_REQUIRED')
                 result.should.have.property('error').which.match(/group nodes/)
-                mockRED.nodes.remove.called.should.be.false()
+                mockRED.actions.invoke.called.should.be.false()
+            })
+            it('should reject nodes that are members of a group', async () => {
+                const mockNode = { id: 'n1', g: 'grp1' }
+                mockRED.nodes.node.withArgs('n1').returns(mockNode)
+                const result = {}
+                await expertAutomations.invokeAction('automation/remove-nodes', {
+                    params: { ids: ['n1'] }
+                }, result)
+                result.should.have.property('success', false)
+                result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
+                result.should.have.property('error').which.match(/member of a group/)
+                mockRED.actions.invoke.called.should.be.false()
             })
         })
         describe('setWires action', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1039,6 +1039,11 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('errorCode', 'GROUP_OPERATION_REQUIRED')
                 result.should.have.property('error').which.match(/group nodes/)
             })
+            it('should reject g property in add-nodes', async () => {
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1', g: 'grp1' }] }
+                }, {})).rejectedWith(/"g" cannot be set directly/)
+            })
         })
         describe('removeTab action', () => {
             it('should remove an existing tab', async () => {
@@ -1701,6 +1706,14 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', false)
                 result.should.have.property('errorCode', 'GROUP_OPERATION_REQUIRED')
                 result.should.have.property('error').which.match(/group nodes/)
+            })
+            it('should reject g property in update-node', async () => {
+                const node = { id: 'n1', type: 'inject', wires: [], changed: false, dirty: false }
+                mockRED.nodes.node.withArgs('n1').returns(node)
+                mockRED.nodes.group.withArgs('n1').returns(null)
+                await expertAutomations.invokeAction('automation/update-node', {
+                    params: { id: 'n1', properties: { g: 'grp1' } }
+                }, {}).should.be.rejectedWith(/"g" cannot be set directly/)
             })
         })
         describe('closeEditorTray action', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -429,14 +429,15 @@ describeMain('expertAutomations', () => {
                 }, result)).rejectedWith(/Workspace locked-tab is locked/)
                 mockRED.nodes.remove.called.should.be.false()
             })
-            it('should reject group IDs and return error directing to manage-groups', async () => {
+            it('should reject group IDs and return GROUP_OPERATION_REQUIRED error', async () => {
                 mockRED.nodes.group.withArgs('g1').returns({ id: 'g1', type: 'group' })
                 const result = {}
                 await expertAutomations.invokeAction('automation/remove-nodes', {
                     params: { ids: ['g1'] }
                 }, result)
                 result.should.have.property('success', false)
-                result.should.have.property('error').which.match(/manage-groups/)
+                result.should.have.property('errorCode', 'GROUP_OPERATION_REQUIRED')
+                result.should.have.property('error').which.match(/group nodes/)
                 mockRED.nodes.remove.called.should.be.false()
             })
         })
@@ -1029,13 +1030,14 @@ describeMain('expertAutomations', () => {
                     params: { nodes: [{ id: 'n1', z: 'tab1' }] }
                 }, result)).rejectedWith(/missing required property: type/)
             })
-            it('should reject group type and return error directing to manage-groups', async () => {
+            it('should reject group type and return GROUP_OPERATION_REQUIRED error', async () => {
                 const result = {}
                 await expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes: [{ id: 'g1', type: 'group', z: 'tab1' }] }
                 }, result)
                 result.should.have.property('success', false)
-                result.should.have.property('error').which.match(/manage-groups/)
+                result.should.have.property('errorCode', 'GROUP_OPERATION_REQUIRED')
+                result.should.have.property('error').which.match(/group nodes/)
             })
         })
         describe('removeTab action', () => {
@@ -1690,14 +1692,15 @@ describeMain('expertAutomations', () => {
                     }, result)).rejectedWith(/resolved to/)
                 })
             })
-            it('should reject group ID and return error directing to manage-groups', async () => {
+            it('should reject group ID and return GROUP_OPERATION_REQUIRED error', async () => {
                 mockRED.nodes.group.withArgs('g1').returns({ id: 'g1', type: 'group' })
                 const result = {}
                 await expertAutomations.invokeAction('automation/update-node', {
                     params: { id: 'g1', properties: { name: 'renamed' } }
                 }, result)
                 result.should.have.property('success', false)
-                result.should.have.property('error').which.match(/manage-groups/)
+                result.should.have.property('errorCode', 'GROUP_OPERATION_REQUIRED')
+                result.should.have.property('error').which.match(/group nodes/)
             })
         })
         describe('closeEditorTray action', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -34,6 +34,7 @@ describeMain('expertAutomations', () => {
             },
             nodes: {
                 node: sinon.stub(),
+                group: sinon.stub().returns(null),
                 getAllFlowNodes: sinon.stub(),
                 createExportableNodeSet: sinon.stub().callsFake((nodes) => nodes || []),
                 dirty: sinon.stub()
@@ -426,6 +427,16 @@ describeMain('expertAutomations', () => {
                 await should(expertAutomations.invokeAction('automation/remove-nodes', {
                     params: { ids: ['n1'] }
                 }, result)).rejectedWith(/Workspace locked-tab is locked/)
+                mockRED.nodes.remove.called.should.be.false()
+            })
+            it('should reject group IDs and return error directing to manage-groups', async () => {
+                mockRED.nodes.group.withArgs('g1').returns({ id: 'g1', type: 'group' })
+                const result = {}
+                await expertAutomations.invokeAction('automation/remove-nodes', {
+                    params: { ids: ['g1'] }
+                }, result)
+                result.should.have.property('success', false)
+                result.should.have.property('error').which.match(/manage-groups/)
                 mockRED.nodes.remove.called.should.be.false()
             })
         })
@@ -1017,6 +1028,14 @@ describeMain('expertAutomations', () => {
                 await should(expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes: [{ id: 'n1', z: 'tab1' }] }
                 }, result)).rejectedWith(/missing required property: type/)
+            })
+            it('should reject group type and return error directing to manage-groups', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'g1', type: 'group', z: 'tab1' }] }
+                }, result)
+                result.should.have.property('success', false)
+                result.should.have.property('error').which.match(/manage-groups/)
             })
         })
         describe('removeTab action', () => {
@@ -1670,6 +1689,15 @@ describeMain('expertAutomations', () => {
                         params: { id: 'n1', patches: [{ property: 'rules.5.to', op: 'replace', start: 1, end: 1, content: 'x' }] }
                     }, result)).rejectedWith(/resolved to/)
                 })
+            })
+            it('should reject group ID and return error directing to manage-groups', async () => {
+                mockRED.nodes.group.withArgs('g1').returns({ id: 'g1', type: 'group' })
+                const result = {}
+                await expertAutomations.invokeAction('automation/update-node', {
+                    params: { id: 'g1', properties: { name: 'renamed' } }
+                }, result)
+                result.should.have.property('success', false)
+                result.should.have.property('error').which.match(/manage-groups/)
             })
         })
         describe('closeEditorTray action', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1040,9 +1040,13 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('error').which.match(/group nodes/)
             })
             it('should reject g property in add-nodes', async () => {
-                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                const result = {}
+                await expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1', g: 'grp1' }] }
-                }, {})).rejectedWith(/"g" cannot be set directly/)
+                }, result)
+                result.should.have.property('success', false)
+                result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
+                result.should.have.property('error').which.match(/"g" cannot be set directly/)
             })
         })
         describe('removeTab action', () => {
@@ -1711,9 +1715,13 @@ describeMain('expertAutomations', () => {
                 const node = { id: 'n1', type: 'inject', wires: [], changed: false, dirty: false }
                 mockRED.nodes.node.withArgs('n1').returns(node)
                 mockRED.nodes.group.withArgs('n1').returns(null)
+                const result = {}
                 await expertAutomations.invokeAction('automation/update-node', {
                     params: { id: 'n1', properties: { g: 'grp1' } }
-                }, {}).should.be.rejectedWith(/"g" cannot be set directly/)
+                }, result)
+                result.should.have.property('success', false)
+                result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
+                result.should.have.property('error').which.match(/"g" cannot be set directly/)
             })
         })
         describe('closeEditorTray action', () => {


### PR DESCRIPTION
## Summary

- `add-nodes`: rejects any node with `type: group` — groups must be created via `automation/manage-groups`
- `update-node`: rejects calls where the target ID is a group — use `automation/manage-groups` to modify groups
- `remove-nodes`: rejects any ID that resolves to a group — use `automation/manage-groups` to delete groups

In all three cases the action returns a clear error message directing to the correct action rather than silently failing or producing an invalid canvas state.

## Test plan

- `add-nodes`: passing `type: group` throws and directs to `manage-groups`
- `update-node`: passing a group ID returns `success: false` with a `manage-groups` error message
- `remove-nodes`: passing a group ID throws and directs to `manage-groups`

Closes #321