### PR TITLE
feat(automation): add align-selection action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -26,6 +26,9 @@ const GET_PALETTE = 'automation/get-palette'
 const LIST_CONFIG_NODES = 'automation/list-config-nodes'
 const OPEN_PALETTE_MANAGER = 'automation/open-palette-manager'
 const MANAGE_GROUPS = 'automation/manage-groups'
+const ALIGN_SELECTION = 'automation/align-selection'
+
+const ALIGNMENT_DIRECTIONS = ['grid', 'left', 'right', 'top', 'bottom', 'middle', 'center']
 
 const ERROR_CODES = Object.freeze({
     GROUP_OPERATION_REQUIRED: 'GROUP_OPERATION_REQUIRED',
@@ -59,7 +62,8 @@ const LINK_NODE_TYPES = ['link in', 'link out', 'link call']
  *   |GET_PALETTE
  *   |LIST_CONFIG_NODES
  *   |OPEN_PALETTE_MANAGER
- *   |MANAGE_GROUPS} ExpertAutomationsActionsEnum
+ *   |MANAGE_GROUPS
+ *   |ALIGN_SELECTION} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -457,6 +461,24 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 },
                 required: ['operations']
+            }
+        },
+        [ALIGN_SELECTION]: {
+            params: {
+                type: 'object',
+                properties: {
+                    ids: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'IDs of nodes to align'
+                    },
+                    direction: {
+                        type: 'string',
+                        enum: ALIGNMENT_DIRECTIONS,
+                        description: 'Alignment direction: "grid" snaps to grid; "left", "right", "top", "bottom" align to the respective edge; "middle" aligns vertically; "center" aligns horizontally'
+                    }
+                },
+                required: ['ids', 'direction']
             }
         }
     })
@@ -1729,6 +1751,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
             result.success = true
             break
         }
+        case ALIGN_SELECTION: {
+            const { aligned, excluded } = this.alignSelection(params.ids, params.direction)
+            result.data = {
+                alignedNodes: aligned.map(n => this._summarizeNode(n)),
+                excludedConfigNodes: excluded.map(n => ({ id: n.id, type: n.type }))
+            }
+            result.success = true
+        }
+            break
+
         default:
             result.handled = false
             result.success = false
@@ -1955,6 +1987,40 @@ export class ExpertAutomations extends ExpertActionsInterface {
         this.RED.actions.invoke('core:ungroup-selection')
         this.RED.nodes.dirty(true)
         this.RED.view.redraw()
+    }
+
+    /**
+     * Align the specified nodes using a Node-RED core alignment action.
+     * @param {string[]} ids - node IDs to align
+     * @param {'grid'|'left'|'right'|'top'|'bottom'|'middle'|'center'} direction
+     */
+    alignSelection (ids, direction) {
+        if (!ids || ids.length === 0) throw new Error('ids array must not be empty')
+        if (!ALIGNMENT_DIRECTIONS.includes(direction)) {
+            throw new Error(`Invalid alignment direction: ${direction}`)
+        }
+        const allNodes = ids.map(id => {
+            const node = this.RED.nodes.node(id)
+            if (!node) throw new Error(`Node ${id} not found`)
+            return node
+        })
+        // Exclude config nodes — they have no canvas position and break alignment
+        const nodes = allNodes.filter(n => {
+            const def = this.RED.nodes.getType(n.type)
+            return !def || def.category !== 'config'
+        })
+        if (nodes.length === 0) throw new Error('No non-config nodes to align')
+        if (direction !== 'grid' && nodes.length < 2) {
+            throw new Error(`Alignment direction "${direction}" requires at least 2 non-config nodes`)
+        }
+        this._assertWorkspaceExists(nodes[0].z)
+        this._assertWorkspaceNotLocked(nodes[0].z)
+        this.RED.view.reveal(nodes[0].id, false)
+        this.RED.view.select({ nodes })
+        this._verifySelection(nodes)
+        this.RED.actions.invoke(`core:align-selection-to-${direction}`)
+        const excluded = allNodes.filter(n => !nodes.includes(n))
+        return { aligned: nodes, excluded }
     }
 
     _summarizeNode (node) {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -101,7 +101,8 @@ describeMain('expertAutomations', () => {
                 'automation/get-palette',
                 'automation/list-config-nodes',
                 'automation/open-palette-manager',
-                'automation/manage-groups'
+                'automation/manage-groups',
+                'automation/align-selection'
             ]
             supportedActions.should.only.have.keys(...expectedKeys)
         })
