### PR TITLE
feat(automations): add set-deploy-mode action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -27,6 +27,7 @@ const LIST_CONFIG_NODES = 'automation/list-config-nodes'
 const OPEN_PALETTE_MANAGER = 'automation/open-palette-manager'
 const MANAGE_GROUPS = 'automation/manage-groups'
 const ARRANGE_NODES = 'automation/arrange-nodes'
+const SET_DEPLOY_MODE = 'automation/set-deploy-mode'
 
 const ALIGNMENT_DIRECTIONS = ['grid', 'left', 'right', 'top', 'bottom', 'middle', 'center']
 const DISTRIBUTE_DIRECTIONS = ['horizontally', 'vertically']
@@ -64,7 +65,8 @@ const LINK_NODE_TYPES = ['link in', 'link out', 'link call']
  *   |LIST_CONFIG_NODES
  *   |OPEN_PALETTE_MANAGER
  *   |MANAGE_GROUPS
- *   |ARRANGE_NODES} ExpertAutomationsActionsEnum
+ *   |ARRANGE_NODES
+ *   |SET_DEPLOY_MODE} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -480,6 +482,19 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 },
                 required: ['ids', 'direction']
+            }
+        },
+        [SET_DEPLOY_MODE]: {
+            params: {
+                type: 'object',
+                properties: {
+                    mode: {
+                        type: 'string',
+                        enum: ['full', 'modified-flows', 'modified-nodes'],
+                        description: '"full" redeploys everything; "modified-flows" redeploys only flows that contain changed nodes; "modified-nodes" redeploys only the changed nodes themselves'
+                    }
+                },
+                required: ['mode']
             }
         }
     })
@@ -1767,6 +1782,22 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
+        case SET_DEPLOY_MODE: {
+            const modeMap = {
+                full: 'core:set-deploy-type-to-full',
+                'modified-flows': 'core:set-deploy-type-to-modified-flows',
+                'modified-nodes': 'core:set-deploy-type-to-modified-nodes'
+            }
+            const coreAction = modeMap[params.mode]
+            if (!coreAction) {
+                result.error = `Unknown deploy mode: ${params.mode}`
+                result.success = false
+                break
+            }
+            this.RED.actions.invoke(coreAction)
+            result.success = true
+            break
+        }
         default:
             result.handled = false
             result.success = false

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -103,7 +103,8 @@ describeMain('expertAutomations', () => {
                 'automation/list-config-nodes',
                 'automation/open-palette-manager',
                 'automation/manage-groups',
-                'automation/arrange-nodes'
+                'automation/arrange-nodes',
+                'automation/set-deploy-mode'
             ]
             supportedActions.should.only.have.keys(...expectedKeys)
         })
@@ -3253,6 +3254,37 @@ describeMain('expertAutomations', () => {
                 await should(expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['cfg1'], direction: 'grid' }
                 }, result)).rejectedWith(/No non-config nodes to align/)
+            })
+        })
+
+        describe('set-deploy-mode action', () => {
+            beforeEach(() => {
+                mockRED.actions = { invoke: sinon.stub() }
+            })
+            it('should invoke core:set-deploy-type-to-full for mode "full"', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-deploy-mode', { params: { mode: 'full' } }, result)
+                mockRED.actions.invoke.calledWith('core:set-deploy-type-to-full').should.be.true()
+                result.should.have.property('success', true)
+            })
+            it('should invoke core:set-deploy-type-to-modified-flows for mode "modified-flows"', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-deploy-mode', { params: { mode: 'modified-flows' } }, result)
+                mockRED.actions.invoke.calledWith('core:set-deploy-type-to-modified-flows').should.be.true()
+                result.should.have.property('success', true)
+            })
+            it('should invoke core:set-deploy-type-to-modified-nodes for mode "modified-nodes"', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-deploy-mode', { params: { mode: 'modified-nodes' } }, result)
+                mockRED.actions.invoke.calledWith('core:set-deploy-type-to-modified-nodes').should.be.true()
+                result.should.have.property('success', true)
+            })
+            it('should return an error for an unknown mode', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-deploy-mode', { params: { mode: 'invalid' } }, result)
+                result.should.have.property('success', false)
+                result.should.have.property('error').which.match(/Unknown deploy mode/)
+                mockRED.actions.invoke.called.should.be.false()
             })
         })
     })


### PR DESCRIPTION
Adds a new `automation/set-deploy-mode` action that changes the Node-RED deploy mode.

The action accepts a `mode` parameter with three values:
- `full` — redeploys everything
- `modified-flows` — redeploys only flows containing changed nodes
- `modified-nodes` — redeploys only the changed nodes themselves

Internally it delegates to the corresponding `core:set-deploy-type-to-*` action already provided by Node-RED.

Closes #174