### PR TITLE
fix(automation): move node to tab via link nodes instead of direct z change

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -608,6 +608,83 @@ export class ExpertAutomations extends ExpertActionsInterface {
     }
 
     /**
+     * Move a node to a different tab, creating link in/out pairs for any cross-tab wires.
+     * Uses core:split-wires-with-junctions first when multiple upstream or downstream nodes exist,
+     * then core:split-wire-with-link-nodes to create the link pairs. The node and its adjacent
+     * link nodes are moved to the target tab via RED.nodes.moveNodeToTab.
+     * @param {string} id - node ID to move
+     * @param {string} targetTabId - target tab ID
+     */
+    _moveNodeToTab (id, targetTabId) {
+        const node = this.RED.nodes.node(id)
+        if (!node) throw new Error(`Node ${id} not found`)
+
+        this._assertWorkspaceExists(targetTabId)
+        this._assertWorkspaceNotLocked(targetTabId)
+        this._assertWorkspaceNotLocked(node.z)
+
+        // Show source tab so link nodes are created on the correct workspace
+        this.RED.workspaces.show(node.z)
+
+        // Use getNodes for upstream/downstream counts (excludes self from upstream result)
+        const upstreamNodes = (this.getNodes(id, 'upstream') || []).filter(n => n.id !== id)
+        const downstreamNodeIds = (node.wires || []).flat()
+        const downstreamNodes = this.getNodes(downstreamNodeIds) || []
+
+        // Get wire objects for the core actions (PORT_TYPE_INPUT = 1, PORT_TYPE_OUTPUT = 0)
+        let inboundWires = this.RED.nodes.getNodeLinks(id, 1)
+        let outboundWires = this.RED.nodes.getNodeLinks(id, 0)
+
+        // Add junctions first when multiple upstream or downstream nodes share a wire boundary
+        let junctionNodes = []
+        if (upstreamNodes.length > 1 || downstreamNodes.length > 1) {
+            this.RED.actions.invoke('core:split-wires-with-junctions', {
+                wires: [...inboundWires, ...outboundWires]
+            })
+            // Re-fetch wires after junction insertion
+            inboundWires = this.RED.nodes.getNodeLinks(id, 1)
+            outboundWires = this.RED.nodes.getNodeLinks(id, 0)
+            // Collect newly created junction nodes (they stay on the source tab)
+            junctionNodes = [
+                ...inboundWires.filter(l => l.source.type === 'junction').map(l => l.source),
+                ...outboundWires.filter(l => l.target.type === 'junction').map(l => l.target)
+            ]
+        }
+
+        // Existing adjacent link nodes (from a previous tab move) are moved directly — no new pair needed
+        const existingLinkIns = inboundWires.filter(l => l.source.type === 'link in').map(l => l.source)
+        const existingLinkOuts = outboundWires.filter(l => l.target.type === 'link out').map(l => l.target)
+
+        // Only split wires where the adjacent node is not already a link node
+        const wiresToSplit = [
+            ...inboundWires.filter(l => l.source.type !== 'link in'),
+            ...outboundWires.filter(l => l.target.type !== 'link out')
+        ]
+
+        const linkNodesToMove = [...existingLinkIns, ...existingLinkOuts]
+
+        if (wiresToSplit.length > 0) {
+            this.RED.view.select({ links: wiresToSplit })
+            this.RED.actions.invoke('core:split-wire-with-link-nodes')
+
+            // Collect the newly created link nodes adjacent to the moved node
+            const newInbound = this.RED.nodes.getNodeLinks(id, 1)
+            const newOutbound = this.RED.nodes.getNodeLinks(id, 0)
+            linkNodesToMove.push(...newInbound.map(l => l.source).filter(n => n.type === 'link in'))
+            linkNodesToMove.push(...newOutbound.map(l => l.target).filter(n => n.type === 'link out'))
+        }
+
+        for (const n of [node, ...linkNodesToMove]) {
+            this.RED.nodes.moveNodeToTab(n, targetTabId)
+        }
+
+        this.RED.nodes.dirty(true)
+        this.RED.view.redraw(true)
+
+        return { linkNodes: linkNodesToMove, junctionNodes }
+    }
+
+    /**
      * Update properties of an existing node in place.
      * Accepts a unified updates array where each item targets a property.
      * Omit start/end for full replacement; provide start for line-based edits.
@@ -1325,13 +1402,28 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 result.success = false
                 break
             }
+            const allLinkNodes = []
+            const allJunctionNodes = []
             for (const { id, updates = [] } of params.nodes) {
-                await this.updateNode(id, updates)
+                const zUpdate = updates.find(u => u.property === 'z' && typeof u.content === 'string')
+                if (zUpdate) {
+                    const { linkNodes, junctionNodes } = this._moveNodeToTab(id, zUpdate.content)
+                    allLinkNodes.push(...linkNodes)
+                    allJunctionNodes.push(...junctionNodes)
+                    const remainingUpdates = updates.filter(u => u.property !== 'z')
+                    if (remainingUpdates.length > 0) {
+                        await this.updateNode(id, remainingUpdates)
+                    }
+                } else {
+                    await this.updateNode(id, updates)
+                }
             }
-            result.data = params.nodes.map(({ id }) => {
-                const updatedNode = this.RED.nodes.node(id)
-                return { ...this._summarizeNode(updatedNode), validation: this._getNodeValidation(updatedNode) }
-            })
+            const summarize = n => ({ ...this._summarizeNode(n), validation: this._getNodeValidation(n) })
+            result.data = [
+                ...params.nodes.map(({ id }) => summarize(this.RED.nodes.node(id))),
+                ...allLinkNodes.map(summarize),
+                ...allJunctionNodes.map(summarize)
+            ]
             result.success = true
         }
             break

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -609,13 +609,15 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
     /**
      * Move a node to a different tab, creating link in/out pairs for any cross-tab wires.
-     * Uses core:split-wires-with-junctions first when multiple upstream or downstream nodes exist,
-     * then core:split-wire-with-link-nodes to create the link pairs. The node and its adjacent
-     * link nodes are moved to the target tab via RED.nodes.moveNodeToTab.
+     * Uses core:split-wires-with-junctions first only for fan-in (multiple inbound) or fan-out
+     * (multiple wires from the same output port), then core:split-wire-with-link-nodes for the
+     * remaining single wires. The node and its adjacent link nodes are moved to the target tab.
      * @param {string} id - node ID to move
      * @param {string} targetTabId - target tab ID
+     * @param {Set<string>} [coMovingIds] - IDs of all nodes being moved to the same tab in this batch;
+     *   wires between co-moving nodes are kept intact (no splitting).
      */
