### PR TITLE
feat(automation): rename to arrange-nodes and add distribution

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -26,9 +26,10 @@ const GET_PALETTE = 'automation/get-palette'
 const LIST_CONFIG_NODES = 'automation/list-config-nodes'
 const OPEN_PALETTE_MANAGER = 'automation/open-palette-manager'
 const MANAGE_GROUPS = 'automation/manage-groups'
-const ALIGN_SELECTION = 'automation/align-selection'
+const ARRANGE_NODES = 'automation/arrange-nodes'
 
 const ALIGNMENT_DIRECTIONS = ['grid', 'left', 'right', 'top', 'bottom', 'middle', 'center']
+const DISTRIBUTE_DIRECTIONS = ['horizontally', 'vertically']
 
 const ERROR_CODES = Object.freeze({
     GROUP_OPERATION_REQUIRED: 'GROUP_OPERATION_REQUIRED',
@@ -63,7 +64,7 @@ const LINK_NODE_TYPES = ['link in', 'link out', 'link call']
  *   |LIST_CONFIG_NODES
  *   |OPEN_PALETTE_MANAGER
  *   |MANAGE_GROUPS
- *   |ALIGN_SELECTION} ExpertAutomationsActionsEnum
+ *   |ARRANGE_NODES} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -463,19 +464,19 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 required: ['operations']
             }
         },
