### PR TITLE
feat(automation): migrate update-node to update-nodes (array params)

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -6,7 +6,7 @@ const GET_NODES = 'automation/get-nodes'
 const EDIT_NODE = 'automation/open-node-edit'
 const SEARCH = 'automation/search'
 const ADD_FLOW_TAB = 'automation/add-flow-tab'
-const UPDATE_NODE = 'automation/update-node'
+const UPDATE_NODES = 'automation/update-nodes'
 const SHOW_WORKSPACE = 'automation/show-workspace'
 const GET_FLOW = 'automation/get-workspace-nodes'
 const LIST_WORKSPACES = 'automation/list-workspaces'
@@ -33,7 +33,7 @@ const MANAGE_GROUPS = 'automation/manage-groups'
  *   |EDIT_NODE
  *   |SEARCH
  *   |ADD_FLOW_TAB
- *   |UPDATE_NODE
+ *   |UPDATE_NODES
  *   |SHOW_WORKSPACE
  *   |GET_FLOW
  *   |LIST_WORKSPACES
@@ -140,33 +140,43 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 }
             }
         },
-        [UPDATE_NODE]: {
+        [UPDATE_NODES]: {
             params: {
                 type: 'object',
                 properties: {
-                    id: { type: 'string', description: 'ID of the node to update' },
-                    properties: { type: 'object', description: 'Key-value pairs to merge into the node object' },
-                    patches: {
+                    nodes: {
                         type: 'array',
-                        description: 'Line-based partial edits for string properties. All line numbers reference the original content before any patches are applied.',
+                        description: 'Array of node updates to apply sequentially',
                         items: {
                             type: 'object',
                             properties: {
-                                property: { type: 'string', description: 'Dot-separated property path of the node to update. Use numeric segments to index arrays (e.g. "rules.0.to" for rules[0].to).' },
-                                op: {
-                                    type: 'string',
-                                    enum: ['replace', 'insert', 'delete'],
-                                    description: 'replace: replace lines start..end. insert: insert content before line start. delete: remove lines start..end.'
-                                },
-                                start: { type: 'number', description: 'Start line (1-indexed, inclusive)' },
-                                end: { type: 'number', description: 'End line (1-indexed, inclusive). Required for replace and delete.' },
-                                content: { type: 'string', description: 'Text to insert or replace with (\\n for multiple lines). Required for replace and insert.' }
+                                id: { type: 'string', description: 'ID of the node to update' },
+                                properties: { type: 'object', description: 'Key-value pairs to merge into the node object' },
+                                patches: {
+                                    type: 'array',
+                                    description: 'Line-based partial edits for string properties. All line numbers reference the original content before any patches are applied.',
+                                    items: {
+                                        type: 'object',
+                                        properties: {
+                                            property: { type: 'string', description: 'Dot-separated property path of the node to update. Use numeric segments to index arrays (e.g. "rules.0.to" for rules[0].to).' },
+                                            op: {
+                                                type: 'string',
+                                                enum: ['replace', 'insert', 'delete'],
+                                                description: 'replace: replace lines start..end. insert: insert content before line start. delete: remove lines start..end.'
+                                            },
+                                            start: { type: 'number', description: 'Start line (1-indexed, inclusive)' },
+                                            end: { type: 'number', description: 'End line (1-indexed, inclusive). Required for replace and delete.' },
+                                            content: { type: 'string', description: 'Text to insert or replace with (\\n for multiple lines). Required for replace and insert.' }
+                                        },
+                                        required: ['property', 'op', 'start']
+                                    }
+                                }
                             },
-                            required: ['property', 'op', 'start']
+                            required: ['id']
                         }
                     }
                 },
-                required: ['id']
+                required: ['nodes']
             }
         },
         [SHOW_WORKSPACE]: {
@@ -1263,16 +1273,20 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
-        case UPDATE_NODE: {
-            if (this.RED.nodes.group(params.id)) {
-                result.error = 'Groups cannot be modified via update-node. Use automation/manage-groups instead.'
+        case UPDATE_NODES: {
+            const groupIds = (params.nodes || []).filter(n => this.RED.nodes.group(n.id)).map(n => n.id)
+            if (groupIds.length > 0) {
+                result.error = `Groups cannot be modified via update-nodes. Use automation/manage-groups instead. Group IDs: ${groupIds.join(', ')}`
                 result.success = false
                 break
             }
-            await this.updateNode(params.id, params.properties, params.patches)
-            const updatedNode = this.RED.nodes.node(params.id)
-            result.data = this._summarizeNode(updatedNode)
-            result.validation = this._getNodeValidation(updatedNode)
+            for (const { id, properties, patches } of params.nodes) {
+                await this.updateNode(id, properties, patches)
+            }
+            result.data = params.nodes.map(({ id }) => {
+                const updatedNode = this.RED.nodes.node(id)
+                return { ...this._summarizeNode(updatedNode), validation: this._getNodeValidation(updatedNode) }
+            })
             result.success = true
         }
             break

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -609,18 +609,29 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
     /**
      * Update properties of an existing node in place.
-     * Supports full property replacement via `properties` and/or line-based
-     * partial edits via `patches`. At least one must be provided.
+     * Accepts a unified updates array where each item targets a property.
+     * Omit start/end for full replacement; provide start for line-based edits.
      * @param {string} id - node ID
-     * @param {Object} [properties] - key-value pairs to merge into the node
-     * @param {Array} [patches] - line-based partial edits: { property, op, start, end?, content? }
+     * @param {Array} updates - [{ property, op, start?, end?, content? }]
      */
-    async updateNode (id, properties, patches) {
-        const hasProperties = properties !== undefined && properties !== null
-        const hasPatches = Array.isArray(patches) && patches.length > 0
-        if (hasProperties && Object.keys(properties).length === 0) {
-            throw new Error('"properties" must not be empty')
+    async updateNode (id, updates) {
+        const properties = {}
+        const patches = []
+        for (const update of updates) {
+            if (typeof update.start === 'number') {
+                patches.push({
+                    property: update.property,
+                    op: update.op,
+                    start: update.start,
+                    ...(update.end !== undefined ? { end: update.end } : {}),
+                    ...(update.content !== undefined ? { content: update.content } : {})
+                })
+            } else {
+                properties[update.property] = update.content
+            }
         }
+        const hasProperties = Object.keys(properties).length > 0
+        const hasPatches = patches.length > 0
         if (!hasProperties && !hasPatches) {
             throw new Error('At least one of "properties" or "patches" must be provided')
         }
@@ -1315,26 +1326,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 break
             }
             for (const { id, updates = [] } of params.nodes) {
-                const properties = {}
-                const patches = []
-                for (const update of updates) {
-                    if (typeof update.start === 'number') {
-                        patches.push({
-                            property: update.property,
-                            op: update.op,
-                            start: update.start,
-                            ...(update.end !== undefined ? { end: update.end } : {}),
-                            ...(update.content !== undefined ? { content: update.content } : {})
-                        })
-                    } else {
-                        properties[update.property] = update.content
-                    }
-                }
-                await this.updateNode(
-                    id,
-                    Object.keys(properties).length > 0 ? properties : undefined,
-                    patches.length > 0 ? patches : undefined
-                )
+                await this.updateNode(id, updates)
             }
             result.data = params.nodes.map(({ id }) => {
                 const updatedNode = this.RED.nodes.node(id)

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -80,7 +80,7 @@ describeMain('expertAutomations', () => {
                 'automation/open-node-edit',
                 'automation/search',
                 'automation/add-flow-tab',
-                'automation/update-node',
+                'automation/update-nodes',
                 'automation/show-workspace',
                 'automation/get-workspace-nodes',
                 'automation/list-workspaces',
@@ -1248,7 +1248,7 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('flows').which.deepEqual([])
             })
         })
-        describe('updateNode action', () => {
+        describe('updateNodes action', () => {
             it('should update node properties with history and changed flag', async () => {
                 const mockNode = { id: 'n1', name: 'old', changed: false }
                 mockRED.nodes.node.withArgs('n1').returns(mockNode)
@@ -1257,8 +1257,8 @@ describeMain('expertAutomations', () => {
                 mockRED.editor = { validateNode: sinon.stub().callsFake(n => { n.valid = true }) }
                 mockRED.view.redraw = sinon.stub()
                 const result = {}
-                await expertAutomations.invokeAction('automation/update-node', {
-                    params: { id: 'n1', properties: { name: 'new' } }
+                await expertAutomations.invokeAction('automation/update-nodes', {
+                    params: { nodes: [{ id: 'n1', properties: { name: 'new' } }] }
                 }, result)
                 mockNode.name.should.equal('new')
                 mockNode.changed.should.be.true()
@@ -1273,10 +1273,10 @@ describeMain('expertAutomations', () => {
                 mockRED.view.updateActive.calledOnce.should.be.true()
                 mockRED.view.redraw.calledOnce.should.be.true()
                 result.should.have.property('success', true)
-                result.should.have.property('data').which.is.an.Object()
-                result.data.should.have.property('id', 'n1')
-                result.data.should.have.property('name', 'new')
-                result.should.have.property('validation').which.deepEqual({ valid: true })
+                result.should.have.property('data').which.is.an.Array()
+                result.data[0].should.have.property('id', 'n1')
+                result.data[0].should.have.property('name', 'new')
+                result.data[0].should.have.property('validation').which.deepEqual({ valid: true })
             })
             it('should return validation errors after update', async () => {
                 const mockNode = { id: 'n1', repeat: 'bad', changed: false }
@@ -1286,11 +1286,11 @@ describeMain('expertAutomations', () => {
                 mockRED.editor = { validateNode: sinon.stub().callsFake(n => { n.valid = false; n.validationErrors = ['repeat'] }) }
                 mockRED.view.redraw = sinon.stub()
                 const result = {}
-                await expertAutomations.invokeAction('automation/update-node', {
-                    params: { id: 'n1', properties: { repeat: 'bad' } }
+                await expertAutomations.invokeAction('automation/update-nodes', {
+                    params: { nodes: [{ id: 'n1', properties: { repeat: 'bad' } }] }
                 }, result)
                 result.should.have.property('success', true)
-                result.should.have.property('validation').which.deepEqual({ valid: false, validationErrors: ['repeat'] })
+                result.data[0].should.have.property('validation').which.deepEqual({ valid: false, validationErrors: ['repeat'] })
             })
             it('should capture old values correctly before applying changes', async () => {
                 const mockNode = { id: 'n1', name: 'original', x: 100, changed: true }
@@ -1299,8 +1299,8 @@ describeMain('expertAutomations', () => {
                 mockRED.history = { push: sinon.stub() }
                 mockRED.view.redraw = sinon.stub()
                 const result = {}
-                await expertAutomations.invokeAction('automation/update-node', {
-                    params: { id: 'n1', properties: { name: 'updated', x: 200 } }
+                await expertAutomations.invokeAction('automation/update-nodes', {
+                    params: { nodes: [{ id: 'n1', properties: { name: 'updated', x: 200 } }] }
                 }, result)
                 const historyArg = mockRED.history.push.firstCall.args[0]
                 historyArg.changes.should.deepEqual({ name: 'original', x: 100 })
@@ -1312,15 +1312,15 @@ describeMain('expertAutomations', () => {
                 const mockNode = { id: 'n1', changed: false }
                 mockRED.nodes.node.withArgs('n1').returns(mockNode)
                 const result = {}
-                await should(expertAutomations.invokeAction('automation/update-node', {
-                    params: { id: 'n1', properties: {} }
+                await should(expertAutomations.invokeAction('automation/update-nodes', {
+                    params: { nodes: [{ id: 'n1', properties: {} }] }
                 }, result)).rejectedWith(/"properties" must not be empty/)
             })
             it('should throw if node not found', async () => {
                 mockRED.nodes.node.returns(null)
                 const result = {}
-                await should(expertAutomations.invokeAction('automation/update-node', {
-                    params: { id: 'missing', properties: { name: 'x' } }
+                await should(expertAutomations.invokeAction('automation/update-nodes', {
+                    params: { nodes: [{ id: 'missing', properties: { name: 'x' } }] }
                 }, result)).rejectedWith(/Node missing not found/)
             })
             describe('patches', () => {
@@ -1342,8 +1342,8 @@ describeMain('expertAutomations', () => {
                 it('should replace a single line', async () => {
                     const mockNode = setupPatchNode({ func: 'a\nb\nc' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 2, end: 2, content: 'B' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 2, end: 2, content: 'B' }] }] }
                     }, result)
                     mockNode.func.should.equal('a\nB\nc')
                     result.should.have.property('success', true)
@@ -1351,37 +1351,39 @@ describeMain('expertAutomations', () => {
                 it('should replace a range with fewer lines', async () => {
                     const mockNode = setupPatchNode({ func: 'a\nb\nc\nd' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 2, end: 3, content: 'X' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 2, end: 3, content: 'X' }] }] }
                     }, result)
                     mockNode.func.should.equal('a\nX\nd')
                 })
                 it('should replace a range with more lines', async () => {
                     const mockNode = setupPatchNode({ func: 'a\nb\nc' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 2, end: 2, content: 'X\nY\nZ' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 2, end: 2, content: 'X\nY\nZ' }] }] }
                     }, result)
                     mockNode.func.should.equal('a\nX\nY\nZ\nc')
                 })
                 it('should delete lines with op delete', async () => {
                     const mockNode = setupPatchNode({ func: 'a\nb\nc\nd' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'delete', start: 2, end: 3 }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'delete', start: 2, end: 3 }] }] }
                     }, result)
                     mockNode.func.should.equal('a\nd')
                 })
                 it('should apply multiple non-overlapping patches bottom-up', async () => {
                     const mockNode = setupPatchNode()
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
+                    await expertAutomations.invokeAction('automation/update-nodes', {
                         params: {
-                            id: 'n1',
-                            patches: [
-                                { property: 'func', op: 'replace', start: 1, end: 1, content: 'TOP' },
-                                { property: 'func', op: 'replace', start: 4, end: 5, content: 'BOTTOM' }
-                            ]
+                            nodes: [{
+                                id: 'n1',
+                                patches: [
+                                    { property: 'func', op: 'replace', start: 1, end: 1, content: 'TOP' },
+                                    { property: 'func', op: 'replace', start: 4, end: 5, content: 'BOTTOM' }
+                                ]
+                            }]
                         }
                     }, result)
                     mockNode.func.should.equal('TOP\nline2\nline3\nBOTTOM')
@@ -1389,13 +1391,15 @@ describeMain('expertAutomations', () => {
                 it('should patch different properties independently', async () => {
                     const mockNode = setupPatchNode({ template: 'h1\nh2\nh3' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
+                    await expertAutomations.invokeAction('automation/update-nodes', {
                         params: {
-                            id: 'n1',
-                            patches: [
-                                { property: 'func', op: 'replace', start: 1, end: 1, content: 'FUNC' },
-                                { property: 'template', op: 'replace', start: 2, end: 2, content: 'H2' }
-                            ]
+                            nodes: [{
+                                id: 'n1',
+                                patches: [
+                                    { property: 'func', op: 'replace', start: 1, end: 1, content: 'FUNC' },
+                                    { property: 'template', op: 'replace', start: 2, end: 2, content: 'H2' }
+                                ]
+                            }]
                         }
                     }, result)
                     mockNode.func.should.equal('FUNC\nline2\nline3\nline4\nline5')
@@ -1404,11 +1408,13 @@ describeMain('expertAutomations', () => {
                 it('should support patches together with properties', async () => {
                     const mockNode = setupPatchNode()
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
+                    await expertAutomations.invokeAction('automation/update-nodes', {
                         params: {
-                            id: 'n1',
-                            properties: { name: 'Patched' },
-                            patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'FIRST' }]
+                            nodes: [{
+                                id: 'n1',
+                                properties: { name: 'Patched' },
+                                patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'FIRST' }]
+                            }]
                         }
                     }, result)
                     mockNode.name.should.equal('Patched')
@@ -1420,8 +1426,8 @@ describeMain('expertAutomations', () => {
                 it('should record original value in history for undo', async () => {
                     const mockNode = setupPatchNode({ func: 'old\ncode' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'new' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'new' }] }] }
                     }, result)
                     mockNode.func.should.equal('new\ncode')
                     const historyArg = mockRED.history.push.firstCall.args[0]
@@ -1430,37 +1436,39 @@ describeMain('expertAutomations', () => {
                 it('should insert lines after the last line (append)', async () => {
                     const mockNode = setupPatchNode({ func: 'a\nb' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'insert', start: 3, content: 'c\nd' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'insert', start: 3, content: 'c\nd' }] }] }
                     }, result)
                     mockNode.func.should.equal('a\nb\nc\nd')
                 })
                 it('should insert lines before the first line (prepend)', async () => {
                     const mockNode = setupPatchNode({ func: 'a\nb' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'insert', start: 1, content: 'z' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'insert', start: 1, content: 'z' }] }] }
                     }, result)
                     mockNode.func.should.equal('z\na\nb')
                 })
                 it('should insert lines between existing lines', async () => {
                     const mockNode = setupPatchNode({ func: 'a\nb\nc' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'insert', start: 3, content: 'inserted' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'insert', start: 3, content: 'inserted' }] }] }
                     }, result)
                     mockNode.func.should.equal('a\nb\ninserted\nc')
                 })
                 it('should replace last line and append new lines in one call', async () => {
                     const mockNode = setupPatchNode()
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
+                    await expertAutomations.invokeAction('automation/update-nodes', {
                         params: {
-                            id: 'n1',
-                            patches: [
-                                { property: 'func', op: 'replace', start: 5, end: 5, content: 'return [msg, null];' },
-                                { property: 'func', op: 'insert', start: 6, content: '// appended' }
-                            ]
+                            nodes: [{
+                                id: 'n1',
+                                patches: [
+                                    { property: 'func', op: 'replace', start: 5, end: 5, content: 'return [msg, null];' },
+                                    { property: 'func', op: 'insert', start: 6, content: '// appended' }
+                                ]
+                            }]
                         }
                     }, result)
                     mockNode.func.should.equal('line1\nline2\nline3\nline4\nreturn [msg, null];\n// appended')
@@ -1468,13 +1476,15 @@ describeMain('expertAutomations', () => {
                 it('should prepend new lines and replace first line in one call', async () => {
                     const mockNode = setupPatchNode()
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
+                    await expertAutomations.invokeAction('automation/update-nodes', {
                         params: {
-                            id: 'n1',
-                            patches: [
-                                { property: 'func', op: 'insert', start: 1, content: '// header' },
-                                { property: 'func', op: 'replace', start: 1, end: 1, content: 'FIRST' }
-                            ]
+                            nodes: [{
+                                id: 'n1',
+                                patches: [
+                                    { property: 'func', op: 'insert', start: 1, content: '// header' },
+                                    { property: 'func', op: 'replace', start: 1, end: 1, content: 'FIRST' }
+                                ]
+                            }]
                         }
                     }, result)
                     mockNode.func.should.equal('// header\nFIRST\nline2\nline3\nline4\nline5')
@@ -1482,40 +1492,40 @@ describeMain('expertAutomations', () => {
                 it('should patch a single-line property', async () => {
                     const mockNode = setupPatchNode({ func: 'only line' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'replaced' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'replaced' }] }] }
                     }, result)
                     mockNode.func.should.equal('replaced')
                 })
                 it('should auto-detect tab separator and preserve it', async () => {
                     const mockNode = setupPatchNode({ func: '$sum(items.price)\t* discount\t+ shipping' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 2, end: 2, content: '* (discount + loyalty)' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 2, end: 2, content: '* (discount + loyalty)' }] }] }
                     }, result)
                     mockNode.func.should.equal('$sum(items.price)\t* (discount + loyalty)\t+ shipping')
                 })
                 it('should insert with tab separator when target uses tabs', async () => {
                     const mockNode = setupPatchNode({ func: 'a\tb\tc' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'insert', start: 4, content: 'd' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'insert', start: 4, content: 'd' }] }] }
                     }, result)
                     mockNode.func.should.equal('a\tb\tc\td')
                 })
                 it('should delete with tab separator when target uses tabs', async () => {
                     const mockNode = setupPatchNode({ func: 'a\tb\tc\td' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'delete', start: 2, end: 3 }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'delete', start: 2, end: 3 }] }] }
                     }, result)
                     mockNode.func.should.equal('a\td')
                 })
                 it('should use newline when value contains both tabs and newlines', async () => {
                     const mockNode = setupPatchNode({ func: 'line1\nline2\twith tab\nline3' })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 2, end: 2, content: 'replaced' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 2, end: 2, content: 'replaced' }] }] }
                     }, result)
                     mockNode.func.should.equal('line1\nreplaced\nline3')
                 })