-    _moveNodeToTab (id, targetTabId) {
+    _moveNodeToTab (id, targetTabId, coMovingIds = new Set()) {
         const node = this.RED.nodes.node(id)
         if (!node) throw new Error(`Node ${id} not found`)
 
@@ -626,20 +628,30 @@ export class ExpertAutomations extends ExpertActionsInterface {
         // Show source tab so link nodes are created on the correct workspace
         this.RED.workspaces.show(node.z)
 
-        // Use getNodes for upstream/downstream counts (excludes self from upstream result)
-        const upstreamNodes = (this.getNodes(id, 'upstream') || []).filter(n => n.id !== id)
-        const downstreamNodeIds = (node.wires || []).flat()
-        const downstreamNodes = this.getNodes(downstreamNodeIds) || []
-
         // Get wire objects for the core actions (PORT_TYPE_INPUT = 1, PORT_TYPE_OUTPUT = 0)
         let inboundWires = this.RED.nodes.getNodeLinks(id, 1)
         let outboundWires = this.RED.nodes.getNodeLinks(id, 0)
 
-        // Add junctions first when multiple upstream or downstream nodes share a wire boundary
+        // Exclude wires to/from co-moving nodes — both ends land on the same tab, no cross-tab split needed.
+        const externalInbound = inboundWires.filter(l => !coMovingIds.has(l.source.id))
+        const externalOutbound = outboundWires.filter(l => !coMovingIds.has(l.target.id))
+
+        // Add junctions only where there is actual fan-in or fan-out on a single port.
+        // Fan-in: multiple external wires arriving at the input. Fan-out: multiple external wires from the same output port.
         let junctionNodes = []
-        if (upstreamNodes.length > 1 || downstreamNodes.length > 1) {
+        const outboundByPort = {}
+        for (const w of externalOutbound) {
+            const port = w.sourcePort ?? 0
+            if (!outboundByPort[port]) outboundByPort[port] = []
+            outboundByPort[port].push(w)
+        }
+        const wiresNeedingJunction = [
+            ...(externalInbound.length > 1 ? externalInbound : []),
+            ...Object.values(outboundByPort).filter(g => g.length > 1).flat()
+        ]
+        if (wiresNeedingJunction.length > 0) {
             this.RED.actions.invoke('core:split-wires-with-junctions', {
-                wires: [...inboundWires, ...outboundWires]
+                wires: wiresNeedingJunction
             })
             // Re-fetch wires after junction insertion
             inboundWires = this.RED.nodes.getNodeLinks(id, 1)
@@ -652,13 +664,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
 
         // Existing adjacent link nodes (from a previous tab move) are moved directly — no new pair needed
-        const existingLinkIns = inboundWires.filter(l => l.source.type === 'link in').map(l => l.source)
-        const existingLinkOuts = outboundWires.filter(l => l.target.type === 'link out').map(l => l.target)
+        const existingLinkIns = inboundWires.filter(l => l.source.type === 'link in' && !coMovingIds.has(l.source.id)).map(l => l.source)
+        const existingLinkOuts = outboundWires.filter(l => l.target.type === 'link out' && !coMovingIds.has(l.target.id)).map(l => l.target)
 
-        // Only split wires where the adjacent node is not already a link node
+        // Only split external wires where the adjacent node is not already a link node
         const wiresToSplit = [
-            ...inboundWires.filter(l => l.source.type !== 'link in'),
-            ...outboundWires.filter(l => l.target.type !== 'link out')
+            ...inboundWires.filter(l => !coMovingIds.has(l.source.id) && l.source.type !== 'link in'),
+            ...outboundWires.filter(l => !coMovingIds.has(l.target.id) && l.target.type !== 'link out')
         ]
 
         const linkNodesToMove = [...existingLinkIns, ...existingLinkOuts]
@@ -1402,12 +1414,23 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 result.success = false
                 break
             }
+            // Pre-compute co-moving sets: nodes being moved to the same target tab in this batch.
+            // Wires between co-moving nodes are kept intact — no splitting needed.
+            const tabMoveGroups = new Map()
+            for (const { id, updates = [] } of params.nodes) {
+                const zUpdate = updates.find(u => u.property === 'z' && typeof u.content === 'string')
+                if (zUpdate) {
+                    if (!tabMoveGroups.has(zUpdate.content)) tabMoveGroups.set(zUpdate.content, new Set())
+                    tabMoveGroups.get(zUpdate.content).add(id)
+                }
+            }
             const allLinkNodes = []
             const allJunctionNodes = []
             for (const { id, updates = [] } of params.nodes) {
                 const zUpdate = updates.find(u => u.property === 'z' && typeof u.content === 'string')
                 if (zUpdate) {
-                    const { linkNodes, junctionNodes } = this._moveNodeToTab(id, zUpdate.content)
+                    const coMovingIds = tabMoveGroups.get(zUpdate.content)
+                    const { linkNodes, junctionNodes } = this._moveNodeToTab(id, zUpdate.content, coMovingIds)
                     allLinkNodes.push(...linkNodes)
                     allJunctionNodes.push(...junctionNodes)
                     const remainingUpdates = updates.filter(u => u.property !== 'z')

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1886,10 +1886,6 @@ describeMain('expertAutomations', () => {
                     const upstreamNode = { id: 'up1', type: 'inject', z: 'tab-a' }
                     const downstreamNode = { id: 'dn1', type: 'debug', z: 'tab-a' }
                     const node = setupTabChangeNode({ wires: [['dn1']] })
-                    // getNodes(id, 'upstream') via getAllFlowNodes: 1 upstream
-                    mockRED.nodes.getAllFlowNodes.withArgs(node, 'up').returns([node, upstreamNode])
-                    // getNodes(['dn1']) via node lookup
-                    mockRED.nodes.node.withArgs('dn1').returns(downstreamNode)
 
                     const inboundWire = { source: upstreamNode, sourcePort: 0, target: node }
                     const outboundWire = { source: node, sourcePort: 0, target: downstreamNode }
@@ -1935,8 +1931,6 @@ describeMain('expertAutomations', () => {
                     const linkIn = { id: 'li-existing', type: 'link in', z: 'tab-a', links: ['lo-existing'] }
                     const linkOut = { id: 'lo-existing', type: 'link out', z: 'tab-a', links: ['li-existing'] }
                     const node = setupTabChangeNode()
-                    // No upstream reachable via wires (link nodes break graph traversal)
-                    mockRED.nodes.getAllFlowNodes.withArgs(node, 'up').returns([node])
 
                     // Both adjacent nodes are already link nodes
                     mockRED.nodes.getNodeLinks.onCall(0).returns([{ source: linkIn, sourcePort: 0, target: node }])
@@ -1964,14 +1958,11 @@ describeMain('expertAutomations', () => {
                     dataIds.should.containEql('lo-existing')
                 })
 
-                it('should add junctions first when multiple upstream nodes share the node', async () => {
+                it('should add junctions only for fan-in wires when multiple upstream nodes share the input', async () => {
                     const up1 = { id: 'up1', type: 'inject', z: 'tab-a' }
                     const up2 = { id: 'up2', type: 'inject', z: 'tab-a' }
                     const dn1 = { id: 'dn1', type: 'debug', z: 'tab-a' }
                     const node = setupTabChangeNode({ wires: [['dn1']] })
-                    // getNodes(id, 'upstream'): 2 upstream nodes
-                    mockRED.nodes.getAllFlowNodes.withArgs(node, 'up').returns([node, up1, up2])
-                    mockRED.nodes.node.withArgs('dn1').returns(dn1)
 
                     const inboundWire1 = { source: up1, sourcePort: 0, target: node }
                     const inboundWire2 = { source: up2, sourcePort: 0, target: node }
@@ -1997,12 +1988,12 @@ describeMain('expertAutomations', () => {
                     }, result)
 
                     result.should.have.property('success', true)
-                    // Junctions invoked with original wires
+                    // Junction invoked only with the fan-in inbound wires, not the single outbound wire
                     const junctionCalls = mockRED.actions.invoke.args.filter(a => a[0] === 'core:split-wires-with-junctions')
                     junctionCalls.length.should.equal(1)
                     junctionCalls[0][1].wires.should.containEql(inboundWire1)
                     junctionCalls[0][1].wires.should.containEql(inboundWire2)
-                    junctionCalls[0][1].wires.should.containEql(outboundWire)
+                    junctionCalls[0][1].wires.should.not.containEql(outboundWire)
                     // Link split invoked after junctions
                     const linkCalls = mockRED.actions.invoke.args.filter(a => a[0] === 'core:split-wire-with-link-nodes')
                     linkCalls.length.should.equal(1)
@@ -2021,11 +2012,6 @@ describeMain('expertAutomations', () => {
                     const dn1 = { id: 'dn1', type: 'debug', z: 'tab-a' }
                     const dn2 = { id: 'dn2', type: 'debug', z: 'tab-a' }
                     const node = setupTabChangeNode({ wires: [['dn1', 'dn2']] })
-                    // getNodes(id, 'upstream'): 1 upstream
-                    mockRED.nodes.getAllFlowNodes.withArgs(node, 'up').returns([node, up1])
-                    // getNodes(['dn1','dn2']) via node lookup
-                    mockRED.nodes.node.withArgs('dn1').returns(dn1)
-                    mockRED.nodes.node.withArgs('dn2').returns(dn2)
 
                     const inboundWire = { source: up1, sourcePort: 0, target: node }
                     const outboundWire1 = { source: node, sourcePort: 0, target: dn1 }
@@ -2068,6 +2054,76 @@ describeMain('expertAutomations', () => {
                     await should(expertAutomations.invokeAction('automation/update-nodes', {
                         params: { nodes: [{ id: 'n1', updates: [{ property: 'z', op: 'replace', content: 'nonexistent' }] }] }
                     }, result)).rejectedWith(/Workspace nonexistent not found/)
+                })
+
+                it('should not split wires between nodes being moved to the same tab together', async () => {
+                    // n1 → n2, both moving to tab-b in one batch
+                    const n1 = {
+                        id: 'n1',
+                        type: 'function',
+                        z: 'tab-a',
+                        x: 100,
+                        y: 100,
+                        wires: [['n2']],
+                        changed: false,
+                        dirty: false
+                    }
+                    const n2 = {
+                        id: 'n2',
+                        type: 'debug',
+                        z: 'tab-a',
+                        x: 300,
+                        y: 100,
+                        wires: [],
+                        changed: false,
+                        dirty: false
+                    }
+                    mockRED.nodes.node.withArgs('n1').returns(n1)
+                    mockRED.nodes.node.withArgs('n2').returns(n2)
+                    mockRED.nodes.group.withArgs('n1').returns(null)
+                    mockRED.nodes.group.withArgs('n2').returns(null)
+                    mockRED.nodes.workspace = sinon.stub()
+                    mockRED.nodes.workspace.withArgs('tab-a').returns({ id: 'tab-a' })
+                    mockRED.nodes.workspace.withArgs('tab-b').returns({ id: 'tab-b' })
+                    mockRED.nodes.moveNodeToTab = sinon.stub()
+                    mockRED.actions = { invoke: sinon.stub() }
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.view.redraw = sinon.stub()
+
+                    const wire = { source: n1, sourcePort: 0, target: n2 }
+                    // For n1: inbound=[], outbound=[n1→n2]
+                    // For n2: inbound=[n1→n2], outbound=[]
+                    mockRED.nodes.getNodeLinks = sinon.stub()
+                    mockRED.nodes.getNodeLinks.onCall(0).returns([]) // n1 inbound
+                    mockRED.nodes.getNodeLinks.onCall(1).returns([wire]) // n1 outbound (co-moving → skipped)
+                    mockRED.nodes.getNodeLinks.onCall(2).returns([wire]) // n2 inbound (co-moving → skipped)
+                    mockRED.nodes.getNodeLinks.onCall(3).returns([]) // n2 outbound
+
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: {
+                            nodes: [
+                                { id: 'n1', updates: [{ property: 'z', op: 'replace', content: 'tab-b' }] },
+                                { id: 'n2', updates: [{ property: 'z', op: 'replace', content: 'tab-b' }] }
+                            ]
+                        }
+                    }, result)
+
+                    result.should.have.property('success', true)
+                    // No junctions or link nodes — both ends of the wire land on the same tab
+                    const junctionCalls = mockRED.actions.invoke.args.filter(a => a[0] === 'core:split-wires-with-junctions')
+                    junctionCalls.length.should.equal(0)
+                    const linkCalls = mockRED.actions.invoke.args.filter(a => a[0] === 'core:split-wire-with-link-nodes')
+                    linkCalls.length.should.equal(0)
+                    // Both nodes moved to tab-b, no extra link nodes
+                    const movedIds = mockRED.nodes.moveNodeToTab.args.map(a => a[0].id)
+                    movedIds.should.containEql('n1')
+                    movedIds.should.containEql('n2')
+                    mockRED.nodes.moveNodeToTab.callCount.should.equal(2)
+                    // Result data contains both nodes
+                    const dataIds = result.data.map(n => n.id)
+                    dataIds.should.containEql('n1')
+                    dataIds.should.containEql('n2')
                 })
 
                 it('should apply non-z updates alongside a tab change', async () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -1841,6 +1841,256 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
                 result.should.have.property('error').which.match(/"g" cannot be set directly/)
             })
+            describe('tab change (z update)', () => {
+                function setupTabChangeNode (overrides = {}) {
+                    const node = {
+                        id: 'n1',
+                        type: 'function',
+                        z: 'tab-a',
+                        x: 100,
+                        y: 100,
+                        wires: [],
+                        changed: false,
+                        dirty: false,
+                        ...overrides
+                    }
+                    mockRED.nodes.node.withArgs('n1').returns(node)
+                    mockRED.nodes.group.withArgs('n1').returns(null)
+                    mockRED.nodes.workspace = sinon.stub()
+                    mockRED.nodes.workspace.withArgs('tab-a').returns({ id: 'tab-a' })
+                    mockRED.nodes.workspace.withArgs('tab-b').returns({ id: 'tab-b' })
+                    // getAllFlowNodes used by getNodes — default: no upstream (just the node itself)
+                    mockRED.nodes.getAllFlowNodes.withArgs(node, 'up').returns([node])
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                    mockRED.nodes.moveNodeToTab = sinon.stub()
+                    mockRED.actions = { invoke: sinon.stub() }
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.view.redraw = sinon.stub()
+                    return node
+                }
+
+                it('should move a node with no wires directly to the target tab', async () => {
+                    const node = setupTabChangeNode()
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', updates: [{ property: 'z', op: 'replace', content: 'tab-b' }] }] }
+                    }, result)
+                    result.should.have.property('success', true)
+                    mockRED.nodes.moveNodeToTab.calledOnce.should.be.true()
+                    mockRED.nodes.moveNodeToTab.firstCall.args[0].should.equal(node)
+                    mockRED.nodes.moveNodeToTab.firstCall.args[1].should.equal('tab-b')
+                    mockRED.actions.invoke.called.should.be.false()
+                })
+
+                it('should split wires with link nodes when single upstream and single downstream', async () => {
+                    const upstreamNode = { id: 'up1', type: 'inject', z: 'tab-a' }
+                    const downstreamNode = { id: 'dn1', type: 'debug', z: 'tab-a' }
+                    const node = setupTabChangeNode({ wires: [['dn1']] })
+                    // getNodes(id, 'upstream') via getAllFlowNodes: 1 upstream
+                    mockRED.nodes.getAllFlowNodes.withArgs(node, 'up').returns([node, upstreamNode])
+                    // getNodes(['dn1']) via node lookup
+                    mockRED.nodes.node.withArgs('dn1').returns(downstreamNode)
+
+                    const inboundWire = { source: upstreamNode, sourcePort: 0, target: node }
+                    const outboundWire = { source: node, sourcePort: 0, target: downstreamNode }
+                    const linkInNode = { id: 'li1', type: 'link in', z: 'tab-a', links: [] }
+                    const linkOutNode = { id: 'lo1', type: 'link out', z: 'tab-a', links: [] }
+
+                    // getNodeLinks calls: [inbound-before, outbound-before, inbound-after-split, outbound-after-split]
+                    mockRED.nodes.getNodeLinks.onCall(0).returns([inboundWire])
+                    mockRED.nodes.getNodeLinks.onCall(1).returns([outboundWire])
+                    mockRED.nodes.getNodeLinks.onCall(2).returns([{ source: linkInNode, sourcePort: 0, target: node }])
+                    mockRED.nodes.getNodeLinks.onCall(3).returns([{ source: node, sourcePort: 0, target: linkOutNode }])
+
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', updates: [{ property: 'z', op: 'replace', content: 'tab-b' }] }] }
+                    }, result)
+
+                    result.should.have.property('success', true)
+                    // No junctions needed (1 upstream, 1 downstream)
+                    const junctionCalls = mockRED.actions.invoke.args.filter(a => a[0] === 'core:split-wires-with-junctions')
+                    junctionCalls.length.should.equal(0)
+                    // Link wire split was invoked
+                    const linkCalls = mockRED.actions.invoke.args.filter(a => a[0] === 'core:split-wire-with-link-nodes')
+                    linkCalls.length.should.equal(1)
+                    // Wires selected before split
+                    mockRED.view.select.calledWith({ links: [inboundWire, outboundWire] }).should.be.true()
+                    // Node + link in + link out moved to target tab
+                    mockRED.nodes.moveNodeToTab.callCount.should.equal(3)
+                    const movedIds = mockRED.nodes.moveNodeToTab.args.map(a => a[0].id)
+                    movedIds.should.containEql('n1')
+                    movedIds.should.containEql('li1')
+                    movedIds.should.containEql('lo1')
+                    mockRED.nodes.moveNodeToTab.args.every(a => a[1] === 'tab-b').should.be.true()
+                    // Result data includes the moved node and the created link nodes
+                    const dataIds = result.data.map(n => n.id)
+                    dataIds.should.containEql('n1')
+                    dataIds.should.containEql('li1')
+                    dataIds.should.containEql('lo1')
+                })
+
+                it('should move existing adjacent link nodes without re-splitting (second move)', async () => {
+                    // Node was already moved once — it now has a link in on its input and link out on its output
+                    const linkIn = { id: 'li-existing', type: 'link in', z: 'tab-a', links: ['lo-existing'] }
+                    const linkOut = { id: 'lo-existing', type: 'link out', z: 'tab-a', links: ['li-existing'] }
+                    const node = setupTabChangeNode()
+                    // No upstream reachable via wires (link nodes break graph traversal)
+                    mockRED.nodes.getAllFlowNodes.withArgs(node, 'up').returns([node])
+
+                    // Both adjacent nodes are already link nodes
+                    mockRED.nodes.getNodeLinks.onCall(0).returns([{ source: linkIn, sourcePort: 0, target: node }])
+                    mockRED.nodes.getNodeLinks.onCall(1).returns([{ source: node, sourcePort: 0, target: linkOut }])
+
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', updates: [{ property: 'z', op: 'replace', content: 'tab-b' }] }] }
+                    }, result)
+
+                    result.should.have.property('success', true)
+                    // No new link pairs created
+                    mockRED.actions.invoke.called.should.be.false()
+                    // Node + existing link in + existing link out all moved to target tab
+                    mockRED.nodes.moveNodeToTab.callCount.should.equal(3)
+                    const movedIds = mockRED.nodes.moveNodeToTab.args.map(a => a[0].id)
+                    movedIds.should.containEql('n1')
+                    movedIds.should.containEql('li-existing')
+                    movedIds.should.containEql('lo-existing')
+                    mockRED.nodes.moveNodeToTab.args.every(a => a[1] === 'tab-b').should.be.true()
+                    // Result data includes the moved node and the carried link nodes
+                    const dataIds = result.data.map(n => n.id)
+                    dataIds.should.containEql('n1')
+                    dataIds.should.containEql('li-existing')
+                    dataIds.should.containEql('lo-existing')
+                })
+
+                it('should add junctions first when multiple upstream nodes share the node', async () => {
+                    const up1 = { id: 'up1', type: 'inject', z: 'tab-a' }
+                    const up2 = { id: 'up2', type: 'inject', z: 'tab-a' }
+                    const dn1 = { id: 'dn1', type: 'debug', z: 'tab-a' }
+                    const node = setupTabChangeNode({ wires: [['dn1']] })
+                    // getNodes(id, 'upstream'): 2 upstream nodes
+                    mockRED.nodes.getAllFlowNodes.withArgs(node, 'up').returns([node, up1, up2])
+                    mockRED.nodes.node.withArgs('dn1').returns(dn1)
+
+                    const inboundWire1 = { source: up1, sourcePort: 0, target: node }
+                    const inboundWire2 = { source: up2, sourcePort: 0, target: node }
+                    const outboundWire = { source: node, sourcePort: 0, target: dn1 }
+                    const junctionNode = { id: 'j1', type: 'junction', z: 'tab-a' }
+                    const junctionWire = { source: junctionNode, sourcePort: 0, target: node }
+                    const linkInNode = { id: 'li1', type: 'link in', z: 'tab-a', links: [] }
+                    const linkOutNode = { id: 'lo1', type: 'link out', z: 'tab-a', links: [] }
+
+                    // getNodeLinks calls: [inbound-before, outbound-before,
+                    //   inbound-after-junctions, outbound-after-junctions,
+                    //   inbound-after-split, outbound-after-split]
+                    mockRED.nodes.getNodeLinks.onCall(0).returns([inboundWire1, inboundWire2])
+                    mockRED.nodes.getNodeLinks.onCall(1).returns([outboundWire])
+                    mockRED.nodes.getNodeLinks.onCall(2).returns([junctionWire])
+                    mockRED.nodes.getNodeLinks.onCall(3).returns([outboundWire])
+                    mockRED.nodes.getNodeLinks.onCall(4).returns([{ source: linkInNode, sourcePort: 0, target: node }])
+                    mockRED.nodes.getNodeLinks.onCall(5).returns([{ source: node, sourcePort: 0, target: linkOutNode }])
+
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', updates: [{ property: 'z', op: 'replace', content: 'tab-b' }] }] }
+                    }, result)
+
+                    result.should.have.property('success', true)
+                    // Junctions invoked with original wires
+                    const junctionCalls = mockRED.actions.invoke.args.filter(a => a[0] === 'core:split-wires-with-junctions')
+                    junctionCalls.length.should.equal(1)
+                    junctionCalls[0][1].wires.should.containEql(inboundWire1)
+                    junctionCalls[0][1].wires.should.containEql(inboundWire2)
+                    junctionCalls[0][1].wires.should.containEql(outboundWire)
+                    // Link split invoked after junctions
+                    const linkCalls = mockRED.actions.invoke.args.filter(a => a[0] === 'core:split-wire-with-link-nodes')
+                    linkCalls.length.should.equal(1)
+                    // Node moved to target tab
+                    const movedIds = mockRED.nodes.moveNodeToTab.args.map(a => a[0].id)
+                    movedIds.should.containEql('n1')
+                    mockRED.nodes.moveNodeToTab.args.every(a => a[1] === 'tab-b').should.be.true()
+                    // Result data includes the moved node and the junction created on the source tab
+                    const dataIds = result.data.map(n => n.id)
+                    dataIds.should.containEql('n1')
+                    dataIds.should.containEql('j1')
+                })
+
+                it('should add junctions first when multiple downstream nodes exist', async () => {
+                    const up1 = { id: 'up1', type: 'inject', z: 'tab-a' }
+                    const dn1 = { id: 'dn1', type: 'debug', z: 'tab-a' }
+                    const dn2 = { id: 'dn2', type: 'debug', z: 'tab-a' }
+                    const node = setupTabChangeNode({ wires: [['dn1', 'dn2']] })
+                    // getNodes(id, 'upstream'): 1 upstream
+                    mockRED.nodes.getAllFlowNodes.withArgs(node, 'up').returns([node, up1])
+                    // getNodes(['dn1','dn2']) via node lookup
+                    mockRED.nodes.node.withArgs('dn1').returns(dn1)
+                    mockRED.nodes.node.withArgs('dn2').returns(dn2)
+
+                    const inboundWire = { source: up1, sourcePort: 0, target: node }
+                    const outboundWire1 = { source: node, sourcePort: 0, target: dn1 }
+                    const outboundWire2 = { source: node, sourcePort: 0, target: dn2 }
+                    const junctionWire = { source: node, sourcePort: 0, target: { id: 'j1', type: 'junction', z: 'tab-a' } }
+                    const linkInNode = { id: 'li1', type: 'link in', z: 'tab-a', links: [] }
+                    const linkOutNode = { id: 'lo1', type: 'link out', z: 'tab-a', links: [] }
+
+                    mockRED.nodes.getNodeLinks.onCall(0).returns([inboundWire])
+                    mockRED.nodes.getNodeLinks.onCall(1).returns([outboundWire1, outboundWire2])
+                    mockRED.nodes.getNodeLinks.onCall(2).returns([inboundWire])
+                    mockRED.nodes.getNodeLinks.onCall(3).returns([junctionWire])
+                    mockRED.nodes.getNodeLinks.onCall(4).returns([{ source: linkInNode, sourcePort: 0, target: node }])
+                    mockRED.nodes.getNodeLinks.onCall(5).returns([{ source: node, sourcePort: 0, target: linkOutNode }])
+
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', updates: [{ property: 'z', op: 'replace', content: 'tab-b' }] }] }
+                    }, result)
+
+                    result.should.have.property('success', true)
+                    const junctionCalls = mockRED.actions.invoke.args.filter(a => a[0] === 'core:split-wires-with-junctions')
+                    junctionCalls.length.should.equal(1)
+                    junctionCalls[0][1].wires.should.containEql(outboundWire1)
+                    junctionCalls[0][1].wires.should.containEql(outboundWire2)
+                    const movedIds = mockRED.nodes.moveNodeToTab.args.map(a => a[0].id)
+                    movedIds.should.containEql('n1')
+                    // Result data includes the moved node and the junction created on the source tab
+                    const dataIds = result.data.map(n => n.id)
+                    dataIds.should.containEql('n1')
+                    dataIds.should.containEql('j1')
+                })
+
+                it('should throw if target tab does not exist', async () => {
+                    const node = { id: 'n1', type: 'function', z: 'tab-a', changed: false }
+                    mockRED.nodes.node.withArgs('n1').returns(node)
+                    mockRED.nodes.group.withArgs('n1').returns(null)
+                    mockRED.nodes.workspace = sinon.stub().returns(null)
+                    const result = {}
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', updates: [{ property: 'z', op: 'replace', content: 'nonexistent' }] }] }
+                    }, result)).rejectedWith(/Workspace nonexistent not found/)
+                })
+
+                it('should apply non-z updates alongside a tab change', async () => {
+                    const node = setupTabChangeNode({ name: 'old-name' })
+                    mockRED.history = { push: sinon.stub() }
+                    mockRED.editor = { validateNode: sinon.stub().callsFake(n => { n.valid = true }) }
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: {
+                            nodes: [{
+                                id: 'n1',
+                                updates: [
+                                    { property: 'z', op: 'replace', content: 'tab-b' },
+                                    { property: 'name', op: 'replace', content: 'new-name' }
+                                ]
+                            }]
+                        }
+                    }, result)
+                    result.should.have.property('success', true)
+                    mockRED.nodes.moveNodeToTab.calledOnce.should.be.true()
+                    node.name.should.equal('new-name')
+                })
+            })
         })
         describe('closeEditorTray action', () => {
             afterEach(() => {


### PR DESCRIPTION
Closes #319

## Summary

When `update_nodes` receives a `z` property change, it now routes through `_moveNodeToTab` instead of applying the change as a plain property update. Directly overwriting `z` removed the node from the source tab without registering it on the target tab.

`_moveNodeToTab` handles the full sequence:

- Detects multiple upstream or downstream connections and inserts junction nodes via `core:split-wires-with-junctions` to collapse fan-in/fan-out into a single wire boundary
- Splits remaining wires with `core:split-wire-with-link-nodes`, creating link in/out pairs to preserve cross-tab connectivity
- Moves the node and its adjacent link nodes to the target tab via `RED.nodes.moveNodeToTab`
- On repeated moves, detects existing adjacent link nodes and carries them directly rather than creating a new pair — prevents stranded link nodes on the intermediate tab
- Returns all created and moved link nodes and junction nodes so they appear in `result.data` alongside the moved node

## Test results

Simple case — node with 4 downstream connections moved to a new tab:

```json
"data": [
  { "id": "7ffc6d83700e21d1", "type": "function", "name": "function 1", "z": "b86c41f4525d53aa", "valid": true },
  { "id": "bea5599439a0bc54", "type": "link in",  "name": "link in 1",  "z": "b86c41f4525d53aa", "links": ["bd6a1ae49037bc87"] },
  { "id": "a4c974107ae01b82", "type": "link out", "name": "link out 2", "z": "b86c41f4525d53aa", "links": ["c9c13605ef5af8bc"] },
  { "id": "9554be56679d4025", "type": "junction", "z": "f9e4970bdc3425c3" },
  { "id": "d0939c755e40c642", "type": "junction", "z": "f9e4970bdc3425c3" }
]
```

Complex case — two nodes connected to each other and to multiple other nodes, each moved to a different tab in separate calls:

```json
"data": [
  { "id": "7ffc6d83700e21d1", "type": "function", "name": "function 1", "z": "ab4768b3f3f6549b", "valid": true },
  { "id": "f55071ab829f2a2d", "type": "link in",  "name": "link in 1",  "z": "ab4768b3f3f6549b" },
  { "id": "43146dcd158c0ffc", "type": "link out", "name": "link out 2", "z": "ab4768b3f3f6549b" },
  { "id": "5070b4d793952f0f", "type": "junction", "z": "f9e4970bdc3425c3" },
  { "id": "46b4137af66b28c9", "type": "junction", "z": "f9e4970bdc3425c3" }
]
```

```json
"data": [
  { "id": "accb2aa3f68779e6", "type": "function", "name": "function 2", "z": "a02a99fcb9672da5", "valid": true },
  { "id": "47362a0660a1c89a", "type": "link in",  "name": "link in 3",  "z": "a02a99fcb9672da5" },
  { "id": "fe6a3ccfc5f6ac9a", "type": "link out", "name": "link out 4", "z": "a02a99fcb9672da5" },
  { "id": "be8759a880974f76", "type": "junction", "z": "f9e4970bdc3425c3" },
  { "id": "94b35b28571d39f5", "type": "junction", "z": "f9e4970bdc3425c3" }
]
```

Moving the same node a second time correctly carries the existing link nodes to the new destination without leaving anything behind on the intermediate tab.