### PR TITLE
fix: Tighter workspace permission checks

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1153,8 +1153,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {string} z - tab ID to remove
      */
     removeTab (z) {
-        this._assertWorkspaceIsEditable(z)
         const ws = this.RED.nodes.workspace(z)
+        if (!ws) throw new Error(`Workspace ${z} not found`)
+        this._assertWorkspaceIsEditable(z)
         this.RED.workspaces.delete(ws)
     }
 

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -588,6 +588,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         } else {
             throw new Error('importFlow expects a JSON string or an array of node objects')
         }
+        this._assertWritePermission()
         // If importing onto the current tab (not creating a new one), check it's not locked
         if (!addFlow && this.RED.workspaces.isLocked()) {
             throw new Error('Cannot import into a locked workspace')
@@ -605,6 +606,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
     }
 
     async addFlowTab (title) {
+        this._assertWritePermission()
         const cmd = () => {
             if (!title) {
                 // if no title is specified, we let the core action perform this (auto naming)
@@ -644,9 +646,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const node = this.RED.nodes.node(id)
         if (!node) throw new Error(`Node ${id} not found`)
 
-        this._assertWorkspaceExists(targetTabId)
-        this._assertWorkspaceNotLocked(targetTabId)
-        this._assertWorkspaceNotLocked(node.z)
+        this._assertWorkspaceIsEditable(targetTabId)
+        this._assertWorkspaceIsEditable(node.z)
 
         const wasDirty = this.RED.nodes.dirty()
 
@@ -773,6 +774,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
         const node = this.RED.nodes.node(id)
         if (!node) throw new Error(`Node ${id} not found`)
+
+        this._assertWorkspaceIsEditable(node.z)
 
         const changes = {}
 
@@ -1064,19 +1067,40 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
     /**
      * Throw if the workspace does not exist.
-     * @param {string} id - workspace ID
+     * @param {string} z - workspace tab ID
      */
-    _assertWorkspaceExists (id) {
-        if (!this.hasWorkspace(id)) throw new Error(`Workspace ${id} not found`)
+    _assertWorkspaceExists (z) {
+        if (!this.hasWorkspace(z)) throw new Error(`Workspace ${z} not found`)
     }
 
     /**
-     * Throw if the workspace tab is locked. No-op when tabId is falsy (e.g. config nodes).
-     * @param {string|null|undefined} tabId - workspace tab ID
+     * Throw if the workspace tab is missing, is locked, or user does not have write permission.
+     * If z is null or undefined, only check the editor state and user permissions (i.e. config nodes).
+     * @param {string|null|undefined} z - workspace tab ID
      */
-    _assertWorkspaceNotLocked (tabId) {
-        if (!tabId) return
-        if (this.RED.workspaces.isLocked(tabId)) throw new Error(`Workspace ${tabId} is locked`)
+    _assertWorkspaceIsEditable (z) {
+        // if z is null or undefined, assume the caller is trying to edit a config node
+        if (z) {
+            this._assertWorkspaceExists(z)
+            if (this.RED.workspaces.isLocked(z)) {
+                throw new Error(`Workspace ${z} is locked`)
+            }
+        }
+        this._assertWritePermission()
+    }
+
+    _assertWritePermission () {
+        if (!this.RED.user.hasPermission('flows.write')) {
+            throw new Error('Permission denied: user account does not have write permission')
+        }
+    }
+
+    isConfigNode (id) {
+        const node = this.RED.nodes.node(id)
+        if (!node) { throw new Error(`Node ${id} not found`) }
+        const def = node._def || this.RED.nodes.getType(node.type)
+        if (!def) { return false }
+        return def.category === 'config'
     }
 
     closeSearch () { this.RED.search.hide() }
@@ -1107,6 +1131,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (tab.id && (this.RED.nodes.node(tab.id) || this.RED.nodes.workspace(tab.id) || this.RED.nodes.subflow(tab.id))) {
             throw new Error(`ID ${tab.id} already exists — provide a unique ID or omit to auto-generate`)
         }
+        this._assertWritePermission()
         const ws = {
             type: 'tab',
             id: tab.id || this.RED.nodes.id(),
@@ -1125,16 +1150,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
 
     /**
      * Remove an existing flow tab from the NR4 editor.
-     * @param {string} id - tab ID to remove
+     * @param {string} z - tab ID to remove
      */
-    removeTab (id) {
-        const ws = this.RED.nodes.workspace(id)
-        if (!ws) {
-            throw new Error(`Tab with id ${id} not found`)
-        }
-        if (ws.locked) {
-            throw new Error(`Tab ${id} is locked and cannot be removed`)
-        }
+    removeTab (z) {
+        this._assertWorkspaceIsEditable(z)
+        const ws = this.RED.nodes.workspace(z)
         this.RED.workspaces.delete(ws)
     }
 
@@ -1152,17 +1172,19 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const prepared = nodes.map(rawNode => {
             if (!rawNode.id) throw new Error('Node is missing required property: id')
             if (!rawNode.type) throw new Error('Node is missing required property: type')
-            const def = this.RED.nodes.getType(rawNode.type)
-            if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
-            const isConfigNode = def.category === 'config'
+            const isConfigNode = this.isConfigNode(rawNode.id)
             if (!isConfigNode && !rawNode.z) throw new Error('Node is missing required property: z')
             return { ...rawNode }
         })
         // Validate all target tabs exist and are not locked
         const uniqueZs = [...new Set(prepared.map(n => n.z).filter(Boolean))]
         for (const z of uniqueZs) {
-            this._assertWorkspaceExists(z)
-            this._assertWorkspaceNotLocked(z)
+            this._assertWorkspaceIsEditable(z)
+        }
+        // If a config node is being added, ensure the user has write permission
+        const hasConfigNodes = prepared.some(n => !n.z)
+        if (hasConfigNodes) {
+            this._assertWritePermission()
         }
         // Pre-import: reject if any node ID already exists on the canvas
         if (!generateIds) {
@@ -1210,7 +1232,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         })
         // Check if any node's workspace is locked
         for (const node of nodes) {
-            this._assertWorkspaceNotLocked(node.z)
+            this._assertWorkspaceIsEditable(node.z)
         }
         this.RED.view.select({ nodes })
         this._verifySelection(nodes)
@@ -1235,12 +1257,22 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (!sourceNode) throw new Error(`Source node ${source} not found`)
         const targetNode = this.RED.nodes.node(target)
         if (!targetNode) throw new Error(`Target node ${target} not found`)
+        // wires can only be set on workspace nodes (not config nodes)
+        if (this.isConfigNode(source)) {
+            throw new Error(`Source node ${source} is a config node and cannot be wired`)
+        }
+        if (this.isConfigNode(target)) {
+            throw new Error(`Target node ${target} is a config node and cannot be wired`)
+        }
+        if (!sourceNode.z) { throw new Error(`Source node ${source} is not a workspace node and cannot be wired`) }
+        if (!targetNode.z) { throw new Error(`Target node ${target} is not a workspace node and cannot be wired`) }
         // Source and target must be on the same tab
         if (sourceNode.z !== targetNode.z) {
             throw new Error('Source and target nodes must be on the same tab')
         }
         // Check workspace is not locked
-        this._assertWorkspaceNotLocked(sourceNode.z)
+        this._assertWorkspaceIsEditable(sourceNode.z)
+        this._assertWorkspaceIsEditable(targetNode.z)
         // Validate output port exists on source
         const port = output ?? 0
         if (port >= (sourceNode.outputs || 0)) {
@@ -1293,6 +1325,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (!sourceNode) throw new Error(`Source node ${source} not found`)
         const targetNode = this.RED.nodes.node(target)
         if (!targetNode) throw new Error(`Target node ${target} not found`)
+        // Validate these are link xxx nodes
+        if (!LINK_NODE_TYPES.includes(sourceNode.type)) {
+            throw new Error(`Source node ${source} must be a link node`)
+        }
+        if (!LINK_NODE_TYPES.includes(targetNode.type)) {
+            throw new Error(`Target node ${target} must be a link node`)
+        }
         // Validate types: source must be link out or link call, target must be link in
         if (sourceNode.type !== 'link out' && sourceNode.type !== 'link call') {
             throw new Error(`Source node ${source} must be a link out or link call node (got ${sourceNode.type})`)
@@ -1308,9 +1347,15 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (sourceNode.type === 'link call' && sourceNode.linkType === 'dynamic') {
             throw new Error(`Source node ${source} is a link call in dynamic mode and cannot have static links`)
         }
-        // Check workspace locks for both nodes
-        this._assertWorkspaceNotLocked(sourceNode.z)
-        if (targetNode.z !== sourceNode.z) this._assertWorkspaceNotLocked(targetNode.z)
+
+        // assert z is an actual workspace tab and that they exists
+        if (!sourceNode.z) { throw new Error(`Source node ${source} is missing workspace (z) property`) }
+        if (!targetNode.z) { throw new Error(`Target node ${target} is missing workspace (z) property`) }
+        // Check workspace is editable for both nodes
+        this._assertWorkspaceIsEditable(sourceNode.z)
+        if (targetNode.z !== sourceNode.z) {
+            this._assertWorkspaceIsEditable(targetNode.z)
+        }
         const isBidirectional = sourceNode.type === 'link out'
         const sourceLinks = sourceNode.links || []
         const targetLinks = targetNode.links || []
@@ -1836,7 +1881,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             throw new Error('All nodes must be on the same tab to form a group')
         }
         const tabId = tabs.size === 1 ? [...tabs][0] : null
-        this._assertWorkspaceNotLocked(tabId)
+        this._assertWorkspaceIsEditable(tabId)
 
         // Snapshot existing group IDs so we can identify the newly created one
         const existingGroupIds = new Set()
@@ -1909,7 +1954,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
     updateGroup (id, { name, nodeIds, remove, style, env } = {}) {
         let group = this.RED.nodes.group(id)
         if (!group) throw new Error(`Group ${id} not found`)
-        this._assertWorkspaceNotLocked(group.z)
+        this._assertWorkspaceIsEditable(group.z)
 
         if (nodeIds && nodeIds.length > 0) {
             if (remove) {
@@ -1982,7 +2027,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
     deleteGroup (id) {
         const group = this.RED.nodes.group(id)
         if (!group) throw new Error(`Group ${id} not found`)
-        this._assertWorkspaceNotLocked(group.z)
+        this._assertWorkspaceIsEditable(group.z)
         this.RED.view.select({ nodes: [group] })
         this._verifySelection([group])
         this.RED.actions.invoke('core:ungroup-selection')
@@ -2007,29 +2052,27 @@ export class ExpertAutomations extends ExpertActionsInterface {
             if (!node) throw new Error(`Node ${id} not found`)
             return node
         })
-        const nodes = allNodes.filter(n => {
-            const def = this.RED.nodes.getType(n.type)
-            return !def || def.category !== 'config'
+        const workspaceNodes = allNodes.filter(n => {
+            return !this.isConfigNode(n.id)
         })
-        if (nodes.length === 0) throw new Error('No non-config nodes to align')
-        if (isDistribute && nodes.length < 3) {
-            throw new Error('Distribution requires at least 3 non-config nodes')
+        if (workspaceNodes.length === 0) throw new Error('No workspace nodes to align')
+        if (isDistribute && workspaceNodes.length < 3) {
+            throw new Error('Distribution requires at least 3 workspace nodes')
         }
-        if (!isDistribute && direction !== 'grid' && nodes.length < 2) {
-            throw new Error(`Alignment direction "${direction}" requires at least 2 non-config nodes`)
+        if (!isDistribute && direction !== 'grid' && workspaceNodes.length < 2) {
+            throw new Error(`Alignment direction "${direction}" requires at least 2 workspace nodes`)
         }
-        this._assertWorkspaceExists(nodes[0].z)
-        this._assertWorkspaceNotLocked(nodes[0].z)
-        this.RED.view.reveal(nodes[0].id, false)
-        this.RED.view.select({ nodes })
-        this._verifySelection(nodes)
+        this._assertWorkspaceIsEditable(workspaceNodes[0].z)
+        this.RED.view.reveal(workspaceNodes[0].id, false)
+        this.RED.view.select({ nodes: workspaceNodes })
+        this._verifySelection(workspaceNodes)
         if (isDistribute) {
             this.RED.actions.invoke(`core:distribute-selection-${direction}`)
         } else {
             this.RED.actions.invoke(`core:align-selection-to-${direction}`)
         }
-        const excluded = allNodes.filter(n => !nodes.includes(n))
-        return { aligned: nodes, excluded }
+        const excluded = allNodes.filter(n => !workspaceNodes.includes(n))
+        return { aligned: workspaceNodes, excluded }
     }
 
     _summarizeNode (node) {

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1173,7 +1173,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const prepared = nodes.map(rawNode => {
             if (!rawNode.id) throw new Error('Node is missing required property: id')
             if (!rawNode.type) throw new Error('Node is missing required property: type')
-            const isConfigNode = this.isConfigNode(rawNode.id)
+            const def = this.RED.nodes.getType(rawNode.type)
+            if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
+            const isConfigNode = def.category === 'config'
             if (!isConfigNode && !rawNode.z) throw new Error('Node is missing required property: z')
             return { ...rawNode }
         })

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1079,6 +1079,15 @@ export class ExpertAutomations extends ExpertActionsInterface {
     }
 
     /**
+     * Throw if the user does not have write permission, which is required for any operation that modifies nodes or workspaces.
+     */
+    _assertWritePermission () {
+        if (!this.RED.user.hasPermission('flows.write')) {
+            throw new Error('Permission denied: user account does not have write permission')
+        }
+    }
+
+    /**
      * Throw if the workspace tab is missing, is locked, or user does not have write permission.
      * If z is null or undefined, only check the editor state and user permissions (i.e. config nodes).
      * @param {string|null|undefined} z - workspace tab ID
@@ -1092,12 +1101,6 @@ export class ExpertAutomations extends ExpertActionsInterface {
             }
         }
         this._assertWritePermission()
-    }
-
-    _assertWritePermission () {
-        if (!this.RED.user.hasPermission('flows.write')) {
-            throw new Error('Permission denied: user account does not have write permission')
-        }
     }
 
     isConfigNode (id) {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -37,12 +37,16 @@ describeMain('expertAutomations', () => {
                 group: sinon.stub().returns(null),
                 getAllFlowNodes: sinon.stub(),
                 createExportableNodeSet: sinon.stub().callsFake((nodes) => nodes || []),
-                dirty: sinon.stub()
+                dirty: sinon.stub(),
+                workspace: sinon.stub().returns({ id: 'default-tab', type: 'tab' })
             },
             settings: {
                 version: '4.1.4'
             },
             state: { DEFAULT: 1 },
+            user: {
+                hasPermission: sinon.stub().returns(true)
+            },
             workspaces: {
                 active: sinon.stub().returns('active-tab'),
                 show: sinon.stub(),
@@ -709,7 +713,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('li1').returns({ id: 'li1', type: 'link in', z: 'tab1' })
                 await should(expertAutomations.invokeAction('automation/set-links', {
                     params: { mode: 'add', source: 'n1', target: 'li1' }
-                }, {})).rejectedWith(/must be a link out or link call node/)
+                }, {})).rejectedWith(/must be a link node/)
             })
             it('should throw if target is not a link in', async () => {
                 mockRED.nodes.node.withArgs('lo1').returns({ id: 'lo1', type: 'link out', mode: 'link', z: 'tab1' })
@@ -1089,7 +1093,8 @@ describeMain('expertAutomations', () => {
                     delete: sinon.stub(),
                     selection: sinon.stub().returns([]),
                     active: sinon.stub().returns(null),
-                    isHidden: sinon.stub().returns(false)
+                    isHidden: sinon.stub().returns(false),
+                    isLocked: sinon.stub().returns(false)
                 }
                 const result = {}
                 await expertAutomations.invokeAction('automation/remove-tab', {
@@ -1103,24 +1108,24 @@ describeMain('expertAutomations', () => {
             })
             it('should throw if tab not found', async () => {
                 mockRED.nodes.workspace = sinon.stub().returns(null)
-                mockRED.workspaces = { delete: sinon.stub() }
+                mockRED.workspaces = { delete: sinon.stub(), isLocked: sinon.stub().returns(false) }
                 await should(expertAutomations.invokeAction('automation/remove-tab', {
                     params: { id: 'does-not-exist' }
-                }, {})).rejectedWith(/Tab with id does-not-exist not found/)
+                }, {})).rejectedWith(/Workspace does-not-exist not found/)
             })
             it('should throw if id is empty', async () => {
                 mockRED.nodes.workspace = sinon.stub().returns(null)
-                mockRED.workspaces = { delete: sinon.stub() }
+                mockRED.workspaces = { delete: sinon.stub(), isLocked: sinon.stub().returns(false) }
                 await should(expertAutomations.invokeAction('automation/remove-tab', {
                     params: { id: '' }
-                }, {})).rejectedWith(/Tab with id .* not found/)
+                }, {})).rejectedWith(/Workspace .* not found/)
             })
             it('should throw if tab is locked', async () => {
                 mockRED.nodes.workspace = sinon.stub().withArgs('locked-tab').returns({ id: 'locked-tab', type: 'tab', locked: true })
-                mockRED.workspaces = { delete: sinon.stub() }
+                mockRED.workspaces = { delete: sinon.stub(), isLocked: sinon.stub().withArgs('locked-tab').returns(true) }
                 await should(expertAutomations.invokeAction('automation/remove-tab', {
                     params: { id: 'locked-tab' }
-                }, {})).rejectedWith(/Tab locked-tab is locked/)
+                }, {})).rejectedWith(/Workspace locked-tab is locked/)
                 mockRED.workspaces.delete.called.should.be.false()
             })
         })
@@ -3174,7 +3179,7 @@ describeMain('expertAutomations', () => {
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['n1', 'n2'], direction: 'horizontally' }
-                }, result)).rejectedWith(/Distribution requires at least 3 non-config nodes/)
+                }, result)).rejectedWith(/Distribution requires at least 3 workspace nodes/)
             })
             it('should throw if ids array is empty', async () => {
                 const result = {}
@@ -3195,7 +3200,7 @@ describeMain('expertAutomations', () => {
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['n1'], direction: 'left' }
-                }, result)).rejectedWith(/requires at least 2 non-config nodes/)
+                }, result)).rejectedWith(/requires at least 2 workspace nodes/)
             })
             it('should allow grid alignment with a single node', async () => {
                 const node = { id: 'n1', type: 'inject', x: 13, y: 27, z: 'tab1' }
@@ -3251,7 +3256,7 @@ describeMain('expertAutomations', () => {
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['cfg1'], direction: 'grid' }
-                }, result)).rejectedWith(/No non-config nodes to align/)
+                }, result)).rejectedWith(/No workspace nodes to align/)
             })
         })
     })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -3259,5 +3259,133 @@ describeMain('expertAutomations', () => {
                 }, result)).rejectedWith(/No workspace nodes to align/)
             })
         })
+        describe('write permission enforcement (flows.write)', () => {
+            beforeEach(() => {
+                mockRED.user.hasPermission = sinon.stub().withArgs('flows.write').returns(false)
+                // Common mocks used across the write-protected actions below
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', type: 'tab' })
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.nodes.addLink = sinon.stub()
+                mockRED.nodes.removeLink = sinon.stub()
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+                mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })
+                mockRED.nodes.addWorkspace = sinon.stub()
+                mockRED.nodes.id = sinon.stub().returns('gen-id')
+                mockRED.nodes.subflow = sinon.stub().returns(null)
+                mockRED.view.importNodes = sinon.stub()
+                mockRED.view.select = sinon.stub()
+                mockRED.view.selection = sinon.stub().returns({ nodes: [] })
+                mockRED.history = { push: sinon.stub() }
+                mockRED.actions = { invoke: sinon.stub() }
+                mockRED.editor = { validateNode: sinon.stub() }
+                mockRED.workspaces = {
+                    ...mockRED.workspaces,
+                    isLocked: sinon.stub().returns(false),
+                    add: sinon.stub(),
+                    delete: sinon.stub()
+                }
+            })
+            it('should reject add-flow-tab', async () => {
+                sinon.stub(expertAutomations.redOps, 'commandAndWait').callsFake((cmd) => { cmd(); return Promise.resolve() })
+                await should(expertAutomations.invokeAction('automation/add-flow-tab', {
+                    params: { title: 'New Flow' }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.view.importNodes.called.should.be.false()
+            })
+            it('should reject add-tab', async () => {
+                mockRED.nodes.workspace = sinon.stub().returns(null) // no existing tab with this id
+                await should(expertAutomations.invokeAction('automation/add-tab', {
+                    params: { label: 'New Tab' }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.nodes.addWorkspace.called.should.be.false()
+            })
+            it('should reject remove-tab', async () => {
+                const ws = { id: 'tab1', type: 'tab' }
+                mockRED.nodes.workspace = sinon.stub().withArgs('tab1').returns(ws)
+                await should(expertAutomations.invokeAction('automation/remove-tab', {
+                    params: { id: 'tab1' }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.workspaces.delete.called.should.be.false()
+            })
+            it('should reject add-nodes', async () => {
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'n1', type: 'inject', z: 'tab1' }] }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.view.importNodes.called.should.be.false()
+            })
+            it('should reject add-nodes for config-only nodes (no z)', async () => {
+                mockRED.nodes.getType = sinon.stub().returns({ category: 'config', inputs: 0, outputs: 0, defaults: {} })
+                await should(expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes: [{ id: 'cfg1', type: 'ui-base' }] }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.view.importNodes.called.should.be.false()
+            })
+            it('should reject remove-nodes', async () => {
+                mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1' })
+                await should(expertAutomations.invokeAction('automation/remove-nodes', {
+                    params: { ids: ['n1'] }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.actions.invoke.called.should.be.false()
+            })
+            it('should reject update-nodes', async () => {
+                mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1', type: 'inject', name: 'old' })
+                await should(expertAutomations.invokeAction('automation/update-nodes', {
+                    params: { nodes: [{ id: 'n1', updates: [{ property: 'name', op: 'replace', content: 'new' }] }] }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.history.push.called.should.be.false()
+            })
+            it('should reject set-wires', async () => {
+                mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1', outputs: 1 })
+                mockRED.nodes.node.withArgs('n2').returns({ id: 'n2', z: 'tab1', type: 'debug' })
+                await should(expertAutomations.invokeAction('automation/set-wires', {
+                    params: { mode: 'add', source: 'n1', target: 'n2' }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.nodes.addLink.called.should.be.false()
+            })
+            it('should reject set-links', async () => {
+                mockRED.nodes.node.withArgs('lo1').returns({ id: 'lo1', type: 'link out', mode: 'link', z: 'tab1', links: [] })
+                mockRED.nodes.node.withArgs('li1').returns({ id: 'li1', type: 'link in', z: 'tab1', links: [] })
+                await should(expertAutomations.invokeAction('automation/set-links', {
+                    params: { mode: 'add', source: 'lo1', target: 'li1' }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.history.push.called.should.be.false()
+            })
+            it('should reject import-flow', async () => {
+                const flowJson = JSON.stringify([{ id: 'n1', type: 'inject' }])
+                await should(expertAutomations.invokeAction('automation/import-flow', {
+                    params: { flow: flowJson }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.view.importNodes.called.should.be.false()
+            })
+            it('should reject manage-groups (create)', async () => {
+                const n1 = { id: 'n1', z: 'tab1' }
+                const n2 = { id: 'n2', z: 'tab1' }
+                mockRED.nodes.node = sinon.stub().callsFake(id => ({ n1, n2 }[id] || null))
+                mockRED.nodes.group = sinon.stub().returns(null)
+                mockRED.nodes.eachGroup = sinon.stub()
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'create', nodeIds: ['n1', 'n2'], name: 'g' }] }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.actions.invoke.called.should.be.false()
+            })
+            it('should reject manage-groups (delete)', async () => {
+                mockRED.nodes.group = sinon.stub().withArgs('g1').returns({ id: 'g1', z: 'tab1', nodes: [] })
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'delete', id: 'g1' }] }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.actions.invoke.called.should.be.false()
+            })
+            it('should reject arrange-nodes', async () => {
+                const n1 = { id: 'n1', type: 'inject', z: 'tab1' }
+                const n2 = { id: 'n2', type: 'debug', z: 'tab1' }
+                mockRED.nodes.node = sinon.stub().callsFake(id => ({ n1, n2 }[id] || null))
+                mockRED.nodes.getType.withArgs('inject').returns({ category: 'input' })
+                mockRED.nodes.getType.withArgs('debug').returns({ category: 'output' })
+                await should(expertAutomations.invokeAction('automation/arrange-nodes', {
+                    params: { ids: ['n1', 'n2'], direction: 'grid' }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.actions.invoke.called.should.be.false()
+            })
+        })
     })
 })

--- a/test/unit/resources/expertComms.test.js
+++ b/test/unit/resources/expertComms.test.js
@@ -122,6 +122,9 @@ describeMain('expertComms', function () {
             workspaces: {
                 isLocked: sinon.stub().returns(false)
             },
+            user: {
+                hasPermission: sinon.stub().returns(true)
+            },
             nrAssistant: {
                 DEBUG: false
             },


### PR DESCRIPTION
## Description

This pull request refactors and strengthens permission and workspace state checks throughout the `ExpertAutomations` class, ensuring that all actions modifying flows, tabs, nodes, and groups enforce write permissions and workspace editability. It also introduces a new helper for identifying config nodes, and improves error handling and validation logic for various node and workspace operations.


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

