### PR TITLE
feat(automations): add export-flow action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -497,7 +497,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     },
                     tabId: {
                         type: 'string',
-                        description: 'ID of the tab to switch to before exporting. Only valid when scope is "current-tab". The tab must exist or an error is thrown.'
+                        description: '(optional) The ID of the tab to switch to before exporting. Only valid when scope is "current-tab". If the tab does not exist, an error will be thrown.'
                     }
                 },
                 required: ['scope']

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -27,6 +27,7 @@ const LIST_CONFIG_NODES = 'automation/list-config-nodes'
 const OPEN_PALETTE_MANAGER = 'automation/open-palette-manager'
 const MANAGE_GROUPS = 'automation/manage-groups'
 const ARRANGE_NODES = 'automation/arrange-nodes'
+const EXPORT_FLOW = 'automation/export-flow'
 
 const ALIGNMENT_DIRECTIONS = ['grid', 'left', 'right', 'top', 'bottom', 'middle', 'center']
 const DISTRIBUTE_DIRECTIONS = ['horizontally', 'vertically']
@@ -64,7 +65,8 @@ const LINK_NODE_TYPES = ['link in', 'link out', 'link call']
  *   |LIST_CONFIG_NODES
  *   |OPEN_PALETTE_MANAGER
  *   |MANAGE_GROUPS
- *   |ARRANGE_NODES} ExpertAutomationsActionsEnum
+ *   |ARRANGE_NODES
+ *   |EXPORT_FLOW} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -480,6 +482,19 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 },
                 required: ['ids', 'direction']
+            }
+        },
+        [EXPORT_FLOW]: {
+            params: {
+                type: 'object',
+                properties: {
+                    scope: {
+                        type: 'string',
+                        enum: ['selection', 'current-tab', 'all-flows'],
+                        description: '"selection" exports the currently selected nodes; "current-tab" exports all nodes on the active flow tab; "all-flows" exports the entire workspace'
+                    }
+                },
+                required: ['scope']
             }
         }
     })
@@ -1767,6 +1782,17 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
+        case EXPORT_FLOW: {
+            const scopeButtonId = {
+                selection: 'red-ui-clipboard-dialog-export-rng-selected',
+                'current-tab': 'red-ui-clipboard-dialog-export-rng-flow',
+                'all-flows': 'red-ui-clipboard-dialog-export-rng-full'
+            }[params.scope]
+            this.RED.actions.invoke('core:show-export-dialog')
+            document.getElementById(scopeButtonId)?.click()
+            result.success = true
+            break
+        }
         default:
             result.handled = false
             result.success = false

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -67,7 +67,7 @@ const LINK_NODE_TYPES = ['link in', 'link out', 'link call']
  *   |OPEN_PALETTE_MANAGER
  *   |MANAGE_GROUPS
  *   |ARRANGE_NODES
- *   |EXPORT_FLOW} ExpertAutomationsActionsEnum
+ *   |EXPORT_FLOW
  *   |SET_DEPLOY_MODE} ExpertAutomationsActionsEnum
  */
 
@@ -497,7 +497,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 },
                 required: ['scope']