@@ -3102,6 +3103,127 @@ describeMain('expertAutomations', () => {
                 result.data[0].should.have.property('op', 'create')
                 result.data[1].should.have.property('op', 'update')
                 existingGroup.name.should.equal('Renamed')
+            })
+        })
+        describe('alignSelection action', () => {
+            beforeEach(() => {
+                mockRED.actions = { invoke: sinon.stub() }
+                mockRED.view.select = sinon.stub()
+                mockRED.view.reveal = sinon.stub()
+                mockRED.view.selection = sinon.stub().callsFake(() => mockRED.view.select.lastCall?.args[0] || { nodes: [] })
+                mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().returns(false) }
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1' })
+                mockRED.nodes.getType = sinon.stub().returns({ category: 'function' })
+            })
+            it('should reveal, select, and invoke core:align-selection-to-grid', async () => {
+                const n1 = { id: 'n1', type: 'inject', x: 13, y: 27, z: 'tab1' }
+                const n2 = { id: 'n2', type: 'debug', x: 45, y: 60, z: 'tab1' }
+                mockRED.nodes.node.withArgs('n1').returns(n1)
+                mockRED.nodes.node.withArgs('n2').returns(n2)
+                const result = {}
+                await expertAutomations.invokeAction('automation/align-selection', {
+                    params: { ids: ['n1', 'n2'], direction: 'grid' }
+                }, result)
+                mockRED.view.reveal.calledWith('n1', false).should.be.true()
+                mockRED.view.reveal.calledBefore(mockRED.view.select).should.be.true()
+                mockRED.view.select.calledWith({ nodes: [n1, n2] }).should.be.true()
+                mockRED.actions.invoke.calledWith('core:align-selection-to-grid').should.be.true()
+                result.should.have.property('success', true)
+                result.data.alignedNodes.should.have.lengthOf(2)
+                result.data.excludedConfigNodes.should.have.lengthOf(0)
+            })
+            it('should invoke the correct core action for each direction', async () => {
+                const n1 = { id: 'n1', type: 'inject', x: 10, y: 20, z: 'tab1' }
+                const n2 = { id: 'n2', type: 'debug', x: 30, y: 40, z: 'tab1' }
+                mockRED.nodes.node.withArgs('n1').returns(n1)
+                mockRED.nodes.node.withArgs('n2').returns(n2)
+                const directions = ['left', 'right', 'top', 'bottom', 'middle', 'center']
+                for (const direction of directions) {
+                    mockRED.actions.invoke.resetHistory()
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/align-selection', {
+                        params: { ids: ['n1', 'n2'], direction }
+                    }, result)
+                    mockRED.actions.invoke.calledWith(`core:align-selection-to-${direction}`).should.be.true()
+                    result.should.have.property('success', true)
+                }
+            })
+            it('should throw if ids array is empty', async () => {
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/align-selection', {
+                    params: { ids: [], direction: 'grid' }
+                }, result)).rejectedWith(/ids array must not be empty/)
+            })
+            it('should throw if a node ID does not exist', async () => {
+                mockRED.nodes.node.returns(null)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/align-selection', {
+                    params: { ids: ['nonexistent'], direction: 'grid' }
+                }, result)).rejectedWith(/Node nonexistent not found/)
+            })
+            it('should throw if non-grid direction is used with a single node', async () => {
+                const node = { id: 'n1', type: 'inject', x: 10, y: 20, z: 'tab1' }
+                mockRED.nodes.node.withArgs('n1').returns(node)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/align-selection', {
+                    params: { ids: ['n1'], direction: 'left' }
+                }, result)).rejectedWith(/requires at least 2 non-config nodes/)
+            })
+            it('should allow grid alignment with a single node', async () => {
+                const node = { id: 'n1', type: 'inject', x: 13, y: 27, z: 'tab1' }
+                mockRED.nodes.node.withArgs('n1').returns(node)
+                const result = {}
+                await expertAutomations.invokeAction('automation/align-selection', {
+                    params: { ids: ['n1'], direction: 'grid' }
+                }, result)
+                mockRED.view.reveal.calledWith('n1', false).should.be.true()
+                mockRED.actions.invoke.calledWith('core:align-selection-to-grid').should.be.true()
+                result.should.have.property('success', true)
+            })
+            it('should throw for an invalid direction', async () => {
+                const node = { id: 'n1', type: 'inject', x: 10, y: 20 }
+                mockRED.nodes.node.withArgs('n1').returns(node)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/align-selection', {
+                    params: { ids: ['n1'], direction: 'diagonal' }
+                }, result)).rejectedWith(/Invalid alignment direction/)
+            })
+            it('should throw if workspace is locked', async () => {
+                const node = { id: 'n1', type: 'inject', x: 10, y: 20, z: 'locked-tab' }
+                mockRED.nodes.node.withArgs('n1').returns(node)
+                mockRED.workspaces.isLocked = sinon.stub().withArgs('locked-tab').returns(true)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/align-selection', {
+                    params: { ids: ['n1'], direction: 'grid' }
+                }, result)).rejectedWith(/Workspace locked-tab is locked/)
+            })
+            it('should exclude config nodes from the selection', async () => {
+                const n1 = { id: 'n1', type: 'inject', x: 10, y: 20, z: 'tab1' }
+                const n2 = { id: 'n2', type: 'debug', x: 30, y: 40, z: 'tab1' }
+                const cfg = { id: 'cfg1', type: 'mqtt-broker', z: 'tab1' }
+                mockRED.nodes.node.withArgs('n1').returns(n1)
+                mockRED.nodes.node.withArgs('n2').returns(n2)
+                mockRED.nodes.node.withArgs('cfg1').returns(cfg)
+                mockRED.nodes.getType.withArgs('mqtt-broker').returns({ category: 'config' })
+                const result = {}
+                await expertAutomations.invokeAction('automation/align-selection', {
+                    params: { ids: ['n1', 'cfg1', 'n2'], direction: 'grid' }
+                }, result)
+                mockRED.view.select.calledWith({ nodes: [n1, n2] }).should.be.true()
+                mockRED.actions.invoke.calledWith('core:align-selection-to-grid').should.be.true()
+                result.should.have.property('success', true)
+                result.data.alignedNodes.should.have.lengthOf(2)
+                result.data.excludedConfigNodes.should.have.lengthOf(1)
+                result.data.excludedConfigNodes[0].should.deepEqual({ id: 'cfg1', type: 'mqtt-broker' })
+            })
+            it('should throw if all nodes are config nodes', async () => {
+                const cfg = { id: 'cfg1', type: 'mqtt-broker', z: 'tab1' }
+                mockRED.nodes.node.withArgs('cfg1').returns(cfg)
+                mockRED.nodes.getType.withArgs('mqtt-broker').returns({ category: 'config' })
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/align-selection', {
+                    params: { ids: ['cfg1'], direction: 'grid' }
+                }, result)).rejectedWith(/No non-config nodes to align/)
             })
         })
     })


### PR DESCRIPTION
## Summary
- Add `automation/align-selection` action that reveals the workspace, selects nodes by ID, and invokes `core:align-selection-to-*` actions
- Supports grid, left, right, top, bottom, middle, and center alignment directions
- Validates minimum 2 non-config nodes for non-grid directions
- Config nodes are automatically excluded from the selection since they lack canvas positions and break alignment
- Returns structured result with `alignedNodes` and `excludedConfigNodes` so the caller knows which nodes were skipped
- Workspace existence and lock checks are performed before alignment

Closes #334