### PR TITLE
feat(automation): add leveled connection traversal

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -92,6 +92,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         type: 'integer',
                         minimum: 0,
                         description: 'Max connection levels to traverse when include is specified. 1 = direct neighbors only, 2 = two hops, etc. 0 = all levels (no limit). Results are grouped by level. Only applicable when include is provided.'
+                    },
+                    includeConfigNodes: {
+                        type: 'boolean',
+                        default: false,
+                        description: 'Whether to include config nodes in the results when using include. Defaults to false.'
                     }
                 }
             }
@@ -120,6 +125,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         type: 'integer',
                         minimum: 0,
                         description: 'Max connection levels to traverse when include is specified. 1 = direct neighbors only, 2 = two hops, etc. 0 = all levels (no limit). Results are grouped by level. Only applicable when include is provided.'
+                    },
+                    includeConfigNodes: {
+                        type: 'boolean',
+                        default: false,
+                        description: 'Whether to include config nodes in the results when using include. Defaults to false.'
                     }
                 }
             }
@@ -493,6 +503,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
     })
 
+    _isConfigNode (node) {
+        const def = this.RED.nodes.getType(node.type)
+        return def && def.category === 'config'
+    }
+
     /**
      * Get nodes connected to a given node in a direction (all levels, flat)
      * @param {object} node - the node to get connections for
@@ -579,10 +594,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {string|string[]} nodeId - the id or ids of the nodes to retrieve
      * @param {'upstream'|'downstream'|'connected'|null} include - if provided, also retrieve nodes upstream, downstream, or connected to the specified node(s). Results are deduplicated.
      * @param {number|undefined} levels - if defined, use BFS and return a Map<level, node[]>. 0 = all levels. Only applies when include is provided.
+     * @param {boolean} [includeConfigNodes=false] - whether to include config nodes in the results when traversing connections
      * @returns {object[]|Map<number, object[]>} flat array (no levels) or Map keyed by level number
      * @throws {Error} if any node ID is not found
      */