@@ -1524,10 +1534,12 @@ describeMain('expertAutomations', () => {
                         rules: [{ from: 'msg.payload', to: '$sum(items.price)\n* 1.0', type: 'jsonata' }]
                     })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
+                    await expertAutomations.invokeAction('automation/update-nodes', {
                         params: {
-                            id: 'n1',
-                            patches: [{ property: 'rules.0.to', op: 'replace', start: 2, end: 2, content: '* 1.2' }]
+                            nodes: [{
+                                id: 'n1',
+                                patches: [{ property: 'rules.0.to', op: 'replace', start: 2, end: 2, content: '* 1.2' }]
+                            }]
                         }
                     }, result)
                     mockNode.rules[0].to.should.equal('$sum(items.price)\n* 1.2')
@@ -1542,13 +1554,15 @@ describeMain('expertAutomations', () => {
                         ]
                     })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
+                    await expertAutomations.invokeAction('automation/update-nodes', {
                         params: {
-                            id: 'n1',
-                            patches: [
-                                { property: 'rules.0.to', op: 'replace', start: 1, end: 1, content: 'LINE1' },
-                                { property: 'rules.1.to', op: 'replace', start: 2, end: 2, content: 'BBB' }
-                            ]
+                            nodes: [{
+                                id: 'n1',
+                                patches: [
+                                    { property: 'rules.0.to', op: 'replace', start: 1, end: 1, content: 'LINE1' },
+                                    { property: 'rules.1.to', op: 'replace', start: 2, end: 2, content: 'BBB' }
+                                ]
+                            }]
                         }
                     }, result)
                     mockNode.rules[0].to.should.equal('LINE1\nline2')
