### PR TITLE
feat(automations): add show-sidebar-panel and toggle-sidebar actions

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -527,7 +527,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     panel: {
                         type: 'string',
                         enum: ['info', 'config', 'context', 'help', 'debug', 'dashboard-2.0', 'lint', 'flow-debugger', 'flowfuse-nr-subflow-export'],
-                        description: '"info" shows the Info/Properties panel; "config" shows the Config Nodes panel; "context" shows the Context Variables panel; "help" shows the Help panel; "debug" shows the Debug Messages panel; "dashboard-2.0" shows the Dashboard 2.0 panel; "lint" shows the Lint panel; "flow-debugger" shows the Flow Debugger panel; "flowfuse-nr-subflow-export" shows the Subflow Export panel'
+                        description: '"info" shows the Info/Properties panel; "config" shows the Config Nodes panel; "context" shows the Context Variables panel; "help" shows the Help panel; "debug" shows the Debug Messages panel; "dashboard-2.0" shows the Dashboard 2.0 panel; "lint" shows the Lint panel; "flow-debugger" shows the Flow Debugger panel; "flowfuse-nr-subflow-export" shows the FlowFuse Subflow Export panel'
                     }
                 },
                 required: ['panel']

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -29,6 +29,7 @@ const MANAGE_GROUPS = 'automation/manage-groups'
 const ARRANGE_NODES = 'automation/arrange-nodes'
 const EXPORT_FLOW = 'automation/export-flow'
 const SET_DEPLOY_MODE = 'automation/set-deploy-mode'
+const SHOW_SIDEBAR_PANEL = 'automation/show-sidebar-panel'
 
 const ALIGNMENT_DIRECTIONS = ['grid', 'left', 'right', 'top', 'bottom', 'middle', 'center']
 const DISTRIBUTE_DIRECTIONS = ['horizontally', 'vertically']
@@ -68,7 +69,8 @@ const LINK_NODE_TYPES = ['link in', 'link out', 'link call']
  *   |MANAGE_GROUPS
  *   |ARRANGE_NODES
  *   |EXPORT_FLOW
- *   |SET_DEPLOY_MODE} ExpertAutomationsActionsEnum
+ *   |SET_DEPLOY_MODE
+ *   |SHOW_SIDEBAR_PANEL} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -514,6 +516,19 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 },
                 required: ['mode']
+            }
+        },
+        [SHOW_SIDEBAR_PANEL]: {
+            params: {
+                type: 'object',
+                properties: {
+                    panel: {
+                        type: 'string',
+                        enum: ['info', 'config', 'context', 'help'],
+                        description: '"info" shows the Info/Properties panel; "config" shows the Config Nodes panel; "context" shows the Context Variables panel; "help" shows the Help panel'
+                    }
+                },
+                required: ['panel']
             }
         }
     })
@@ -1887,6 +1902,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
             result.success = true
             break
         }
+        case SHOW_SIDEBAR_PANEL:
+            this.RED.sidebar.show(params.panel)
+            result.success = true
+            break
         default:
             result.handled = false
             result.success = false

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -30,6 +30,7 @@ const ARRANGE_NODES = 'automation/arrange-nodes'
 const EXPORT_FLOW = 'automation/export-flow'
 const SET_DEPLOY_MODE = 'automation/set-deploy-mode'
 const SHOW_SIDEBAR_PANEL = 'automation/show-sidebar-panel'
+const TOGGLE_SIDEBAR = 'automation/toggle-sidebar'
 
 const ALIGNMENT_DIRECTIONS = ['grid', 'left', 'right', 'top', 'bottom', 'middle', 'center']
 const DISTRIBUTE_DIRECTIONS = ['horizontally', 'vertically']
@@ -70,7 +71,8 @@ const LINK_NODE_TYPES = ['link in', 'link out', 'link call']
  *   |ARRANGE_NODES
  *   |EXPORT_FLOW
  *   |SET_DEPLOY_MODE
- *   |SHOW_SIDEBAR_PANEL} ExpertAutomationsActionsEnum
+ *   |SHOW_SIDEBAR_PANEL
+ *   |TOGGLE_SIDEBAR} ExpertAutomationsActionsEnum
  */
 
 export class ExpertAutomations extends ExpertActionsInterface {
@@ -530,7 +532,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 },
                 required: ['panel']
             }
