### PR TITLE
feat(automation): hard-reject wires property in update-node

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -32,6 +32,8 @@ const ERROR_CODES = Object.freeze({
     FORBIDDEN_PROPERTY: 'FORBIDDEN_PROPERTY'
 })
 
+const LINK_NODE_TYPES = ['link in', 'link out', 'link call']
+
 /**
  * @typedef {SELECT_NODES
  *   |GET_NODES
@@ -1287,7 +1289,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 result.success = false
                 break
             }
-            if (params.properties && 'links' in params.properties) {
+            if (params.properties && 'links' in params.properties && LINK_NODE_TYPES.includes(this.RED.nodes.node(params.id)?.type)) {
                 result.error = `Node ${params.id}: "links" cannot be set directly — link connections must be managed via a dedicated action`
                 result.errorCode = ERROR_CODES.FORBIDDEN_PROPERTY
                 result.success = false
@@ -1384,7 +1386,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 result.success = false
                 break
             }
-            const linksNode = (params.nodes || []).find(n => n.links !== undefined)
+            const linksNode = (params.nodes || []).find(n => n.links !== undefined && LINK_NODE_TYPES.includes(n.type))
             if (linksNode) {
                 result.error = `Node ${linksNode.id}: "links" cannot be set directly — link connections must be managed via a dedicated action`
                 result.errorCode = ERROR_CODES.FORBIDDEN_PROPERTY

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -984,6 +984,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const prepared = nodes.map(rawNode => {
             if (!rawNode.id) throw new Error('Node is missing required property: id')
             if (!rawNode.type) throw new Error('Node is missing required property: type')
+            if (rawNode.wires !== undefined) throw new Error(`Node ${rawNode.id}: cannot set "wires" via add-nodes — use automation/set-wires to manage connections`)
             const def = this.RED.nodes.getType(rawNode.type)
             if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
             const isConfigNode = def.category === 'config'

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -597,6 +597,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (hasProperties && Object.keys(properties).length === 0) {
             throw new Error('"properties" must not be empty')
         }
+        if (hasProperties && 'wires' in properties) {
+            throw new Error(`Node ${id}: cannot set "wires" via update-node — use automation/set-wires to manage connections`)
+        }
         if (!hasProperties && !hasPatches) {
             throw new Error('At least one of "properties" or "patches" must be provided')
         }

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1287,6 +1287,12 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 result.success = false
                 break
             }
+            if (params.properties && 'links' in params.properties) {
+                result.error = `Node ${params.id}: "links" cannot be set directly — link connections must be managed via a dedicated action`
+                result.errorCode = ERROR_CODES.FORBIDDEN_PROPERTY
+                result.success = false
+                break
+            }
             if (params.properties && 'g' in params.properties) {
                 result.error = `Node ${params.id}: "g" cannot be set directly — group membership must be managed via a dedicated action`
                 result.errorCode = ERROR_CODES.FORBIDDEN_PROPERTY
@@ -1374,6 +1380,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
             const wiresNode = (params.nodes || []).find(n => n.wires !== undefined)
             if (wiresNode) {
                 result.error = `Node ${wiresNode.id}: "wires" cannot be set directly — wire connections must be managed via a dedicated action`
+                result.errorCode = ERROR_CODES.FORBIDDEN_PROPERTY
+                result.success = false
+                break
+            }
+            const linksNode = (params.nodes || []).find(n => n.links !== undefined)
+            if (linksNode) {
+                result.error = `Node ${linksNode.id}: "links" cannot be set directly — link connections must be managed via a dedicated action`
                 result.errorCode = ERROR_CODES.FORBIDDEN_PROPERTY
                 result.success = false
                 break

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -602,7 +602,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             throw new Error('"properties" must not be empty')
         }
         if (hasProperties && 'wires' in properties) {
-            throw new Error(`Node ${id}: cannot set "wires" via update-node — use automation/set-wires to manage connections`)
+            throw new Error(`Node ${id}: "wires" cannot be set directly — wire connections must be managed via a dedicated action`)
         }
         if (!hasProperties && !hasPatches) {
             throw new Error('At least one of "properties" or "patches" must be provided')
@@ -988,7 +988,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const prepared = nodes.map(rawNode => {
             if (!rawNode.id) throw new Error('Node is missing required property: id')
             if (!rawNode.type) throw new Error('Node is missing required property: type')
-            if (rawNode.wires !== undefined) throw new Error(`Node ${rawNode.id}: cannot set "wires" via add-nodes — use automation/set-wires to manage connections`)
+            if (rawNode.wires !== undefined) throw new Error(`Node ${rawNode.id}: "wires" cannot be set directly — wire connections must be managed via a dedicated action`)
             const def = this.RED.nodes.getType(rawNode.type)
             if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
             const isConfigNode = def.category === 'config'

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1699,6 +1699,14 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', false)
                 result.should.have.property('error').which.match(/manage-groups/)
             })
+            it('should reject wires property and direct to set-wires', async () => {
+                const node = { id: 'n1', type: 'inject', wires: [['n2']], changed: false, dirty: false }
+                mockRED.nodes.node.withArgs('n1').returns(node)
+                mockRED.nodes.group.withArgs('n1').returns(null)
+                await expertAutomations.invokeAction('automation/update-node', {
+                    params: { id: 'n1', properties: { wires: [['n3']] } }
+                }, {}).should.be.rejectedWith(/set-wires/)
+            })
         })
         describe('closeEditorTray action', () => {
             afterEach(() => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1051,7 +1051,7 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
                 result.should.have.property('error').which.match(/"wires" cannot be set directly/)
             })
-            it('should reject links property in add-nodes', async () => {
+            it('should reject links property in add-nodes for link node types', async () => {
                 const result = {}
                 await expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes: [{ id: 'lo1', type: 'link out', z: 'tab1', links: ['li1'] }] }
@@ -1059,6 +1059,15 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', false)
                 result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
                 result.should.have.property('error').which.match(/"links" cannot be set directly/)
+            })
+            it('should not reject links property in add-nodes for non-link node types', async () => {
+                const result = {}
+                try {
+                    await expertAutomations.invokeAction('automation/add-nodes', {
+                        params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1', links: ['something'] }] }
+                    }, result)
+                } catch (_) { /* may fail for unrelated reasons — only check no FORBIDDEN_PROPERTY */ }
+                result.should.not.have.property('errorCode', 'FORBIDDEN_PROPERTY')
             })
             it('should reject g property in add-nodes', async () => {
                 const result = {}
@@ -1779,7 +1788,7 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
                 result.should.have.property('error').which.match(/"wires" cannot be set directly/)
             })