-
+            }
+        },
         [SET_DEPLOY_MODE]: {
             params: {
                 type: 'object',
@@ -1855,6 +1856,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
             }[params.scope]
             this.RED.actions.invoke('core:show-export-dialog')
             document.getElementById(scopeButtonId)?.click()
+            result.success = true
+            break
+        }
         case SET_DEPLOY_MODE: {
             const modeMap = {
                 full: 'core:set-deploy-type-to-full',

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -493,7 +493,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     scope: {
                         type: 'string',
                         enum: ['selection', 'current-tab', 'all-flows'],
-                        description: '"selection" exports the currently selected nodes; "current-tab" exports all nodes on the active flow tab; "all-flows" exports the entire workspace'
+                        description: 'Scope specifies what should be exported. Options are "selection" to export currently selected nodes, "current-tab" to export all nodes on the active flow tab, "all-flows" to export all flows on all workspace tabs including config nodes and subflows'
                     },
                     tabId: {
                         type: 'string',

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -494,6 +494,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         type: 'string',
                         enum: ['selection', 'current-tab', 'all-flows'],
                         description: '"selection" exports the currently selected nodes; "current-tab" exports all nodes on the active flow tab; "all-flows" exports the entire workspace'
+                    },
+                    tabId: {
+                        type: 'string',
+                        description: 'ID of the tab to switch to before exporting. Only valid when scope is "current-tab". The tab must exist or an error is thrown.'
                     }
                 },
                 required: ['scope']
@@ -1849,6 +1853,14 @@ export class ExpertAutomations extends ExpertActionsInterface {
             break
 
         case EXPORT_FLOW: {
+            if (params.tabId) {
+                if (params.scope !== 'current-tab') {
+                    result.error = '"tabId" is only valid when scope is "current-tab"'
+                    result.success = false
+                    break
+                }
+                this.showWorkspace(params.tabId)
+            }
             const scopeButtonId = {
                 selection: 'red-ui-clipboard-dialog-export-rng-selected',
                 'current-tab': 'red-ui-clipboard-dialog-export-rng-flow',

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -3457,6 +3457,29 @@ describeMain('expertAutomations', () => {
                 clickedId.should.equal('red-ui-clipboard-dialog-export-rng-full')
                 result.should.have.property('success', true)
             })
+            it('should switch to the given tab before exporting when tabId is provided', async () => {
+                mockRED.nodes.workspace.withArgs('tab123').returns({ id: 'tab123', type: 'tab' })
+                const result = {}
+                await expertAutomations.invokeAction('automation/export-flow', { params: { scope: 'current-tab', tabId: 'tab123' } }, result)
+                mockRED.workspaces.show.calledWith('tab123').should.be.true()
+                mockRED.actions.invoke.calledWith('core:show-export-dialog').should.be.true()
+                clickedId.should.equal('red-ui-clipboard-dialog-export-rng-flow')
+                result.should.have.property('success', true)
+            })
+            it('should throw if tabId refers to a non-existent tab', async () => {
+                mockRED.nodes.workspace.withArgs('missing-tab').returns(null)
+                await should(expertAutomations.invokeAction('automation/export-flow', {
+                    params: { scope: 'current-tab', tabId: 'missing-tab' }
+                }, {})).rejectedWith(/missing-tab/)
+            })
+            it('should return an error if tabId is provided with a scope other than "current-tab"', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/export-flow', { params: { scope: 'all-flows', tabId: 'tab123' } }, result)
+                result.should.have.property('success', false)
+                result.should.have.property('error').which.match(/"tabId" is only valid/)
+                mockRED.workspaces.show.called.should.be.false()
+                mockRED.actions.invoke.called.should.be.false()
+            })
         })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -103,7 +103,8 @@ describeMain('expertAutomations', () => {
                 'automation/list-config-nodes',
                 'automation/open-palette-manager',
                 'automation/manage-groups',
-                'automation/arrange-nodes'
+                'automation/arrange-nodes',
+                'automation/export-flow'
             ]
             supportedActions.should.only.have.keys(...expectedKeys)
         })
@@ -3253,6 +3254,43 @@ describeMain('expertAutomations', () => {
                 await should(expertAutomations.invokeAction('automation/arrange-nodes', {
                     params: { ids: ['cfg1'], direction: 'grid' }
                 }, result)).rejectedWith(/No non-config nodes to align/)
+            })
+        })
+
+        describe('export-flow action', () => {
+            let clickedId
+            beforeEach(() => {
+                mockRED.actions = { invoke: sinon.stub() }
+                clickedId = null
+                global.document = {
+                    getElementById: sinon.stub().callsFake(id => ({
+                        click: () => { clickedId = id }
+                    }))
+                }
+            })
+            afterEach(() => {
+                delete global.document
+            })
+            it('should invoke core:show-export-dialog and click the selected-nodes button for scope "selection"', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/export-flow', { params: { scope: 'selection' } }, result)
+                mockRED.actions.invoke.calledWith('core:show-export-dialog').should.be.true()
+                clickedId.should.equal('red-ui-clipboard-dialog-export-rng-selected')
+                result.should.have.property('success', true)
+            })
+            it('should invoke core:show-export-dialog and click the flow button for scope "current-tab"', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/export-flow', { params: { scope: 'current-tab' } }, result)
+                mockRED.actions.invoke.calledWith('core:show-export-dialog').should.be.true()
+                clickedId.should.equal('red-ui-clipboard-dialog-export-rng-flow')
+                result.should.have.property('success', true)
+            })
+            it('should invoke core:show-export-dialog and click the full button for scope "all-flows"', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/export-flow', { params: { scope: 'all-flows' } }, result)
+                mockRED.actions.invoke.calledWith('core:show-export-dialog').should.be.true()
+                clickedId.should.equal('red-ui-clipboard-dialog-export-rng-full')
+                result.should.have.property('success', true)
             })
         })
     })


### PR DESCRIPTION
Adds a new `automation/export-flow` action that opens the Node-RED export dialog pre-scoped to the requested range.

The action accepts a `scope` parameter:
- `selection` — exports the currently selected nodes
- `current-tab` — exports all nodes on the active flow tab
- `all-flows` — exports the entire workspace

Internally it invokes `core:show-export-dialog` and then clicks the corresponding range button in the dialog DOM so the correct scope is pre-selected when the dialog opens.

Closes [#359](https://github.com/FlowFuse/nr-assistant/issues/359)