-    getNodes (nodeId, include, levels) {
+    getNodes (nodeId, include, levels, includeConfigNodes = false) {
         const ids = Array.isArray(nodeId) ? nodeId : [nodeId]
         const nodes = ids.map(id => {
             const node = this.RED.nodes.node(id)
@@ -592,14 +608,29 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (!include) {
             return nodes
         }
+        const filterConfig = !includeConfigNodes
+            ? (arr) => arr.filter(n => !this._isConfigNode(n))
+            : (arr) => arr
         if (levels !== undefined && levels !== null) {
-            return this._getConnectedByLevel(nodes, include, levels)
+            const levelMap = this._getConnectedByLevel(nodes, include, levels)
+            if (filterConfig !== null) {
+                for (const [level, levelNodes] of levelMap) {
+                    if (level === 0) continue
+                    const filtered = filterConfig(levelNodes)
+                    if (filtered.length > 0) {
+                        levelMap.set(level, filtered)
+                    } else {
+                        levelMap.delete(level)
+                    }
+                }
+            }
+            return levelMap
         }
         const seen = new Set()
         const result = []
         for (const node of nodes) {
             const connected = this._getConnectedNodes(node, include)
-            for (const n of connected) {
+            for (const n of filterConfig(connected)) {
                 if (!seen.has(n.id)) {
                     seen.add(n.id)
                     result.push(n)
@@ -614,11 +645,12 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {string|string[]} nodeId - the id or ids of the nodes to select
      * @param {'upstream'|'downstream'|'connected'|null} include - if provided, also select nodes upstream, downstream, or connected to the specified node(s).
      * @param {number|undefined} levels - if defined, use BFS traversal. 0 = all levels.
+     * @param {boolean} [includeConfigNodes=false] - whether to include config nodes when traversing connections
      * @returns {object[]|Map<number, object[]>} flat array or Map keyed by level
      * @throws {Error} if any node ID is not found
      */
-    selectNodes (nodeId, include, levels) {
-        const result = this.getNodes(nodeId, include, levels)
+    selectNodes (nodeId, include, levels, includeConfigNodes = false) {
+        const result = this.getNodes(nodeId, include, levels, includeConfigNodes)
         let allNodes
         if (result instanceof Map) {
             allNodes = []
@@ -1253,7 +1285,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             if (!rawNode.type) throw new Error('Node is missing required property: type')
             const def = this.RED.nodes.getType(rawNode.type)
             if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
-            const isConfigNode = def.category === 'config'
+            const isConfigNode = this._isConfigNode(rawNode)
             if (!isConfigNode && !rawNode.z) throw new Error('Node is missing required property: z')
             return { ...rawNode }
         })
@@ -1484,13 +1516,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
         result.handled = true // default to handled=true (set to false in default case below if action is not implemented)
         switch (actionName) {
         case SELECT_NODES: {
-            const _nodes = this.selectNodes(params.id || params.ids, params.include, params.levels)
+            const _nodes = this.selectNodes(params.id || params.ids, params.include, params.levels, params.includeConfigNodes)
             result.nodes = this._formatNodeResult(_nodes, params.options?.includeModuleConfig)
             result.success = true
         }
             break
         case GET_NODES: {
-            const _nodes = this.getNodes(params.id || params.ids, params.include, params.levels)
+            const _nodes = this.getNodes(params.id || params.ids, params.include, params.levels, params.includeConfigNodes)
             result.nodes = this._formatNodeResult(_nodes, params.options?.includeModuleConfig)
             result.success = true
         }
@@ -2120,10 +2152,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             return node
         })
         // Exclude config nodes — they have no canvas position and break alignment
-        const nodes = allNodes.filter(n => {
-            const def = this.RED.nodes.getType(n.type)
-            return !def || def.category !== 'config'
-        })
+        const nodes = allNodes.filter(n => !this._isConfigNode(n))
         if (nodes.length === 0) throw new Error('No non-config nodes to align')
         if (direction !== 'grid' && nodes.length < 2) {
             throw new Error(`Alignment direction "${direction}" requires at least 2 non-config nodes`)

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -87,6 +87,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         type: 'string',
                         enum: ['upstream', 'downstream', 'connected'],
                         description: 'Specify whether to also retrieve nodes upstream, downstream, or connected to the specified node(s).'
+                    },
+                    levels: {
+                        type: 'integer',
+                        minimum: 0,
+                        description: 'Max connection levels to traverse when include is specified. 1 = direct neighbors only, 2 = two hops, etc. 0 = all levels (no limit). Results are grouped by level. Only applicable when include is provided.'
                     }
                 }
             }
@@ -110,6 +115,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         type: 'string',
                         enum: ['upstream', 'downstream', 'connected'],
                         description: 'Specify whether to also select nodes upstream, downstream, or connected to the specified node(s).'
+                    },
+                    levels: {
+                        type: 'integer',
+                        minimum: 0,
+                        description: 'Max connection levels to traverse when include is specified. 1 = direct neighbors only, 2 = two hops, etc. 0 = all levels (no limit). Results are grouped by level. Only applicable when include is provided.'
                     }
                 }
             }
@@ -484,7 +494,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
     })
 
     /**
-     * Get nodes connected to a given node in a direction
+     * Get nodes connected to a given node in a direction (all levels, flat)
      * @param {object} node - the node to get connections for
      * @param {'upstream'|'downstream'|'connected'|null} include - direction to traverse
      * @returns {object[]} the connected nodes (includes the start node)
@@ -502,13 +512,77 @@ export class ExpertAutomations extends ExpertActionsInterface {
     }
 
     /**
+     * Get direct neighbors of a node in a direction using getNodeLinks
+     * @param {object} node - the node to get neighbors for
+     * @param {'upstream'|'downstream'|'connected'} direction - direction to traverse
+     * @returns {object[]} direct neighbor nodes (deduplicated)
+     */
+    _getDirectNeighbors (node, direction) {
+        const neighbors = []
+        const seen = new Set()
+        if (direction === 'upstream' || direction === 'connected') {
+            const inLinks = this.RED.nodes.getNodeLinks(node.id, 1)
+            for (const link of inLinks) {
+                if (!seen.has(link.source.id)) {
+                    seen.add(link.source.id)
+                    neighbors.push(link.source)
+                }
+            }
+        }
+        if (direction === 'downstream' || direction === 'connected') {
+            const outLinks = this.RED.nodes.getNodeLinks(node.id, 0)
+            for (const link of outLinks) {
+                if (!seen.has(link.target.id)) {
+                    seen.add(link.target.id)
+                    neighbors.push(link.target)
+                }
+            }
+        }
+        return neighbors
+    }
+
+    /**
+     * BFS traversal from start nodes, returning nodes grouped by level
+     * @param {object[]} startNodes - the starting nodes (level 0)
+     * @param {'upstream'|'downstream'|'connected'} direction - direction to traverse
+     * @param {number} maxLevels - max levels to traverse (0 = unlimited)
+     * @returns {Map<number, object[]>} nodes grouped by level
+     */
+    _getConnectedByLevel (startNodes, direction, maxLevels) {
+        const levelMap = new Map()
+        const visited = new Set()
+        levelMap.set(0, startNodes)
+        for (const n of startNodes) visited.add(n.id)
+        let currentLevel = startNodes
+        const limit = maxLevels === 0 ? Infinity : maxLevels
+        for (let level = 0; currentLevel.length > 0 && level < limit; level++) {
+            const nextLevel = []
+            for (const node of currentLevel) {
+                const neighbors = this._getDirectNeighbors(node, direction)
+                for (const neighbor of neighbors) {
+                    if (!visited.has(neighbor.id)) {
+                        visited.add(neighbor.id)
+                        nextLevel.push(neighbor)
+                    }
+                }
+            }
+            if (nextLevel.length > 0) {
+                levelMap.set(level + 1, nextLevel)
+            }
+            currentLevel = nextLevel
+        }
+        return levelMap
+    }
+
+    /**
      * Get node or nodes by id
      * @param {string|string[]} nodeId - the id or ids of the nodes to retrieve
      * @param {'upstream'|'downstream'|'connected'|null} include - if provided, also retrieve nodes upstream, downstream, or connected to the specified node(s). Results are deduplicated.
-     * @returns {object[]} the nodes that were retrieved
+     * @param {number|undefined} levels - if defined, use BFS and return a Map<level, node[]>. 0 = all levels. Only applies when include is provided.
+     * @returns {object[]|Map<number, object[]>} flat array (no levels) or Map keyed by level number
      * @throws {Error} if any node ID is not found
      */
-    getNodes (nodeId, include) {
+    getNodes (nodeId, include, levels) {
         const ids = Array.isArray(nodeId) ? nodeId : [nodeId]
         const nodes = ids.map(id => {
             const node = this.RED.nodes.node(id)
@@ -517,6 +591,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
         })
         if (!include) {
             return nodes
+        }
+        if (levels !== undefined && levels !== null) {
+            return this._getConnectedByLevel(nodes, include, levels)
         }
         const seen = new Set()
         const result = []
@@ -536,17 +613,25 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * Select node or nodes on the workspace
      * @param {string|string[]} nodeId - the id or ids of the nodes to select
      * @param {'upstream'|'downstream'|'connected'|null} include - if provided, also select nodes upstream, downstream, or connected to the specified node(s).
-     * @returns {object[]} the nodes that were selected
+     * @param {number|undefined} levels - if defined, use BFS traversal. 0 = all levels.
+     * @returns {object[]|Map<number, object[]>} flat array or Map keyed by level
      * @throws {Error} if any node ID is not found
      */
-    selectNodes (nodeId, include) {
-        const nodes = this.getNodes(nodeId, include)
-        if (nodes.length > 0) {
+    selectNodes (nodeId, include, levels) {
+        const result = this.getNodes(nodeId, include, levels)
+        let allNodes
+        if (result instanceof Map) {
+            allNodes = []
+            for (const nodes of result.values()) allNodes.push(...nodes)
+        } else {
+            allNodes = result
+        }
+        if (allNodes.length > 0) {
             const id = Array.isArray(nodeId) ? nodeId[0] : nodeId
             this.RED.view.reveal(id, false)
-            this.RED.view.select({ nodes })
+            this.RED.view.select({ nodes: allNodes })
         }
-        return nodes
+        return result
     }
 
     /**
@@ -1399,20 +1484,14 @@ export class ExpertAutomations extends ExpertActionsInterface {
         result.handled = true // default to handled=true (set to false in default case below if action is not implemented)
         switch (actionName) {
         case SELECT_NODES: {
-            const _nodes = this.selectNodes(params.id || params.ids, params.include)
-            if (!_nodes || _nodes.length === 0) {
-                throw new Error('No nodes found to select with the provided parameters')
-            }
-            result.nodes = this._formatNodes(_nodes, params.options?.includeModuleConfig)
+            const _nodes = this.selectNodes(params.id || params.ids, params.include, params.levels)
+            result.nodes = this._formatNodeResult(_nodes, params.options?.includeModuleConfig)
             result.success = true
         }
             break
         case GET_NODES: {
-            const _nodes = this.getNodes(params.id || params.ids, params.include)
-            if (!_nodes || _nodes.length === 0) {
-                throw new Error('No nodes found with the provided parameters')
-            }
-            result.nodes = this._formatNodes(_nodes, params.options?.includeModuleConfig)
+            const _nodes = this.getNodes(params.id || params.ids, params.include, params.levels)
+            result.nodes = this._formatNodeResult(_nodes, params.options?.includeModuleConfig)
             result.success = true
         }
             break
@@ -1781,6 +1860,31 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
     _formatNodes (nodes, includeModuleConfig = true) {
         return this.RED.nodes.createExportableNodeSet(nodes, { includeModuleConfig })
+    }
+
+    /**
+     * Format a node result that may be a flat array or a leveled Map
+     * @param {object[]|Map<number, object[]>} nodes - flat array or Map<level, node[]>
+     * @param {boolean} includeModuleConfig
+     * @returns {object[]|object} formatted flat array, or object keyed by level number
+     */
+    _formatNodeResult (nodes, includeModuleConfig) {
+        if (nodes instanceof Map) {
+            let total = 0
+            const leveled = {}
+            for (const [level, levelNodes] of nodes) {
+                leveled[level] = this._formatNodes(levelNodes, includeModuleConfig)
+                total += levelNodes.length
+            }
+            if (total === 0) {
+                throw new Error('No nodes found with the provided parameters')
+            }
+            return leveled
+        }
+        if (!nodes || nodes.length === 0) {
+            throw new Error('No nodes found with the provided parameters')
+        }
+        return this._formatNodes(nodes, includeModuleConfig)
     }
 
     /**

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1517,13 +1517,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
         switch (actionName) {
         case SELECT_NODES: {
             const _nodes = this.selectNodes(params.id || params.ids, params.include, params.levels, params.includeConfigNodes)
-            result.nodes = this._formatNodeResult(_nodes, params.options?.includeModuleConfig)
+            result.nodes = this._formatNodeResult(_nodes, params.options?.includeModuleConfig, params.includeConfigNodes !== false)
             result.success = true
         }
             break
         case GET_NODES: {
             const _nodes = this.getNodes(params.id || params.ids, params.include, params.levels, params.includeConfigNodes)
-            result.nodes = this._formatNodeResult(_nodes, params.options?.includeModuleConfig)
+            result.nodes = this._formatNodeResult(_nodes, params.options?.includeModuleConfig, params.includeConfigNodes !== false)
             result.success = true
         }
             break
@@ -1890,22 +1890,28 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
     }
 
-    _formatNodes (nodes, includeModuleConfig = true) {
-        return this.RED.nodes.createExportableNodeSet(nodes, { includeModuleConfig })
+    _formatNodes (nodes, includeModuleConfig = true, includeConfigNodes = true) {
+        const formatted = this.RED.nodes.createExportableNodeSet(nodes, { includeModuleConfig })
+        if (!includeConfigNodes) {
+            const requestedIds = new Set(nodes.map(n => n.id))
+            return formatted.filter(n => requestedIds.has(n.id) || !this._isConfigNode(n))
+        }
+        return formatted
     }
 
     /**
      * Format a node result that may be a flat array or a leveled Map
      * @param {object[]|Map<number, object[]>} nodes - flat array or Map<level, node[]>
      * @param {boolean} includeModuleConfig
+     * @param {boolean} includeConfigNodes - whether to keep config nodes added by createExportableNodeSet
      * @returns {object[]|object} formatted flat array, or object keyed by level number
      */
-    _formatNodeResult (nodes, includeModuleConfig) {
+    _formatNodeResult (nodes, includeModuleConfig, includeConfigNodes = true) {
         if (nodes instanceof Map) {
             let total = 0
             const leveled = {}
             for (const [level, levelNodes] of nodes) {
-                leveled[level] = this._formatNodes(levelNodes, includeModuleConfig)
+                leveled[level] = this._formatNodes(levelNodes, includeModuleConfig, includeConfigNodes)
                 total += levelNodes.length
             }
             if (total === 0) {
@@ -1916,7 +1922,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (!nodes || nodes.length === 0) {
             throw new Error('No nodes found with the provided parameters')
         }
-        return this._formatNodes(nodes, includeModuleConfig)
+        return this._formatNodes(nodes, includeModuleConfig, includeConfigNodes)
     }
 
     /**

--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -682,7 +682,8 @@ export class ExpertComms {
             let actualType = data === null ? 'null' : typeof data
             if (Array.isArray(data)) actualType = 'array'
 
-            if (allowedTypes && !allowedTypes.includes(actualType)) {
+            if (allowedTypes && !allowedTypes.includes(actualType) &&
+                !(actualType === 'number' && allowedTypes.includes('integer') && Number.isInteger(data))) {
                 errors.push(`${path}: is not of a type(s) ${allowedTypes.join(' or ')}`)
                 return
             }

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -192,6 +192,75 @@ describeMain('expertAutomations', () => {
                 result.should.have.lengthOf(2)
                 result.map(n => n.id).should.deepEqual(['n1', 'shared'])
             })
+            describe('leveled connections', () => {
+                const n1 = { id: 'n1' }
+                const n2 = { id: 'n2' }
+                const n3 = { id: 'n3' }
+                const n4 = { id: 'n4' }
+                beforeEach(() => {
+                    mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                    mockRED.nodes.node.withArgs('n1').returns(n1)
+                    mockRED.nodes.node.withArgs('n2').returns(n2)
+                    mockRED.nodes.node.withArgs('n3').returns(n3)
+                    mockRED.nodes.node.withArgs('n4').returns(n4)
+                })
+                it('should return nodes grouped by level for downstream', () => {
+                    // n1 -> n2 -> n3 -> n4
+                    mockRED.nodes.getNodeLinks.withArgs('n1', 0).returns([{ target: n2 }])
+                    mockRED.nodes.getNodeLinks.withArgs('n2', 0).returns([{ target: n3 }])
+                    mockRED.nodes.getNodeLinks.withArgs('n3', 0).returns([{ target: n4 }])
+                    mockRED.nodes.getNodeLinks.withArgs('n4', 0).returns([])
+                    const result = expertAutomations.getNodes('n1', 'downstream', 0)
+                    result.should.be.instanceOf(Map)
+                    result.get(0).map(n => n.id).should.deepEqual(['n1'])
+                    result.get(1).map(n => n.id).should.deepEqual(['n2'])
+                    result.get(2).map(n => n.id).should.deepEqual(['n3'])
+                    result.get(3).map(n => n.id).should.deepEqual(['n4'])
+                })
+                it('should limit traversal to maxLevels', () => {
+                    // n1 -> n2 -> n3 -> n4, but only 1 level
+                    mockRED.nodes.getNodeLinks.withArgs('n1', 0).returns([{ target: n2 }])
+                    mockRED.nodes.getNodeLinks.withArgs('n2', 0).returns([{ target: n3 }])
+                    const result = expertAutomations.getNodes('n1', 'downstream', 1)
+                    result.should.be.instanceOf(Map)
+                    result.get(0).map(n => n.id).should.deepEqual(['n1'])
+                    result.get(1).map(n => n.id).should.deepEqual(['n2'])
+                    should(result.get(2)).be.undefined()
+                })
+                it('should traverse upstream using input links', () => {
+                    // n3 <- n2 <- n1
+                    mockRED.nodes.getNodeLinks.withArgs('n3', 1).returns([{ source: n2 }])
+                    mockRED.nodes.getNodeLinks.withArgs('n2', 1).returns([{ source: n1 }])
+                    mockRED.nodes.getNodeLinks.withArgs('n1', 1).returns([])
+                    const result = expertAutomations.getNodes('n3', 'upstream', 0)
+                    result.get(0).map(n => n.id).should.deepEqual(['n3'])
+                    result.get(1).map(n => n.id).should.deepEqual(['n2'])
+                    result.get(2).map(n => n.id).should.deepEqual(['n1'])
+                })
+                it('should traverse connected (both directions)', () => {
+                    // n2 -> n1 -> n3
+                    mockRED.nodes.getNodeLinks.withArgs('n1', 1).returns([{ source: n2 }])
+                    mockRED.nodes.getNodeLinks.withArgs('n1', 0).returns([{ target: n3 }])
+                    mockRED.nodes.getNodeLinks.withArgs('n2', 1).returns([])
+                    mockRED.nodes.getNodeLinks.withArgs('n2', 0).returns([])
+                    mockRED.nodes.getNodeLinks.withArgs('n3', 1).returns([])
+                    mockRED.nodes.getNodeLinks.withArgs('n3', 0).returns([])
+                    const result = expertAutomations.getNodes('n1', 'connected', 0)
+                    result.get(0).map(n => n.id).should.deepEqual(['n1'])
+                    result.get(1).should.have.lengthOf(2)
+                    const level1Ids = result.get(1).map(n => n.id).sort()
+                    level1Ids.should.deepEqual(['n2', 'n3'])
+                })
+                it('should deduplicate across multiple start nodes', () => {
+                    // n1 -> n3, n2 -> n3
+                    mockRED.nodes.getNodeLinks.withArgs('n1', 0).returns([{ target: n3 }])
+                    mockRED.nodes.getNodeLinks.withArgs('n2', 0).returns([{ target: n3 }])
+                    mockRED.nodes.getNodeLinks.withArgs('n3', 0).returns([])
+                    const result = expertAutomations.getNodes(['n1', 'n2'], 'downstream', 0)
+                    result.get(0).should.have.lengthOf(2)
+                    result.get(1).map(n => n.id).should.deepEqual(['n3'])
+                })
+            })
         })
         describe('editNode', () => {
             it('should edit a node when in default state', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -36,6 +36,7 @@ describeMain('expertAutomations', () => {
                 node: sinon.stub(),
                 group: sinon.stub().returns(null),
                 getAllFlowNodes: sinon.stub(),
+                getType: sinon.stub().returns({ category: 'function' }),
                 createExportableNodeSet: sinon.stub().callsFake((nodes) => nodes || []),
                 dirty: sinon.stub()
             },


### PR DESCRIPTION
## Summary

- Add `levels` parameter to get-nodes and select-nodes actions for BFS traversal
- When `levels` is specified with `include`, nodes are returned grouped by connection level (0 = start, 1 = direct neighbors, etc.)
- `levels=0` traverses all levels; omitting `levels` preserves flat-array behavior
- Add `includeConfigNodes` parameter (default false) to control whether config nodes appear in traversal results
- Filter config nodes injected by `createExportableNodeSet` during formatting, not just during BFS traversal

## Test plan

- Verify downstream traversal returns nodes grouped by correct levels
- Verify maxLevels limits traversal depth (levels=1 returns only direct neighbors)
- Verify upstream traversal uses input links correctly
- Verify connected traversal walks both directions
- Verify deduplication across multiple start nodes
- Verify existing flat-array behavior when levels is omitted
- Verify config nodes are excluded from results when includeConfigNodes is false (default)
- Verify config nodes injected by createExportableNodeSet are filtered post-formatting

Closes #350