### PR TITLE
fix(automations): update config node users array in updateNode

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -776,6 +776,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
         const changes = {}
 
+        this.RED.nodes.updateConfigNodeUsers(node, { action: 'remove' })
+
         // Apply line-based patches first (before full property replacement)
         // so that patches reference the original line numbers
         if (hasPatches) {
@@ -794,6 +796,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
             Object.assign(node, properties)
         }
 
+        this.RED.nodes.updateConfigNodeUsers(node, { action: 'add' })
+
         const wasChanged = node.changed
         this.RED.history.push({ t: 'edit', node, changes, changed: wasChanged, dirty: this.RED.nodes.dirty() })
         node.changed = true
@@ -805,6 +809,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         this.RED.view.updateActive()
         this.RED.view.redraw()
         this.RED.sidebar?.info?.refresh()
+        this.RED.sidebar?.config?.refresh()
 
         if (this.RED.view.state() !== this.RED.state?.DEFAULT) {
             await this.closeEditorTray()

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -37,7 +37,8 @@ describeMain('expertAutomations', () => {
                 group: sinon.stub().returns(null),
                 getAllFlowNodes: sinon.stub(),
                 createExportableNodeSet: sinon.stub().callsFake((nodes) => nodes || []),
-                dirty: sinon.stub()
+                dirty: sinon.stub(),
+                updateConfigNodeUsers: sinon.stub()
             },
             settings: {
                 version: '4.1.4'


### PR DESCRIPTION
Fixes #356

## Background

`users` is a runtime-only in-memory array Node-RED keeps on every config node. It holds direct references to the regular nodes that currently reference it, and is used by:

- The sidebar "unused" badge (`users.length === 0` marks a config node unused)
- Validation — re-validates dependent nodes when a config node edit is saved
- Deletion — clears the config property on every node in `users` when a config node is deleted
- The "X nodes use this" tooltip in the config sidebar

It is never persisted to flow JSON; it is rebuilt from scratch on every import via `addNode` calling `updateConfigNodeUsers`. That function is also called by `removeNode`, but it was never called during a forward edit — so any `updateNode` call that changed a config-type property left `users` stale.

## Changes

**Fix 1 — keep `users` correct**

Wrap all mutations in `updateNode` with a remove/add pair:

```js
this.RED.nodes.updateConfigNodeUsers(node, { action: 'remove' })
// patches and property assignments
this.RED.nodes.updateConfigNodeUsers(node, { action: 'add' })
```

The `remove` call runs while the node still holds its old values, splicing it from the old config node's `users`. The `add` call runs after all changes are applied, inserting it into the new config node's `users`. Both the patch path and the full property-replacement path are covered by this single pair.

**Fix 2 — refresh the sidebar config panel**

Add `this.RED.sidebar?.config?.refresh()` after mutations. The config panel reads `users.length` directly but has no listener for `nodes:change` — without this call the badge stays stale until something else triggers a redraw.