@@ -1558,8 +1572,8 @@ describeMain('expertAutomations', () => {
                     setupPatchNode()
                     mockRED.sidebar = { info: { refresh: sinon.stub() } }
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'X' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'X' }] }] }
                     }, result)
                     mockRED.sidebar.info.refresh.calledOnce.should.be.true()
                 })
@@ -1573,8 +1587,8 @@ describeMain('expertAutomations', () => {
                     })
                     global.$ = sinon.stub().returns({ trigger: triggerStub })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'X' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'X' }] }] }
                     }, result)
                     triggerStub.calledWith('click').should.be.true()
                     result.should.have.property('success', true)
@@ -1584,8 +1598,8 @@ describeMain('expertAutomations', () => {
                     setupPatchNode()
                     global.$ = sinon.stub().returns({ trigger: sinon.stub() })
                     const result = {}
-                    await expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'X' }] }
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'X' }] }] }
                     }, result)
                     global.$.called.should.be.false()
                     delete global.$
@@ -1593,113 +1607,115 @@ describeMain('expertAutomations', () => {
                 it('should throw if start > end for replace', async () => {
                     setupPatchNode()
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 5, end: 2, content: 'x' }] }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 5, end: 2, content: 'x' }] }] }
                     }, result)).rejectedWith(/Invalid patch range/)
                 })
                 it('should throw if end exceeds line count', async () => {
                     setupPatchNode({ func: 'a\nb' })
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 999, content: 'x' }] }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 999, content: 'x' }] }] }
                     }, result)).rejectedWith(/exceeds line count/)
                 })
                 it('should throw if property is not a string', async () => {
                     setupPatchNode()
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'x', op: 'replace', start: 1, end: 1, content: '100' }] }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'x', op: 'replace', start: 1, end: 1, content: '100' }] }] }
                     }, result)).rejectedWith(/not a string/)
                 })
                 it('should throw on overlapping replace patches', async () => {
                     setupPatchNode()
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
                         params: {
-                            id: 'n1',
-                            patches: [
-                                { property: 'func', op: 'replace', start: 1, end: 3, content: 'a' },
-                                { property: 'func', op: 'replace', start: 2, end: 4, content: 'b' }
-                            ]
+                            nodes: [{
+                                id: 'n1',
+                                patches: [
+                                    { property: 'func', op: 'replace', start: 1, end: 3, content: 'a' },
+                                    { property: 'func', op: 'replace', start: 2, end: 4, content: 'b' }
+                                ]
+                            }]
                         }
                     }, result)).rejectedWith(/Overlapping patches/)
                 })
                 it('should throw if neither properties nor patches provided', async () => {
                     setupPatchNode()
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1' }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1' }] }
                     }, result)).rejectedWith(/At least one of/)
                 })
                 it('should throw if node not found with patches', async () => {
                     mockRED.nodes.node.returns(null)
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'missing', patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'x' }] }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'missing', patches: [{ property: 'func', op: 'replace', start: 1, end: 1, content: 'x' }] }] }
                     }, result)).rejectedWith(/Node missing not found/)
                 })
                 it('should throw if start is not a positive integer', async () => {
                     setupPatchNode()
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 0, end: 1, content: 'x' }] }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 0, end: 1, content: 'x' }] }] }
                     }, result)).rejectedWith(/must be a positive integer/)
                 })
                 it('should throw if insert position exceeds line count + 1', async () => {
                     setupPatchNode({ func: 'a\nb' })
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'insert', start: 4, content: 'x' }] }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'insert', start: 4, content: 'x' }] }] }
                     }, result)).rejectedWith(/exceeds line count/)
                 })
                 it('should throw if replace is missing end', async () => {
                     setupPatchNode()
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, content: 'x' }] }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, content: 'x' }] }] }
                     }, result)).rejectedWith(/requires "end"/)
                 })
                 it('should throw if replace is missing content', async () => {
                     setupPatchNode()
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 1 }] }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'replace', start: 1, end: 1 }] }] }
                     }, result)).rejectedWith(/requires "content"/)
                 })
                 it('should throw if delete is missing end', async () => {
                     setupPatchNode()
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'delete', start: 1 }] }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'delete', start: 1 }] }] }
                     }, result)).rejectedWith(/requires "end"/)
                 })
                 it('should throw if insert is missing content', async () => {
                     setupPatchNode()
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'insert', start: 1 }] }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'insert', start: 1 }] }] }
                     }, result)).rejectedWith(/requires "content"/)
                 })
                 it('should throw on unknown op', async () => {
                     setupPatchNode()
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'func', op: 'move', start: 1 }] }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'func', op: 'move', start: 1 }] }] }
                     }, result)).rejectedWith(/Unknown patch op/)
                 })
                 it('should throw if nested path cannot be resolved', async () => {
                     setupPatchNode({ rules: [{ to: 'value' }] })
                     const result = {}
-                    await should(expertAutomations.invokeAction('automation/update-node', {
-                        params: { id: 'n1', patches: [{ property: 'rules.5.to', op: 'replace', start: 1, end: 1, content: 'x' }] }
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', patches: [{ property: 'rules.5.to', op: 'replace', start: 1, end: 1, content: 'x' }] }] }
                     }, result)).rejectedWith(/resolved to/)
                 })
             })
             it('should reject group ID and return error directing to manage-groups', async () => {
                 mockRED.nodes.group.withArgs('g1').returns({ id: 'g1', type: 'group' })
                 const result = {}
-                await expertAutomations.invokeAction('automation/update-node', {
-                    params: { id: 'g1', properties: { name: 'renamed' } }
+                await expertAutomations.invokeAction('automation/update-nodes', {
+                    params: { nodes: [{ id: 'g1', properties: { name: 'renamed' } }] }
                 }, result)
                 result.should.have.property('success', false)
                 result.should.have.property('error').which.match(/manage-groups/)
@@ -1708,8 +1724,8 @@ describeMain('expertAutomations', () => {
                 const node = { id: 'n1', type: 'inject', wires: [['n2']], changed: false, dirty: false }
                 mockRED.nodes.node.withArgs('n1').returns(node)
                 mockRED.nodes.group.withArgs('n1').returns(null)
-                await expertAutomations.invokeAction('automation/update-node', {
-                    params: { id: 'n1', properties: { wires: [['n3']] } }
+                await expertAutomations.invokeAction('automation/update-nodes', {
+                    params: { nodes: [{ id: 'n1', properties: { wires: [['n3']] } }] }
                 }, {}).should.be.rejectedWith(/set-wires/)
             })
         })


### PR DESCRIPTION
Closes #325

## Summary

- Renames `automation/update-node` to `automation/update-nodes`
- Replaces the separate `properties`/`patches` params with a single `updates` array — each item targets a property by name and supports two modes:
  - Full replacement: `{ property: "name", op: "replace", content: "My Node" }` — omit `start`/`end`
  - Line-based edit: `{ property: "func", op: "replace", start: 1, end: 3, content: "new code" }` — provide `start` (and `end` for replace/delete)
- The action now does the full/line split internally, matching the MCP tool input schema exactly — `start` is optional throughout
- Accepts multiple node entries in one call; result changes from `{ data: {...}, validation: {...} }` to `{ data: [{ ...summary, validation }] }` — one entry per node
- Adds wires, links (link-type nodes only), and g rejection checks, consistent with `add-nodes`
- MCP tool updated to pass `updates` directly without pre-splitting

## Test plan

- All property update tests migrated to `updates` array format
- All line-based patch tests migrated to `updates` array format with `start`
- Full replacement and line-based edits combined in one call
- Group rejection, wires rejection, links rejection (link node types only), and g rejection tests updated