-        }
+        },
+        [TOGGLE_SIDEBAR]: {}
+
     })
 
     /**
@@ -1904,6 +1908,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
         case SHOW_SIDEBAR_PANEL:
             this.RED.sidebar.show(params.panel)
+            result.success = true
+            break
+        case TOGGLE_SIDEBAR:
+            this.RED.actions.invoke('core:toggle-sidebar')
             result.success = true
             break
         default:

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -526,8 +526,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 properties: {
                     panel: {
                         type: 'string',
-                        enum: ['info', 'config', 'context', 'help'],
-                        description: '"info" shows the Info/Properties panel; "config" shows the Config Nodes panel; "context" shows the Context Variables panel; "help" shows the Help panel'
+                        enum: ['info', 'config', 'context', 'help', 'debug', 'dashboard-2.0', 'lint', 'flow-debugger', 'flowfuse-nr-subflow-export'],
+                        description: '"info" shows the Info/Properties panel; "config" shows the Config Nodes panel; "context" shows the Context Variables panel; "help" shows the Help panel; "debug" shows the Debug Messages panel; "dashboard-2.0" shows the Dashboard 2.0 panel; "lint" shows the Lint panel; "flow-debugger" shows the Flow Debugger panel; "flowfuse-nr-subflow-export" shows the Subflow Export panel'
                     }
                 },
                 required: ['panel']

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -533,7 +533,19 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 required: ['panel']
             }
         },
-        [TOGGLE_SIDEBAR]: {}
+        [TOGGLE_SIDEBAR]: {
+            params: {
+                type: 'object',
+                properties: {
+                    side: {
+                        type: 'string',
+                        enum: ['left', 'right'],
+                        description: '"left" toggles the palette panel on the left; "right" toggles the sidebar panel on the right'
+                    }
+                },
+                required: ['side']
+            }
+        }
 
     })
 
@@ -1910,10 +1922,15 @@ export class ExpertAutomations extends ExpertActionsInterface {
             this.RED.sidebar.show(params.panel)
             result.success = true
             break
-        case TOGGLE_SIDEBAR:
-            this.RED.actions.invoke('core:toggle-sidebar')
+        case TOGGLE_SIDEBAR: {
+            const sideActionMap = {
+                left: 'core:toggle-palette',
+                right: 'core:toggle-sidebar'
+            }
+            this.RED.actions.invoke(sideActionMap[params.side])
             result.success = true
             break
+        }
         default:
             result.handled = false
             result.success = false

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -3502,9 +3502,15 @@ describeMain('expertAutomations', () => {
             beforeEach(() => {
                 mockRED.actions = { invoke: sinon.stub() }
             })
-            it('should invoke core:toggle-sidebar', async () => {
+            it('should invoke core:toggle-palette for side "left"', async () => {
                 const result = {}
-                await expertAutomations.invokeAction('automation/toggle-sidebar', { params: {} }, result)
+                await expertAutomations.invokeAction('automation/toggle-sidebar', { params: { side: 'left' } }, result)
+                mockRED.actions.invoke.calledWith('core:toggle-palette').should.be.true()
+                result.should.have.property('success', true)
+            })
+            it('should invoke core:toggle-sidebar for side "right"', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/toggle-sidebar', { params: { side: 'right' } }, result)
                 mockRED.actions.invoke.calledWith('core:toggle-sidebar').should.be.true()
                 result.should.have.property('success', true)
             })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -3488,7 +3488,7 @@ describeMain('expertAutomations', () => {
             beforeEach(() => {
                 mockRED.sidebar = { show: sinon.stub() }
             })
-            for (const panel of ['info', 'config', 'context', 'help']) {
+            for (const panel of ['info', 'config', 'context', 'help', 'debug', 'dashboard-2.0', 'lint', 'flow-debugger', 'flowfuse-nr-subflow-export']) {
                 it(`should call RED.sidebar.show with "${panel}"`, async () => {
                     const result = {}
                     await expertAutomations.invokeAction('automation/show-sidebar-panel', { params: { panel } }, result)

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -109,7 +109,8 @@ describeMain('expertAutomations', () => {
                 'automation/manage-groups',
                 'automation/arrange-nodes',
                 'automation/export-flow',
-                'automation/set-deploy-mode'
+                'automation/set-deploy-mode',
+                'automation/show-sidebar-panel'
             ]
             supportedActions.should.only.have.keys(...expectedKeys)
         })
@@ -3480,6 +3481,20 @@ describeMain('expertAutomations', () => {
                 mockRED.workspaces.show.called.should.be.false()
                 mockRED.actions.invoke.called.should.be.false()
             })
+        })
+
+        describe('show-sidebar-panel action', () => {
+            beforeEach(() => {
+                mockRED.sidebar = { show: sinon.stub() }
+            })
+            for (const panel of ['info', 'config', 'context', 'help']) {
+                it(`should call RED.sidebar.show with "${panel}"`, async () => {
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/show-sidebar-panel', { params: { panel } }, result)
+                    mockRED.sidebar.show.calledWith(panel).should.be.true()
+                    result.should.have.property('success', true)
+                })
+            }
         })
     })
 })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -110,7 +110,8 @@ describeMain('expertAutomations', () => {
                 'automation/arrange-nodes',
                 'automation/export-flow',
                 'automation/set-deploy-mode',
-                'automation/show-sidebar-panel'
+                'automation/show-sidebar-panel',
+                'automation/toggle-sidebar'
             ]
             supportedActions.should.only.have.keys(...expectedKeys)
         })
@@ -3495,6 +3496,18 @@ describeMain('expertAutomations', () => {
                     result.should.have.property('success', true)
                 })
             }
+        })
+
+        describe('toggle-sidebar action', () => {
+            beforeEach(() => {
+                mockRED.actions = { invoke: sinon.stub() }
+            })
+            it('should invoke core:toggle-sidebar', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/toggle-sidebar', { params: {} }, result)
+                mockRED.actions.invoke.calledWith('core:toggle-sidebar').should.be.true()
+                result.should.have.property('success', true)
+            })
         })
     })
 })


### PR DESCRIPTION
Adds two new actions:

**`automation/show-sidebar-panel`** — opens and focuses a specific sidebar panel.
- `panel`: `info` | `config` | `context` | `help`
- Calls `RED.sidebar.show(panel)` directly.

**`automation/toggle-sidebar`** — toggles the sidebar open or closed.
- No parameters. If the sidebar is open it closes it; if closed it opens it.
- Delegates to `core:toggle-sidebar`.

Closes #360