-            it('should reject links property in update-node', async () => {
+            it('should reject links property in update-node for link node types', async () => {
                 const node = { id: 'lo1', type: 'link out', links: ['li1'], changed: false, dirty: false }
                 mockRED.nodes.node.withArgs('lo1').returns(node)
                 mockRED.nodes.group.withArgs('lo1').returns(null)
@@ -1790,6 +1799,21 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', false)
                 result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
                 result.should.have.property('error').which.match(/"links" cannot be set directly/)
+            })
+            it('should not reject links property in update-node for non-link node types', async () => {
+                const node = { id: 'n1', type: 'inject', links: ['something'], changed: false, dirty: false }
+                mockRED.nodes.node.withArgs('n1').returns(node)
+                mockRED.nodes.group.withArgs('n1').returns(null)
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.history = { push: sinon.stub() }
+                mockRED.editor = { validateNode: sinon.stub().callsFake(n => { n.valid = true }) }
+                mockRED.view.redraw = sinon.stub()
+                const result = {}
+                await expertAutomations.invokeAction('automation/update-node', {
+                    params: { id: 'n1', properties: { links: ['something-else'] } }
+                }, result)
+                result.should.not.have.property('errorCode', 'FORBIDDEN_PROPERTY')
+                result.should.have.property('success', true)
             })
             it('should reject g property in update-node', async () => {
                 const node = { id: 'n1', type: 'inject', wires: [], changed: false, dirty: false }

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1037,6 +1037,11 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', false)
                 result.should.have.property('error').which.match(/manage-groups/)
             })
+            it('should reject wires property and direct to set-wires', async () => {
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1', wires: [['n2']] }] }
+                }, {})).rejectedWith(/set-wires/)
+            })
         })
         describe('removeTab action', () => {
             it('should remove an existing tab', async () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1039,10 +1039,10 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('errorCode', 'GROUP_OPERATION_REQUIRED')
                 result.should.have.property('error').which.match(/group nodes/)
             })
-            it('should reject wires property and direct to set-wires', async () => {
+            it('should reject wires property in add-nodes', async () => {
                 await should(expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1', wires: [['n2']] }] }
-                }, {})).rejectedWith(/set-wires/)
+                }, {})).rejectedWith(/"wires" cannot be set directly/)
             })
         })
         describe('removeTab action', () => {
@@ -1707,13 +1707,13 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('errorCode', 'GROUP_OPERATION_REQUIRED')
                 result.should.have.property('error').which.match(/group nodes/)
             })