-        [ALIGN_SELECTION]: {
+        [ARRANGE_NODES]: {
             params: {
                 type: 'object',
                 properties: {
                     ids: {
                         type: 'array',
                         items: { type: 'string' },
-                        description: 'IDs of nodes to align'
+                        description: 'IDs of nodes to align or distribute'
                     },
                     direction: {
                         type: 'string',
-                        enum: ALIGNMENT_DIRECTIONS,
-                        description: 'Alignment direction: "grid" snaps to grid; "left", "right", "top", "bottom" align to the respective edge; "middle" aligns vertically; "center" aligns horizontally'
+                        enum: [...ALIGNMENT_DIRECTIONS, ...DISTRIBUTE_DIRECTIONS],
+                        description: 'Alignment: "grid" snaps to grid; "left", "right", "top", "bottom" align to edge; "middle" aligns vertically; "center" aligns horizontally. Distribution: "horizontally" or "vertically" evenly spaces nodes (requires 3+)'
                     }
                 },
                 required: ['ids', 'direction']
@@ -1751,8 +1752,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
             result.success = true
             break
         }
-        case ALIGN_SELECTION: {
-            const { aligned, excluded } = this.alignSelection(params.ids, params.direction)
+        case ARRANGE_NODES: {
+            const { aligned, excluded } = this.arrangeNodes(params.ids, params.direction)
             result.data = {
                 alignedNodes: aligned.map(n => this._summarizeNode(n)),
                 excludedConfigNodes: excluded.map(n => ({ id: n.id, type: n.type }))
@@ -1990,27 +1991,31 @@ export class ExpertAutomations extends ExpertActionsInterface {
     }
 
     /**
-     * Align the specified nodes using a Node-RED core alignment action.
-     * @param {string[]} ids - node IDs to align
-     * @param {'grid'|'left'|'right'|'top'|'bottom'|'middle'|'center'} direction
+     * Align or distribute the specified nodes using a Node-RED core action.
+     * @param {string[]} ids - node IDs to arrange
+     * @param {string} direction - alignment or distribution direction
      */
-    alignSelection (ids, direction) {
+    arrangeNodes (ids, direction) {
         if (!ids || ids.length === 0) throw new Error('ids array must not be empty')
-        if (!ALIGNMENT_DIRECTIONS.includes(direction)) {
-            throw new Error(`Invalid alignment direction: ${direction}`)
+        const isDistribute = DISTRIBUTE_DIRECTIONS.includes(direction)
+        const isAlign = ALIGNMENT_DIRECTIONS.includes(direction)
+        if (!isDistribute && !isAlign) {
+            throw new Error(`Invalid direction "${direction}". Valid alignment: ${ALIGNMENT_DIRECTIONS.join(', ')}. Valid distribution: ${DISTRIBUTE_DIRECTIONS.join(', ')}`)
         }
         const allNodes = ids.map(id => {
             const node = this.RED.nodes.node(id)
             if (!node) throw new Error(`Node ${id} not found`)
             return node
         })
-        // Exclude config nodes — they have no canvas position and break alignment
         const nodes = allNodes.filter(n => {
             const def = this.RED.nodes.getType(n.type)
             return !def || def.category !== 'config'
         })
         if (nodes.length === 0) throw new Error('No non-config nodes to align')
-        if (direction !== 'grid' && nodes.length < 2) {
+        if (isDistribute && nodes.length < 3) {
+            throw new Error('Distribution requires at least 3 non-config nodes')
+        }
+        if (!isDistribute && direction !== 'grid' && nodes.length < 2) {
             throw new Error(`Alignment direction "${direction}" requires at least 2 non-config nodes`)
         }
         this._assertWorkspaceExists(nodes[0].z)
@@ -2018,7 +2023,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
         this.RED.view.reveal(nodes[0].id, false)
         this.RED.view.select({ nodes })
         this._verifySelection(nodes)
-        this.RED.actions.invoke(`core:align-selection-to-${direction}`)
+        if (isDistribute) {
+            this.RED.actions.invoke(`core:distribute-selection-${direction}`)
+        } else {
+            this.RED.actions.invoke(`core:align-selection-to-${direction}`)
+        }
         const excluded = allNodes.filter(n => !nodes.includes(n))
         return { aligned: nodes, excluded }
     }

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -102,7 +102,7 @@ describeMain('expertAutomations', () => {
                 'automation/list-config-nodes',
                 'automation/open-palette-manager',
                 'automation/manage-groups',
-                'automation/align-selection'
+                'automation/arrange-nodes'
             ]
             supportedActions.should.only.have.keys(...expectedKeys)
         })
@@ -3105,7 +3105,7 @@ describeMain('expertAutomations', () => {
                 existingGroup.name.should.equal('Renamed')
             })
         })
-        describe('alignSelection action', () => {
+        describe('arrangeNodes action', () => {
             beforeEach(() => {
                 mockRED.actions = { invoke: sinon.stub() }
                 mockRED.view.select = sinon.stub()
@@ -3121,7 +3121,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('n1').returns(n1)
                 mockRED.nodes.node.withArgs('n2').returns(n2)
                 const result = {}
-                await expertAutomations.invokeAction('automation/align-selection', {
+                await expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['n1', 'n2'], direction: 'grid' }
                 }, result)
                 mockRED.view.reveal.calledWith('n1', false).should.be.true()
@@ -3132,7 +3132,7 @@ describeMain('expertAutomations', () => {
                 result.data.alignedNodes.should.have.lengthOf(2)
                 result.data.excludedConfigNodes.should.have.lengthOf(0)
             })
-            it('should invoke the correct core action for each direction', async () => {
+            it('should invoke the correct core action for each alignment direction', async () => {
                 const n1 = { id: 'n1', type: 'inject', x: 10, y: 20, z: 'tab1' }
                 const n2 = { id: 'n2', type: 'debug', x: 30, y: 40, z: 'tab1' }
                 mockRED.nodes.node.withArgs('n1').returns(n1)
@@ -3141,31 +3141,59 @@ describeMain('expertAutomations', () => {
                 for (const direction of directions) {
                     mockRED.actions.invoke.resetHistory()
                     const result = {}
-                    await expertAutomations.invokeAction('automation/align-selection', {
+                    await expertAutomations.invokeAction('automation/arrange-nodes', {
                         params: { ids: ['n1', 'n2'], direction }
                     }, result)
                     mockRED.actions.invoke.calledWith(`core:align-selection-to-${direction}`).should.be.true()
                     result.should.have.property('success', true)
                 }
             })
+            it('should invoke core:distribute-selection for distribution directions', async () => {
+                const n1 = { id: 'n1', type: 'inject', x: 10, y: 20, z: 'tab1' }
+                const n2 = { id: 'n2', type: 'debug', x: 30, y: 40, z: 'tab1' }
+                const n3 = { id: 'n3', type: 'function', x: 50, y: 60, z: 'tab1' }
+                mockRED.nodes.node.withArgs('n1').returns(n1)
+                mockRED.nodes.node.withArgs('n2').returns(n2)
+                mockRED.nodes.node.withArgs('n3').returns(n3)
+                for (const direction of ['horizontally', 'vertically']) {
+                    mockRED.actions.invoke.resetHistory()
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/arrange-nodes', {
+                        params: { ids: ['n1', 'n2', 'n3'], direction }
+                    }, result)
+                    mockRED.actions.invoke.calledWith(`core:distribute-selection-${direction}`).should.be.true()
+                    result.should.have.property('success', true)
+                    result.data.alignedNodes.should.have.lengthOf(3)
+                }
+            })
+            it('should throw if distribution is requested with fewer than 3 nodes', async () => {
+                const n1 = { id: 'n1', type: 'inject', x: 10, y: 20, z: 'tab1' }
+                const n2 = { id: 'n2', type: 'debug', x: 30, y: 40, z: 'tab1' }
+                mockRED.nodes.node.withArgs('n1').returns(n1)
+                mockRED.nodes.node.withArgs('n2').returns(n2)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/arrange-nodes', {
+                    params: { ids: ['n1', 'n2'], direction: 'horizontally' }
+                }, result)).rejectedWith(/Distribution requires at least 3 non-config nodes/)
+            })
             it('should throw if ids array is empty', async () => {
                 const result = {}
-                await should(expertAutomations.invokeAction('automation/align-selection', {
+                await should(expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: [], direction: 'grid' }
                 }, result)).rejectedWith(/ids array must not be empty/)
             })
             it('should throw if a node ID does not exist', async () => {
                 mockRED.nodes.node.returns(null)
                 const result = {}
-                await should(expertAutomations.invokeAction('automation/align-selection', {
+                await should(expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['nonexistent'], direction: 'grid' }
                 }, result)).rejectedWith(/Node nonexistent not found/)
             })
-            it('should throw if non-grid direction is used with a single node', async () => {
+            it('should throw if non-grid alignment direction is used with a single node', async () => {
                 const node = { id: 'n1', type: 'inject', x: 10, y: 20, z: 'tab1' }
                 mockRED.nodes.node.withArgs('n1').returns(node)
                 const result = {}
-                await should(expertAutomations.invokeAction('automation/align-selection', {
+                await should(expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['n1'], direction: 'left' }
                 }, result)).rejectedWith(/requires at least 2 non-config nodes/)
             })
@@ -3173,7 +3201,7 @@ describeMain('expertAutomations', () => {
                 const node = { id: 'n1', type: 'inject', x: 13, y: 27, z: 'tab1' }
                 mockRED.nodes.node.withArgs('n1').returns(node)
                 const result = {}
-                await expertAutomations.invokeAction('automation/align-selection', {
+                await expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['n1'], direction: 'grid' }
                 }, result)
                 mockRED.view.reveal.calledWith('n1', false).should.be.true()
@@ -3184,16 +3212,16 @@ describeMain('expertAutomations', () => {
                 const node = { id: 'n1', type: 'inject', x: 10, y: 20 }
                 mockRED.nodes.node.withArgs('n1').returns(node)
                 const result = {}
-                await should(expertAutomations.invokeAction('automation/align-selection', {
+                await should(expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['n1'], direction: 'diagonal' }
-                }, result)).rejectedWith(/Invalid alignment direction/)
+                }, result)).rejectedWith(/Invalid direction/)
             })
             it('should throw if workspace is locked', async () => {
                 const node = { id: 'n1', type: 'inject', x: 10, y: 20, z: 'locked-tab' }
                 mockRED.nodes.node.withArgs('n1').returns(node)
                 mockRED.workspaces.isLocked = sinon.stub().withArgs('locked-tab').returns(true)
                 const result = {}
-                await should(expertAutomations.invokeAction('automation/align-selection', {
+                await should(expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['n1'], direction: 'grid' }
                 }, result)).rejectedWith(/Workspace locked-tab is locked/)
             })
@@ -3206,7 +3234,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('cfg1').returns(cfg)
                 mockRED.nodes.getType.withArgs('mqtt-broker').returns({ category: 'config' })
                 const result = {}
-                await expertAutomations.invokeAction('automation/align-selection', {
+                await expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['n1', 'cfg1', 'n2'], direction: 'grid' }
                 }, result)
                 mockRED.view.select.calledWith({ nodes: [n1, n2] }).should.be.true()
@@ -3221,7 +3249,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('cfg1').returns(cfg)
                 mockRED.nodes.getType.withArgs('mqtt-broker').returns({ category: 'config' })
                 const result = {}
-                await should(expertAutomations.invokeAction('automation/align-selection', {
+                await should(expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['cfg1'], direction: 'grid' }
                 }, result)).rejectedWith(/No non-config nodes to align/)
             })


### PR DESCRIPTION
## Summary
- Renames `align-selection` action to `arrange-nodes`
- Adds horizontal and vertical distribution directions (requires 3+ nodes)
- Alignment directions unchanged: grid, left, right, top, bottom, middle, center

Closes #352 

## Test plan
- Existing alignment tests updated to use new action name
- New tests for distribution directions and minimum node count validation
- All 392 tests passing