-            it('should reject wires property and direct to set-wires', async () => {
+            it('should reject wires property in update-node', async () => {
                 const node = { id: 'n1', type: 'inject', wires: [['n2']], changed: false, dirty: false }
                 mockRED.nodes.node.withArgs('n1').returns(node)
                 mockRED.nodes.group.withArgs('n1').returns(null)
                 await expertAutomations.invokeAction('automation/update-node', {
                     params: { id: 'n1', properties: { wires: [['n3']] } }
-                }, {}).should.be.rejectedWith(/set-wires/)
+                }, {}).should.be.rejectedWith(/"wires" cannot be set directly/)
             })
         })
         describe('closeEditorTray action', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1051,6 +1051,15 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
                 result.should.have.property('error').which.match(/"wires" cannot be set directly/)
             })
+            it('should reject links property in add-nodes', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'lo1', type: 'link out', z: 'tab1', links: ['li1'] }] }
+                }, result)
+                result.should.have.property('success', false)
+                result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
+                result.should.have.property('error').which.match(/"links" cannot be set directly/)
+            })
             it('should reject g property in add-nodes', async () => {
                 const result = {}
                 await expertAutomations.invokeAction('automation/add-nodes', {
@@ -1769,6 +1778,18 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('success', false)
                 result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
                 result.should.have.property('error').which.match(/"wires" cannot be set directly/)
+            })
+            it('should reject links property in update-node', async () => {
+                const node = { id: 'lo1', type: 'link out', links: ['li1'], changed: false, dirty: false }
+                mockRED.nodes.node.withArgs('lo1').returns(node)
+                mockRED.nodes.group.withArgs('lo1').returns(null)
+                const result = {}
+                await expertAutomations.invokeAction('automation/update-node', {
+                    params: { id: 'lo1', properties: { links: ['li2'] } }
+                }, result)
+                result.should.have.property('success', false)
+                result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
+                result.should.have.property('error').which.match(/"links" cannot be set directly/)
             })
             it('should reject g property in update-node', async () => {
                 const node = { id: 'n1', type: 'inject', wires: [], changed: false, dirty: false }


### PR DESCRIPTION
Closes #320

## Summary

- `automation/update-node`: throws if `properties` contains a `wires` key, or a `links` key when the node is of type `link in`, `link out`, or `link call` — connections must go through dedicated actions
- `automation/add-nodes`: same rejection — throws if any node definition has a `wires` key, or a `links` key on a link node type

## Test plan

- `update-node`: passing `properties: { wires: [...] }` throws with a message directing to the dedicated action
- `update-node`: passing `properties: { links: [...] }` on a `link out` node throws; on a non-link node it is allowed
- `add-nodes`: passing a node with a `wires` property throws with the same direction
- `add-nodes`: passing a `link out` node with a `links` property throws; a non-link node with `links` is allowed