### PR TITLE
feat: add create-subroutine automation action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowfuse/nr-assistant",
-    "version": "0.16.0",
+    "version": "0.17.0",
     "description": "FlowFuse Node-RED Expert plugin",
     "main": "index.js",
     "scripts": {

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -345,10 +345,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         type: 'array',
                         items: { type: 'string' },
                         minItems: 1,
-                        description: 'IDs of the existing node(s) to move into the subroutine body. Must form a single-entry, single-exit subgraph: a single node, or connected nodes with one way in and one way out (a branch that reconverges is fine, not only a straight chain).'
+                        description: 'IDs of the existing node(s) to move into the subroutine body. A group ID is accepted and expanded to its member nodes (nested groups recurse). The resulting nodes must form a single-entry, single-exit subgraph: a single node, or connected nodes with one way in and one way out (a branch that reconverges is fine, not only a straight chain).'
                     },
                     name: { type: 'string', description: 'Name for the subroutine, used to label the created link nodes and the group. Defaults to "Subroutine".' },
-                    targetTabId: { type: 'string', description: 'Optional tab ID to move the subroutine body (link in, the selected nodes, link out, catch) onto. The link call and error switch stay inline with the caller. Omit to keep the body on the same tab.' },
                     timeout: { type: 'number', description: 'Link call timeout in seconds. Defaults to 5.', default: 5 }
                 },
                 required: ['ids']
@@ -1511,14 +1510,17 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * nodes must form a single-entry, single-exit subgraph (the common case is a
      * single node, or a linear chain). The result is:
      *   caller:  <upstream> -> [link call] -> [switch on msg.error] -> <downstream>
+     *                                              \-> [debug] (Error branch)
      *   body:    [link in] -> <entry> ... <exit> -> [link out, mode: return]
      *            [catch (group scope)] -> [link out]
      * The link call targets the link in, so at runtime the message is routed into
      * the body and returned to the caller by the return-mode link out. A group-scoped
      * catch routes body errors back out the same link out, and a switch on the
-     * caller side splits the returned message into an error branch and a normal
-     * branch. The body (link in, the selected nodes, link out and the catch) is
-     * wrapped in a named group.
+     * caller side splits the returned message into an "Error" branch and a "Success"
+     * branch; the Error branch is wired to a debug node so failures are visible by
+     * default. The link call, switch and debug stay on the original row where the
+     * selection was; the body (link in, the selected nodes, link out and the catch)
+     * is dropped below the caller and wrapped in a named group.
      *
      * Rather than hand-building node JSON, this orchestrates the module's own
      * validated actions (addNodes / setWires / setLinks / createGroup), so node-type,
@@ -1526,17 +1528,45 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * all come from those existing actions.
      *
      * @param {object} params
-     * @param {string[]} params.ids - IDs of the node(s) to move into the subroutine body
+     * @param {string[]} params.ids - IDs of the node(s) to move into the subroutine body; a group ID is expanded to its member nodes (recursively for nested groups)
      * @param {string} [params.name] - name used to label the created link nodes and group
-     * @param {string} [params.targetTabId] - if given, move the body (link in, selected nodes, link out, catch) to this tab; the link call and switch stay inline with the caller
      * @param {number|string} [params.timeout=5] - link call timeout in seconds
-     * @returns {{linkInId:string, linkOutId:string, linkCallId:string, switchId:string, catchId:string, entryId:string, exitId:string}}
+     * @returns {{linkInId:string, linkOutId:string, linkCallId:string, switchId:string, catchId:string, debugId:string, entryId:string, exitId:string}}
      */
-    createSubroutine ({ ids, name, targetTabId, timeout } = {}) {
+    createSubroutine ({ ids, name, timeout } = {}) {
         if (!Array.isArray(ids) || ids.length === 0) {
             throw new Error('createSubroutine requires a non-empty "ids" array of node IDs to wrap')
         }
-        const uniqueIds = [...new Set(ids)]
+        // A selected group is shorthand for its contents: expand any group IDs into
+        // their member nodes (groups nest, so recurse) before validating, so a whole
+        // group can be wrapped. The group containers drop out; only the real nodes
+        // inside form the body, and the existing checks below run on those.
+        const resolveGroup = (id) => {
+            const g = this.RED.nodes.group && this.RED.nodes.group(id)
+            if (g) return g
+            const node = this.RED.nodes.node(id)
+            return (node && node.type === 'group') ? node : null
+        }
+        const leafIds = []
+        const visited = new Set()
+        const collectLeaves = (id) => {
+            if (!id || visited.has(id)) return
+            visited.add(id)
+            const group = resolveGroup(id)
+            if (group) {
+                for (const member of (group.nodes || [])) {
+                    collectLeaves(typeof member === 'object' ? member.id : member)
+                }
+                return
+            }
+            leafIds.push(id)
+        }
+        for (const id of ids) collectLeaves(id)
+
+        const uniqueIds = [...new Set(leafIds)]
+        if (uniqueIds.length === 0) {
+            throw new Error('createSubroutine found no nodes to wrap; the selected group(s) are empty')
+        }
         const selection = uniqueIds.map(id => {
             const n = this.RED.nodes.node(id)
             if (!n) throw new Error(`Node ${id} not found`)
@@ -1550,22 +1580,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
         const z = tabIds[0]
         this._assertWorkspaceIsEditable(z)
-        if (targetTabId && targetTabId !== z) {
-            this._assertWorkspaceIsEditable(targetTabId)
-        }
 
-        // Config, link and group nodes cannot be wrapped.
-        // Config nodes are global (no x/y) so they have no place in a flow-anchored body;
-        // a group is a visual container, not a node on the message path.
+        // Config and link nodes cannot be wrapped. Config nodes are global (no x/y) so
+        // they have no place in a flow-anchored body; link nodes are the subroutine's own
+        // plumbing. (Group containers never reach here — they are expanded above.)
         for (const n of selection) {
             if (this.isConfigNode(n.id)) {
                 throw new Error(`Node ${n.id} is a "${n.type}" config node and cannot be placed inside a subroutine`)
             }
             if (LINK_NODE_TYPES.includes(n.type)) {
                 throw new Error(`Node ${n.id} is a "${n.type}" node and cannot be placed inside a subroutine`)
-            }
-            if (n.type === 'group') {
-                throw new Error(`Node ${n.id} is a "${n.type}" and cannot be placed inside a subroutine`)
             }
         }
 
@@ -1636,40 +1660,52 @@ export class ExpertAutomations extends ExpertActionsInterface {
         // Link call timeout in seconds; defaults to 5. Stored as a string, as the core link call expects.
         const callTimeout = (timeout === undefined || timeout === null || timeout === '') ? 5 : timeout
 
-        // Defensive: the link nodes below are positioned relative to the entry/exit
-        // coordinates. If those are ever non-finite, anchor off 50/50 rather than the origin.
+        // The link call replaces the selection inline, where the nodes were; the body
+        // (link in, the selected nodes, link out, catch) is dropped below the caller row
+        // so the group does not sit on top of the call. Coordinates are defended against
+        // non-finite values (anchor off 50/50, and the exit off to the entry's right).
         const finiteOr = (v, fallback) => (typeof v === 'number' && Number.isFinite(v)) ? v : fallback
-        entryNode.x = finiteOr(entryNode.x, 50)
-        entryNode.y = finiteOr(entryNode.y, 50)
-        exitNode.x = finiteOr(exitNode.x, entryNode.x + gridSize * 16)
-        exitNode.y = finiteOr(exitNode.y, entryNode.y)
+        const callerX = finiteOr(entryNode.x, 50)
+        const callerY = finiteOr(entryNode.y, 50)
+        const bodyTopBefore = Math.min(...selection.map(n => finiteOr(n.y, callerY)))
+        const drop = (callerY + gridSize * 8) - bodyTopBefore
+        for (const n of selection) {
+            n.x = finiteOr(n.x, n === exitNode ? callerX + gridSize * 16 : callerX)
+            n.y = finiteOr(n.y, callerY) + drop
+            n.dirty = true
+        }
 
         const linkInId = this.RED.nodes.id()
         const linkOutId = this.RED.nodes.id()
         const linkCallId = this.RED.nodes.id()
         const switchId = this.RED.nodes.id()
         const catchId = this.RED.nodes.id()
+        const debugId = this.RED.nodes.id()
 
-        // 1. Create the link nodes, the caller-side error switch and the group catch
-        //    (addNodes applies node defaults + history). The link call's target is
-        //    set afterwards via setLinks; the catch's group scope is bound by createGroup.
+        // 1. Create the link nodes, the caller-side error switch, an error debug and the
+        //    group catch (addNodes applies node defaults + history). The link call's target
+        //    is set afterwards via setLinks; the catch's group scope is bound by createGroup.
+        //    The caller (link call, switch, debug) stays on the original row; the body sits below.
         this.addNodes([
             { id: linkInId, type: 'link in', z, x: entryNode.x - gridSize * 8, y: entryNode.y, name: label, links: [] },
             { id: linkOutId, type: 'link out', z, x: exitNode.x + gridSize * 8, y: exitNode.y, name: `${label} return`, mode: 'return', links: [] },
-            { id: linkCallId, type: 'link call', z, x: entryNode.x, y: entryNode.y + gridSize * 6, name: `Call ${label}`, linkType: 'static', timeout: String(callTimeout), links: [] },
-            { id: switchId, type: 'switch', z, x: entryNode.x + gridSize * 8, y: entryNode.y + gridSize * 6, name: 'error?', property: 'error', propertyType: 'msg', rules: [{ t: 'nempty' }, { t: 'else' }], checkall: 'true', repair: false, outputs: 2, outputLabels: ['error', 'ok'] },
+            { id: linkCallId, type: 'link call', z, x: callerX, y: callerY, name: `Call ${label}`, linkType: 'static', timeout: String(callTimeout), links: [] },
+            { id: switchId, type: 'switch', z, x: callerX + gridSize * 8, y: callerY, name: 'error?', property: 'error', propertyType: 'msg', rules: [{ t: 'nempty' }, { t: 'else' }], checkall: 'true', repair: false, outputs: 2, outputLabels: ['Error', 'Success'] },
+            { id: debugId, type: 'debug', z, x: callerX + gridSize * 16, y: callerY - gridSize * 2, name: `${label} error`, active: true, tosidebar: true, console: false, tostatus: false, complete: 'true', statusType: 'auto' },
             { id: catchId, type: 'catch', z, x: exitNode.x, y: exitNode.y + gridSize * 4, name: '', scope: 'group', uncaught: false }
         ])
 
         // 2. Redirect the caller: upstream now feeds the link call; the link call's
-        //    return feeds a switch on msg.error. The "no error" branch continues to
-        //    whatever was downstream of the exit; the "error" branch is left for the
-        //    caller to wire up.
+        //    return feeds a switch on msg.error. The "Success" branch continues to
+        //    whatever was downstream of the exit; the "Error" branch goes to a debug node
+        //    so failures are visible by default (the caller can rewire it to a notification,
+        //    a log, or further handling).
         for (const w of entryInbound) {
             this.setWires({ mode: 'remove', source: w.source.id, output: w.sourcePort, target: entryNode.id })
             this.setWires({ mode: 'add', source: w.source.id, output: w.sourcePort, target: linkCallId })
         }
         this.setWires({ mode: 'add', source: linkCallId, output: 0, target: switchId })
+        this.setWires({ mode: 'add', source: switchId, output: 0, target: debugId })
         for (const w of exitOutbound) {
             this.setWires({ mode: 'remove', source: exitNode.id, output: w.sourcePort, target: w.target.id })
             this.setWires({ mode: 'add', source: switchId, output: 1, target: w.target.id })
@@ -1682,27 +1718,17 @@ export class ExpertAutomations extends ExpertActionsInterface {
         this.setWires({ mode: 'add', source: catchId, output: 0, target: linkOutId })
         this.setLinks({ mode: 'add', source: linkCallId, target: linkInId })
 
-        // 4. Optionally relocate the body to another tab; the link call and switch
-        //    stay inline with the caller and reach the body via the cross-tab link.
-        const bodyIds = [linkInId, ...uniqueIds, linkOutId, catchId]
-        const bodyTab = (targetTabId && targetTabId !== z) ? targetTabId : z
-        if (bodyTab !== z) {
-            for (const id of bodyIds) {
-                const node = this.RED.nodes.node(id)
-                if (node) this.RED.nodes.moveNodeToTab(node, bodyTab)
-            }
-        }
-
-        // 5. Wrap the body (link in, the selected nodes, link out and the catch) in a
+        // 4. Wrap the body (link in, the selected nodes, link out and the catch) in a
         //    named group so the subroutine reads as one unit; the catch's group scope
-        //    binds to this group.
-        this.RED.workspaces.show(bodyTab)
+        //    binds to this group. This action only creates the subroutine on its tab;
+        //    relocating, renaming or deleting it afterwards is done with the group/node tools.
+        const bodyIds = [linkInId, ...uniqueIds, linkOutId, catchId]
         this.createGroup(bodyIds, label)
 
         this.RED.nodes.dirty(true)
         this.RED.view.redraw(true)
 
-        return { linkInId, linkOutId, linkCallId, switchId, catchId, entryId: entryNode.id, exitId: exitNode.id }
+        return { linkInId, linkOutId, linkCallId, switchId, catchId, debugId, entryId: entryNode.id, exitId: exitNode.id }
     }
 
     get supportedActions () {

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1547,8 +1547,12 @@ export class ExpertAutomations extends ExpertActionsInterface {
             this._assertWorkspaceIsEditable(targetTabId)
         }
 
-        // Link nodes, subflow instances and groups cannot be wrapped
+        // Config, link, subflow-instance, group and junction nodes cannot be wrapped.
+        // Config nodes are global (no x/y) so they have no place in a flow-anchored body.
         for (const n of selection) {
+            if (this.isConfigNode(n.id)) {
+                throw new Error(`Node ${n.id} is a "${n.type}" config node and cannot be placed inside a subroutine`)
+            }
             if (LINK_NODE_TYPES.includes(n.type)) {
                 throw new Error(`Node ${n.id} is a "${n.type}" node and cannot be placed inside a subroutine`)
             }
@@ -1624,6 +1628,14 @@ export class ExpertAutomations extends ExpertActionsInterface {
         this.RED.workspaces.show(z)
         const gridSize = (this.RED.view.gridSize && this.RED.view.gridSize()) || 20
         const label = (typeof name === 'string' && name.trim()) ? name.trim() : 'Subroutine'
+
+        // Defensive: the link nodes below are positioned relative to the entry/exit
+        // coordinates. If those are ever non-finite, anchor off 50/50 rather than the origin.
+        const finiteOr = (v, fallback) => (typeof v === 'number' && Number.isFinite(v)) ? v : fallback
+        entryNode.x = finiteOr(entryNode.x, 50)
+        entryNode.y = finiteOr(entryNode.y, 50)
+        exitNode.x = finiteOr(exitNode.x, entryNode.x + gridSize * 16)
+        exitNode.y = finiteOr(exitNode.y, entryNode.y)
 
         const linkInId = this.RED.nodes.id()
         const linkOutId = this.RED.nodes.id()

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -345,10 +345,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         type: 'array',
                         items: { type: 'string' },
                         minItems: 1,
-                        description: 'IDs of the existing node(s) to move into the subroutine body. Must form a single-entry, single-exit subgraph (a single node or a linear chain).'
+                        description: 'IDs of the existing node(s) to move into the subroutine body. Must form a single-entry, single-exit subgraph: a single node, or connected nodes with one way in and one way out (a branch that reconverges is fine, not only a straight chain).'
                     },
-                    name: { type: 'string', description: 'Name for the subroutine, used to label the created link nodes. Defaults to "Subroutine".' },
-                    targetTabId: { type: 'string', description: 'Optional tab ID to move the subroutine body (link in, the selected nodes, link out) onto. The link call stays inline with the caller. Omit to keep the body on the same tab.' }
+                    name: { type: 'string', description: 'Name for the subroutine, used to label the created link nodes and the group. Defaults to "Subroutine".' },
+                    targetTabId: { type: 'string', description: 'Optional tab ID to move the subroutine body (link in, the selected nodes, link out, catch) onto. The link call and error switch stay inline with the caller. Omit to keep the body on the same tab.' },
+                    timeout: { type: 'number', description: 'Link call timeout in seconds. Defaults to 5.', default: 5 }
                 },
                 required: ['ids']
             }
@@ -1509,23 +1510,29 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * link nodes, replacing them inline with a single `link call`. The selected
      * nodes must form a single-entry, single-exit subgraph (the common case is a
      * single node, or a linear chain). The result is:
-     *   caller:  <upstream> -> [link call] -> <downstream>
+     *   caller:  <upstream> -> [link call] -> [switch on msg.error] -> <downstream>
      *   body:    [link in] -> <entry> ... <exit> -> [link out, mode: return]
+     *            [catch (group scope)] -> [link out]
      * The link call targets the link in, so at runtime the message is routed into
-     * the body and returned to the caller by the return-mode link out.
+     * the body and returned to the caller by the return-mode link out. A group-scoped
+     * catch routes body errors back out the same link out, and a switch on the
+     * caller side splits the returned message into an error branch and a normal
+     * branch. The body (link in, the selected nodes, link out and the catch) is
+     * wrapped in a named group.
      *
      * Rather than hand-building node JSON, this orchestrates the module's own
-     * validated actions (addNodes / setWires / setLinks), so node-type, port,
-     * same-tab, link-type and duplicate-wire validation (and undo/redo history)
+     * validated actions (addNodes / setWires / setLinks / createGroup), so node-type,
+     * port, same-tab, link-type and duplicate-wire validation (and undo/redo history)
      * all come from those existing actions.
      *
      * @param {object} params
      * @param {string[]} params.ids - IDs of the node(s) to move into the subroutine body
-     * @param {string} [params.name] - name used to label the created link nodes
-     * @param {string} [params.targetTabId] - if given, move the body (link in, selected nodes, link out) to this tab; the link call stays inline with the caller
-     * @returns {{linkInId:string, linkOutId:string, linkCallId:string, entryId:string, exitId:string}}
+     * @param {string} [params.name] - name used to label the created link nodes and group
+     * @param {string} [params.targetTabId] - if given, move the body (link in, selected nodes, link out, catch) to this tab; the link call and switch stay inline with the caller
+     * @param {number|string} [params.timeout=5] - link call timeout in seconds
+     * @returns {{linkInId:string, linkOutId:string, linkCallId:string, switchId:string, catchId:string, entryId:string, exitId:string}}
      */
-    createSubroutine ({ ids, name, targetTabId } = {}) {
+    createSubroutine ({ ids, name, targetTabId, timeout } = {}) {
         if (!Array.isArray(ids) || ids.length === 0) {
             throw new Error('createSubroutine requires a non-empty "ids" array of node IDs to wrap')
         }
@@ -1547,8 +1554,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
             this._assertWorkspaceIsEditable(targetTabId)
         }
 
-        // Config, link, subflow-instance, group and junction nodes cannot be wrapped.
-        // Config nodes are global (no x/y) so they have no place in a flow-anchored body.
+        // Config, link and group nodes cannot be wrapped.
+        // Config nodes are global (no x/y) so they have no place in a flow-anchored body;
+        // a group is a visual container, not a node on the message path.
         for (const n of selection) {
             if (this.isConfigNode(n.id)) {
                 throw new Error(`Node ${n.id} is a "${n.type}" config node and cannot be placed inside a subroutine`)
@@ -1556,10 +1564,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             if (LINK_NODE_TYPES.includes(n.type)) {
                 throw new Error(`Node ${n.id} is a "${n.type}" node and cannot be placed inside a subroutine`)
             }
-            if (typeof n.type === 'string' && n.type.startsWith('subflow:')) {
-                throw new Error(`Node ${n.id} is a subflow instance and cannot be placed inside a subroutine`)
-            }
-            if (n.type === 'group' || n.type === 'junction') {
+            if (n.type === 'group') {
                 throw new Error(`Node ${n.id} is a "${n.type}" and cannot be placed inside a subroutine`)
             }
         }
@@ -1595,10 +1600,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const sources = selection.filter(n => !internalInboundCount.get(n.id))
         const sinks = selection.filter(n => !internalOutboundCount.get(n.id))
         if (sources.length !== 1) {
-            throw new Error(`A subroutine needs a single entry node, but the selection has ${sources.length} (${sources.map(n => n.id).join(', ')}). Select a single node or a linear chain, or use add_subflow for a multi-input component.`)
+            throw new Error(`A subroutine needs a single entry node, but the selection has ${sources.length} (${sources.map(n => n.id).join(', ')}). Select a single-entry, single-exit subgraph: a single node, or connected nodes with one way in and one way out.`)
         }
         if (sinks.length !== 1) {
-            throw new Error(`A subroutine needs a single exit node, but the selection has ${sinks.length} (${sinks.map(n => n.id).join(', ')}). Select a single node or a linear chain, or use add_subflow for a multi-output component.`)
+            throw new Error(`A subroutine needs a single exit node, but the selection has ${sinks.length} (${sinks.map(n => n.id).join(', ')}). Select a single-entry, single-exit subgraph: a single node, or connected nodes with one way in and one way out.`)
         }
         const entryNode = sources[0]
         const exitNode = sinks[0]
@@ -1628,6 +1633,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
         this.RED.workspaces.show(z)
         const gridSize = (this.RED.view.gridSize && this.RED.view.gridSize()) || 20
         const label = (typeof name === 'string' && name.trim()) ? name.trim() : 'Subroutine'
+        // Link call timeout in seconds; defaults to 5. Stored as a string, as the core link call expects.
+        const callTimeout = (timeout === undefined || timeout === null || timeout === '') ? 5 : timeout
 
         // Defensive: the link nodes below are positioned relative to the entry/exit
         // coordinates. If those are ever non-finite, anchor off 50/50 rather than the origin.
@@ -1640,45 +1647,62 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const linkInId = this.RED.nodes.id()
         const linkOutId = this.RED.nodes.id()
         const linkCallId = this.RED.nodes.id()
+        const switchId = this.RED.nodes.id()
+        const catchId = this.RED.nodes.id()
 
-        // 1. Create the link nodes (addNodes applies node defaults + history).
-        //    The link call's target is set afterwards via setLinks.
+        // 1. Create the link nodes, the caller-side error switch and the group catch
+        //    (addNodes applies node defaults + history). The link call's target is
+        //    set afterwards via setLinks; the catch's group scope is bound by createGroup.
         this.addNodes([
             { id: linkInId, type: 'link in', z, x: entryNode.x - gridSize * 8, y: entryNode.y, name: label, links: [] },
             { id: linkOutId, type: 'link out', z, x: exitNode.x + gridSize * 8, y: exitNode.y, name: `${label} return`, mode: 'return', links: [] },
-            { id: linkCallId, type: 'link call', z, x: entryNode.x, y: entryNode.y + gridSize * 6, name: `Call ${label}`, linkType: 'static', links: [] }
+            { id: linkCallId, type: 'link call', z, x: entryNode.x, y: entryNode.y + gridSize * 6, name: `Call ${label}`, linkType: 'static', timeout: String(callTimeout), links: [] },
+            { id: switchId, type: 'switch', z, x: entryNode.x + gridSize * 8, y: entryNode.y + gridSize * 6, name: 'error?', property: 'error', propertyType: 'msg', rules: [{ t: 'nempty' }, { t: 'else' }], checkall: 'true', repair: false, outputs: 2, outputLabels: ['error', 'ok'] },
+            { id: catchId, type: 'catch', z, x: exitNode.x, y: exitNode.y + gridSize * 4, name: '', scope: 'group', uncaught: false }
         ])
 
-        // 2. Redirect the caller: upstream now feeds the link call, and the link
-        //    call's return feeds whatever was downstream of the exit.
+        // 2. Redirect the caller: upstream now feeds the link call; the link call's
+        //    return feeds a switch on msg.error. The "no error" branch continues to
+        //    whatever was downstream of the exit; the "error" branch is left for the
+        //    caller to wire up.
         for (const w of entryInbound) {
             this.setWires({ mode: 'remove', source: w.source.id, output: w.sourcePort, target: entryNode.id })
             this.setWires({ mode: 'add', source: w.source.id, output: w.sourcePort, target: linkCallId })
         }
+        this.setWires({ mode: 'add', source: linkCallId, output: 0, target: switchId })
         for (const w of exitOutbound) {
             this.setWires({ mode: 'remove', source: exitNode.id, output: w.sourcePort, target: w.target.id })
-            this.setWires({ mode: 'add', source: linkCallId, output: 0, target: w.target.id })
+            this.setWires({ mode: 'add', source: switchId, output: 1, target: w.target.id })
         }
 
-        // 3. Wire the body (link in -> entry, exit -> link out) and point the
-        //    link call at the link in.
+        // 3. Wire the body (link in -> entry, exit -> link out), route caught body
+        //    errors back through the link out, and point the link call at the link in.
         this.setWires({ mode: 'add', source: linkInId, output: 0, target: entryNode.id })
         this.setWires({ mode: 'add', source: exitNode.id, output: exitPort, target: linkOutId })
+        this.setWires({ mode: 'add', source: catchId, output: 0, target: linkOutId })
         this.setLinks({ mode: 'add', source: linkCallId, target: linkInId })
 
-        // 4. Optionally relocate the body to another tab; the link call stays
-        //    inline with the caller and reaches the body via the cross-tab link.
-        if (targetTabId && targetTabId !== z) {
-            for (const id of [linkInId, ...uniqueIds, linkOutId]) {
+        // 4. Optionally relocate the body to another tab; the link call and switch
+        //    stay inline with the caller and reach the body via the cross-tab link.
+        const bodyIds = [linkInId, ...uniqueIds, linkOutId, catchId]
+        const bodyTab = (targetTabId && targetTabId !== z) ? targetTabId : z
+        if (bodyTab !== z) {
+            for (const id of bodyIds) {
                 const node = this.RED.nodes.node(id)
-                if (node) this.RED.nodes.moveNodeToTab(node, targetTabId)
+                if (node) this.RED.nodes.moveNodeToTab(node, bodyTab)
             }
         }
+
+        // 5. Wrap the body (link in, the selected nodes, link out and the catch) in a
+        //    named group so the subroutine reads as one unit; the catch's group scope
+        //    binds to this group.
+        this.RED.workspaces.show(bodyTab)
+        this.createGroup(bodyIds, label)
 
         this.RED.nodes.dirty(true)
         this.RED.view.redraw(true)
 
-        return { linkInId, linkOutId, linkCallId, entryId: entryNode.id, exitId: exitNode.id }
+        return { linkInId, linkOutId, linkCallId, switchId, catchId, entryId: entryNode.id, exitId: exitNode.id }
     }
 
     get supportedActions () {

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1657,84 +1657,123 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const exitPort = exitPorts.length ? exitPorts[0] : 0
         const entryInbound = externalInboundByNode.get(entryNode.id) || []
 
-        // --- build the subroutine by orchestrating this module's own validated
-        // actions (addNodes / setWires / setLinks) rather than poking RED directly,
-        // so node-type, port, same-tab, link-type and duplicate validation all apply.
-        this.RED.workspaces.show(z)
-        const gridSize = (this.RED.view.gridSize && this.RED.view.gridSize()) || 20
-        const label = (typeof name === 'string' && name.trim()) ? name.trim() : 'Subroutine'
-        // Link call timeout in seconds; defaults to 5. Stored as a string, as the core link call expects.
-        const callTimeout = (timeout === undefined || timeout === null || timeout === '') ? 5 : timeout
-
-        // The link call replaces the selection inline, where the nodes were; the body
-        // (link in, the selected nodes, link out, catch) is dropped below the caller row
-        // so the group does not sit on top of the call. Coordinates are defended against
-        // non-finite values (anchor off 50/50, and the exit off to the entry's right).
-        const finiteOr = (v, fallback) => (typeof v === 'number' && Number.isFinite(v)) ? v : fallback
-        const callerX = finiteOr(entryNode.x, 50)
-        const callerY = finiteOr(entryNode.y, 50)
-        const bodyTopBefore = Math.min(...selection.map(n => finiteOr(n.y, callerY)))
-        const drop = (callerY + gridSize * 8) - bodyTopBefore
-        for (const n of selection) {
-            n.x = finiteOr(n.x, n === exitNode ? callerX + gridSize * 16 : callerX)
-            n.y = finiteOr(n.y, callerY) + drop
-            n.dirty = true
+        // Pre-flight the boundary nodes before mutating anything. The SESE check above
+        // only proves the topology (one source, one sink); it does not prove the entry
+        // can be wired into or the exit can be wired out of. setWires enforces both, but
+        // only in step 3 below — after the scaffolding and caller rewiring are already in
+        // place — so an inject entry (no inputs) or a debug exit (no output port) would
+        // otherwise fail mid-build. Reject them here, while the flow is still untouched.
+        const entryDef = this.RED.nodes.getType(entryNode.type)
+        if (entryDef && entryDef.inputs === 0) {
+            throw new Error(`The entry node ${entryNode.id} (${entryNode.type}) does not accept inputs, so a subroutine cannot be called into it. Pick an entry node that accepts an input.`)
+        }
+        if ((exitNode.outputs || 0) <= exitPort) {
+            throw new Error(`The exit node ${exitNode.id} (${exitNode.type}) has no output port ${exitPort}, so the subroutine has no way to return. Pick an exit node with an output.`)
         }
 
-        const linkInId = this.RED.nodes.id()
-        const linkOutId = this.RED.nodes.id()
-        const linkCallId = this.RED.nodes.id()
-        const switchId = this.RED.nodes.id()
-        const catchId = this.RED.nodes.id()
-        const debugId = this.RED.nodes.id()
+        // Snapshot for rollback. The build below performs many mutating sub-actions
+        // (the body move, addNodes, setWires, setLinks, createGroup), each of which records
+        // a Node-RED history event. If any step throws partway, rewind every recorded event
+        // (LIFO) so a failed createSubroutine leaves the flow exactly as it found it, rather
+        // than stranding half-built scaffolding on the canvas.
+        const historyDepth = this.RED.history.depth()
+        try {
+            // --- build the subroutine by orchestrating this module's own validated
+            // actions (addNodes / setWires / setLinks) rather than poking RED directly,
+            // so node-type, port, same-tab, link-type and duplicate validation all apply.
+            this.RED.workspaces.show(z)
+            const gridSize = (this.RED.view.gridSize && this.RED.view.gridSize()) || 20
+            const label = (typeof name === 'string' && name.trim()) ? name.trim() : 'Subroutine'
+            // Link call timeout in seconds; defaults to 5. Stored as a string, as the core link call expects.
+            const callTimeout = (timeout === undefined || timeout === null || timeout === '') ? 5 : timeout
 
-        // 1. Create the link nodes, the caller-side error switch, an error debug and the
-        //    group catch (addNodes applies node defaults + history). The link call's target
-        //    is set afterwards via setLinks; the catch's group scope is bound by createGroup.
-        //    The caller (link call, switch, debug) stays on the original row; the body sits below.
-        this.addNodes([
-            { id: linkInId, type: 'link in', z, x: entryNode.x - gridSize * 8, y: entryNode.y, name: label, links: [] },
-            { id: linkOutId, type: 'link out', z, x: exitNode.x + gridSize * 8, y: exitNode.y, name: `${label} return`, mode: 'return', links: [] },
-            { id: linkCallId, type: 'link call', z, x: callerX, y: callerY, name: `Call ${label}`, linkType: 'static', timeout: String(callTimeout), links: [] },
-            { id: switchId, type: 'switch', z, x: callerX + gridSize * 8, y: callerY, name: 'error?', property: 'error', propertyType: 'msg', rules: [{ t: 'nempty' }, { t: 'else' }], checkall: 'true', repair: false, outputs: 2, outputLabels: ['Error', 'Success'] },
-            { id: debugId, type: 'debug', z, x: callerX + gridSize * 16, y: callerY - gridSize * 2, name: `${label} error`, active: true, tosidebar: true, console: false, tostatus: false, complete: 'true', statusType: 'auto' },
-            { id: catchId, type: 'catch', z, x: exitNode.x, y: exitNode.y + gridSize * 4, name: '', scope: 'group', uncaught: false }
-        ])
+            // The link call replaces the selection inline, where the nodes were; the body
+            // (link in, the selected nodes, link out, catch) is dropped below the caller row
+            // so the group does not sit on top of the call. Coordinates are defended against
+            // non-finite values (anchor off 50/50, and the exit off to the entry's right).
+            const finiteOr = (v, fallback) => (typeof v === 'number' && Number.isFinite(v)) ? v : fallback
+            const callerX = finiteOr(entryNode.x, 50)
+            const callerY = finiteOr(entryNode.y, 50)
+            const bodyTopBefore = Math.min(...selection.map(n => finiteOr(n.y, callerY)))
+            const drop = (callerY + gridSize * 8) - bodyTopBefore
+            const wasDirtyBeforeMove = this.RED.nodes.dirty()
+            const movedNodes = []
+            for (const n of selection) {
+                movedNodes.push({ n, ox: n.x, oy: n.y, moved: n.moved })
+                n.x = finiteOr(n.x, n === exitNode ? callerX + gridSize * 16 : callerX)
+                n.y = finiteOr(n.y, callerY) + drop
+                n.dirty = true
+                n.moved = true
+            }
+            // Record the repositioning as a native 'move' history event (rather than a bare
+            // x/y write) so it is undoable along with the rest of the subroutine, and so the
+            // transactional rollback below reverts it via history.pop like every other step.
+            this.RED.history.push({ t: 'move', nodes: movedNodes, dirty: wasDirtyBeforeMove })
 
-        // 2. Redirect the caller: upstream now feeds the link call; the link call's
-        //    return feeds a switch on msg.error. The "Success" branch continues to
-        //    whatever was downstream of the exit; the "Error" branch goes to a debug node
-        //    so failures are visible by default (the caller can rewire it to a notification,
-        //    a log, or further handling).
-        for (const w of entryInbound) {
-            this.setWires({ mode: 'remove', source: w.source.id, output: w.sourcePort, target: entryNode.id })
-            this.setWires({ mode: 'add', source: w.source.id, output: w.sourcePort, target: linkCallId })
+            const linkInId = this.RED.nodes.id()
+            const linkOutId = this.RED.nodes.id()
+            const linkCallId = this.RED.nodes.id()
+            const switchId = this.RED.nodes.id()
+            const catchId = this.RED.nodes.id()
+            const debugId = this.RED.nodes.id()
+
+            // 1. Create the link nodes, the caller-side error switch, an error debug and the
+            //    group catch (addNodes applies node defaults + history). The link call's target
+            //    is set afterwards via setLinks; the catch's group scope is bound by createGroup.
+            //    The caller (link call, switch, debug) stays on the original row; the body sits below.
+            this.addNodes([
+                { id: linkInId, type: 'link in', z, x: entryNode.x - gridSize * 8, y: entryNode.y, name: label, links: [] },
+                { id: linkOutId, type: 'link out', z, x: exitNode.x + gridSize * 8, y: exitNode.y, name: `${label} return`, mode: 'return', links: [] },
+                { id: linkCallId, type: 'link call', z, x: callerX, y: callerY, name: `Call ${label}`, linkType: 'static', timeout: String(callTimeout), links: [] },
+                { id: switchId, type: 'switch', z, x: callerX + gridSize * 8, y: callerY, name: 'error?', property: 'error', propertyType: 'msg', rules: [{ t: 'nempty' }, { t: 'else' }], checkall: 'true', repair: false, outputs: 2, outputLabels: ['Error', 'Success'] },
+                { id: debugId, type: 'debug', z, x: callerX + gridSize * 16, y: callerY - gridSize * 2, name: `${label} error`, active: true, tosidebar: true, console: false, tostatus: false, complete: 'true', statusType: 'auto' },
+                { id: catchId, type: 'catch', z, x: exitNode.x, y: exitNode.y + gridSize * 4, name: '', scope: 'group', uncaught: false }
+            ])
+
+            // 2. Redirect the caller: upstream now feeds the link call; the link call's
+            //    return feeds a switch on msg.error. The "Success" branch continues to
+            //    whatever was downstream of the exit; the "Error" branch goes to a debug node
+            //    so failures are visible by default (the caller can rewire it to a notification,
+            //    a log, or further handling).
+            for (const w of entryInbound) {
+                this.setWires({ mode: 'remove', source: w.source.id, output: w.sourcePort, target: entryNode.id })
+                this.setWires({ mode: 'add', source: w.source.id, output: w.sourcePort, target: linkCallId })
+            }
+            this.setWires({ mode: 'add', source: linkCallId, output: 0, target: switchId })
+            this.setWires({ mode: 'add', source: switchId, output: 0, target: debugId })
+            for (const w of exitOutbound) {
+                this.setWires({ mode: 'remove', source: exitNode.id, output: w.sourcePort, target: w.target.id })
+                this.setWires({ mode: 'add', source: switchId, output: 1, target: w.target.id })
+            }
+
+            // 3. Wire the body (link in -> entry, exit -> link out), route caught body
+            //    errors back through the link out, and point the link call at the link in.
+            this.setWires({ mode: 'add', source: linkInId, output: 0, target: entryNode.id })
+            this.setWires({ mode: 'add', source: exitNode.id, output: exitPort, target: linkOutId })
+            this.setWires({ mode: 'add', source: catchId, output: 0, target: linkOutId })
+            this.setLinks({ mode: 'add', source: linkCallId, target: linkInId })
+
+            // 4. Wrap the body (link in, the selected nodes, link out and the catch) in a
+            //    named group so the subroutine reads as one unit; the catch's group scope
+            //    binds to this group. This action only creates the subroutine on its tab;
+            //    relocating, renaming or deleting it afterwards is done with the group/node tools.
+            const bodyIds = [linkInId, ...bodyNodeIds, linkOutId, catchId]
+            this.createGroup(bodyIds, label)
+
+            this.RED.nodes.dirty(true)
+            this.RED.view.redraw(true)
+
+            return { linkInId, linkOutId, linkCallId, switchId, catchId, debugId, entryId: entryNode.id, exitId: exitNode.id }
+        } catch (err) {
+            // Roll the flow back to its pre-build state by undoing every history event
+            // recorded above (newest first): the body group, the wiring, the scaffolding
+            // nodes, and the body move all revert through history.pop.
+            while (this.RED.history.depth() > historyDepth) {
+                this.RED.history.pop()
+            }
+            this.RED.view.redraw(true)
+            throw err
         }
-        this.setWires({ mode: 'add', source: linkCallId, output: 0, target: switchId })
-        this.setWires({ mode: 'add', source: switchId, output: 0, target: debugId })
-        for (const w of exitOutbound) {
-            this.setWires({ mode: 'remove', source: exitNode.id, output: w.sourcePort, target: w.target.id })
-            this.setWires({ mode: 'add', source: switchId, output: 1, target: w.target.id })
-        }
-
-        // 3. Wire the body (link in -> entry, exit -> link out), route caught body
-        //    errors back through the link out, and point the link call at the link in.
-        this.setWires({ mode: 'add', source: linkInId, output: 0, target: entryNode.id })
-        this.setWires({ mode: 'add', source: exitNode.id, output: exitPort, target: linkOutId })
-        this.setWires({ mode: 'add', source: catchId, output: 0, target: linkOutId })
-        this.setLinks({ mode: 'add', source: linkCallId, target: linkInId })
-
-        // 4. Wrap the body (link in, the selected nodes, link out and the catch) in a
-        //    named group so the subroutine reads as one unit; the catch's group scope
-        //    binds to this group. This action only creates the subroutine on its tab;
-        //    relocating, renaming or deleting it afterwards is done with the group/node tools.
-        const bodyIds = [linkInId, ...bodyNodeIds, linkOutId, catchId]
-        this.createGroup(bodyIds, label)
-
-        this.RED.nodes.dirty(true)
-        this.RED.view.redraw(true)
-
-        return { linkInId, linkOutId, linkCallId, switchId, catchId, debugId, entryId: entryNode.id, exitId: exitNode.id }
     }
 
     get supportedActions () {

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1717,6 +1717,20 @@ export class ExpertAutomations extends ExpertActionsInterface {
             const catchId = this.RED.nodes.id()
             const debugId = this.RED.nodes.id()
 
+            // Space the caller row by the nodes' rendered widths rather than a fixed offset.
+            // Node-RED sizes a node from its label: w = max(100, 20*ceil((labelPx+57)/20)),
+            // and x is the node centre. The link call is labelled "Call <name>", so a long
+            // subroutine name widens it and a fixed gridSize*8 gap would let it overrun the
+            // switch. Estimate each width (~7px/char), then place each node centre-to-centre
+            // by half of both widths plus a one-grid margin, snapped to the grid.
+            const estWidth = (text) => Math.max(100, 20 * Math.ceil(((String(text).length * 7) + 57) / 20))
+            const gapTo = (fromX, fromW, toW) => fromX + Math.ceil((fromW / 2 + toW / 2 + gridSize) / gridSize) * gridSize
+            const linkCallW = estWidth(`Call ${label}`)
+            const switchW = estWidth('error?')
+            const debugW = estWidth(`${label} error`)
+            const switchX = gapTo(callerX, linkCallW, switchW)
+            const debugX = gapTo(switchX, switchW, debugW)
+
             // 1. Create the link nodes, the caller-side error switch, an error debug and the
             //    group catch (addNodes applies node defaults + history). The link call's target
             //    is set afterwards via setLinks; the catch's group scope is bound by createGroup.
@@ -1725,8 +1739,8 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 { id: linkInId, type: 'link in', z, x: entryNode.x - gridSize * 8, y: entryNode.y, name: label, links: [] },
                 { id: linkOutId, type: 'link out', z, x: exitNode.x + gridSize * 8, y: exitNode.y, name: `${label} return`, mode: 'return', links: [] },
                 { id: linkCallId, type: 'link call', z, x: callerX, y: callerY, name: `Call ${label}`, linkType: 'static', timeout: String(callTimeout), links: [] },
-                { id: switchId, type: 'switch', z, x: callerX + gridSize * 8, y: callerY, name: 'error?', property: 'error', propertyType: 'msg', rules: [{ t: 'nempty' }, { t: 'else' }], checkall: 'true', repair: false, outputs: 2, outputLabels: ['Error', 'Success'] },
-                { id: debugId, type: 'debug', z, x: callerX + gridSize * 16, y: callerY - gridSize * 2, name: `${label} error`, active: true, tosidebar: true, console: false, tostatus: false, complete: 'true', statusType: 'auto' },
+                { id: switchId, type: 'switch', z, x: switchX, y: callerY, name: 'error?', property: 'error', propertyType: 'msg', rules: [{ t: 'nempty' }, { t: 'else' }], checkall: 'true', repair: false, outputs: 2, outputLabels: ['Error', 'Success'] },
+                { id: debugId, type: 'debug', z, x: debugX, y: callerY - gridSize * 2, name: `${label} error`, active: true, tosidebar: true, console: false, tostatus: false, complete: 'true', statusType: 'auto' },
                 { id: catchId, type: 'catch', z, x: exitNode.x, y: exitNode.y + gridSize * 4, name: '', scope: 'group', uncaught: false }
             ])
 

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -19,6 +19,7 @@ const ADD_NODES = 'automation/add-nodes'
 const REMOVE_NODES = 'automation/remove-nodes'
 const SET_WIRES = 'automation/set-wires'
 const SET_LINKS = 'automation/set-links'
+const CREATE_SUBROUTINE = 'automation/create-subroutine'
 const IMPORT_FLOW = 'automation/import-flow'
 const CLOSE_EDITOR_TRAY = 'automation/close-editor-tray'
 const GET_NODE_TYPES = 'automation/get-node-types'
@@ -61,6 +62,7 @@ const LINK_NODE_TYPES = ['link in', 'link out', 'link call']
  *   |REMOVE_NODES
  *   |SET_WIRES
  *   |SET_LINKS
+ *   |CREATE_SUBROUTINE
  *   |IMPORT_FLOW
  *   |CLOSE_EDITOR_TRAY
  *   |GET_NODE_TYPES
@@ -333,6 +335,22 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     target: { type: 'string', description: 'Target link node ID (link in)' }
                 },
                 required: ['mode', 'source', 'target']
+            }
+        },
+        [CREATE_SUBROUTINE]: {
+            params: {
+                type: 'object',
+                properties: {
+                    ids: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        minItems: 1,
+                        description: 'IDs of the existing node(s) to move into the subroutine body. Must form a single-entry, single-exit subgraph (a single node or a linear chain).'
+                    },
+                    name: { type: 'string', description: 'Name for the subroutine, used to label the created link nodes. Defaults to "Subroutine".' },
+                    targetTabId: { type: 'string', description: 'Optional tab ID to move the subroutine body (link in, the selected nodes, link out) onto. The link call stays inline with the caller. Omit to keep the body on the same tab.' }
+                },
+                required: ['ids']
             }
         },
         [IMPORT_FLOW]: {
@@ -1486,6 +1504,171 @@ export class ExpertAutomations extends ExpertActionsInterface {
         this.RED.view.redraw()
     }
 
+    /**
+     * Wrap one or more existing nodes into a callable subroutine built from core
+     * link nodes, replacing them inline with a single `link call`. The selected
+     * nodes must form a single-entry, single-exit subgraph (the common case is a
+     * single node, or a linear chain). The result is:
+     *   caller:  <upstream> -> [link call] -> <downstream>
+     *   body:    [link in] -> <entry> ... <exit> -> [link out, mode: return]
+     * The link call targets the link in, so at runtime the message is routed into
+     * the body and returned to the caller by the return-mode link out.
+     *
+     * Rather than hand-building node JSON, this orchestrates the module's own
+     * validated actions (addNodes / setWires / setLinks), so node-type, port,
+     * same-tab, link-type and duplicate-wire validation (and undo/redo history)
+     * all come from those existing actions.
+     *
+     * @param {object} params
+     * @param {string[]} params.ids - IDs of the node(s) to move into the subroutine body
+     * @param {string} [params.name] - name used to label the created link nodes
+     * @param {string} [params.targetTabId] - if given, move the body (link in, selected nodes, link out) to this tab; the link call stays inline with the caller
+     * @returns {{linkInId:string, linkOutId:string, linkCallId:string, entryId:string, exitId:string}}
+     */
+    createSubroutine ({ ids, name, targetTabId } = {}) {
+        if (!Array.isArray(ids) || ids.length === 0) {
+            throw new Error('createSubroutine requires a non-empty "ids" array of node IDs to wrap')
+        }
+        const uniqueIds = [...new Set(ids)]
+        const selection = uniqueIds.map(id => {
+            const n = this.RED.nodes.node(id)
+            if (!n) throw new Error(`Node ${id} not found`)
+            return n
+        })
+
+        // All body nodes must be regular nodes on the same tab
+        const tabIds = [...new Set(selection.map(n => n.z))]
+        if (tabIds.length !== 1 || !tabIds[0]) {
+            throw new Error('All subroutine nodes must be regular (non-config) nodes on the same tab')
+        }
+        const z = tabIds[0]
+        this._assertWorkspaceIsEditable(z)
+        if (targetTabId && targetTabId !== z) {
+            this._assertWorkspaceIsEditable(targetTabId)
+        }
+
+        // Link nodes, subflow instances and groups cannot be wrapped
+        for (const n of selection) {
+            if (LINK_NODE_TYPES.includes(n.type)) {
+                throw new Error(`Node ${n.id} is a "${n.type}" node and cannot be placed inside a subroutine`)
+            }
+            if (typeof n.type === 'string' && n.type.startsWith('subflow:')) {
+                throw new Error(`Node ${n.id} is a subflow instance and cannot be placed inside a subroutine`)
+            }
+            if (n.type === 'group' || n.type === 'junction') {
+                throw new Error(`Node ${n.id} is a "${n.type}" and cannot be placed inside a subroutine`)
+            }
+        }
+
+        const idSet = new Set(uniqueIds)
+
+        // Classify the wires at the boundary of the selection (PORT_TYPE_INPUT = 1, PORT_TYPE_OUTPUT = 0)
+        const externalInboundByNode = new Map()
+        const externalOutboundByNode = new Map()
+        const internalInboundCount = new Map()
+        const internalOutboundCount = new Map()
+        for (const n of selection) {
+            for (const w of this.RED.nodes.getNodeLinks(n.id, 1)) {
+                if (idSet.has(w.source.id)) {
+                    internalInboundCount.set(n.id, (internalInboundCount.get(n.id) || 0) + 1)
+                } else {
+                    if (!externalInboundByNode.has(n.id)) externalInboundByNode.set(n.id, [])
+                    externalInboundByNode.get(n.id).push(w)
+                }
+            }
+            for (const w of this.RED.nodes.getNodeLinks(n.id, 0)) {
+                if (idSet.has(w.target.id)) {
+                    internalOutboundCount.set(n.id, (internalOutboundCount.get(n.id) || 0) + 1)
+                } else {
+                    if (!externalOutboundByNode.has(n.id)) externalOutboundByNode.set(n.id, [])
+                    externalOutboundByNode.get(n.id).push(w)
+                }
+            }
+        }
+
+        // Entry = unique subgraph source (no inbound from a selected node);
+        // exit  = unique subgraph sink   (no outbound to a selected node).
+        const sources = selection.filter(n => !internalInboundCount.get(n.id))
+        const sinks = selection.filter(n => !internalOutboundCount.get(n.id))
+        if (sources.length !== 1) {
+            throw new Error(`A subroutine needs a single entry node, but the selection has ${sources.length} (${sources.map(n => n.id).join(', ')}). Select a single node or a linear chain, or use add_subflow for a multi-input component.`)
+        }
+        if (sinks.length !== 1) {
+            throw new Error(`A subroutine needs a single exit node, but the selection has ${sinks.length} (${sinks.map(n => n.id).join(', ')}). Select a single node or a linear chain, or use add_subflow for a multi-output component.`)
+        }
+        const entryNode = sources[0]
+        const exitNode = sinks[0]
+
+        // All external traffic must converge on the single entry/exit
+        const strayIn = [...externalInboundByNode.keys()].filter(id => id !== entryNode.id)
+        if (strayIn.length) {
+            throw new Error(`External wires enter non-entry node(s) ${strayIn.join(', ')}. A subroutine can only be entered through its single entry node.`)
+        }
+        const strayOut = [...externalOutboundByNode.keys()].filter(id => id !== exitNode.id)
+        if (strayOut.length) {
+            throw new Error(`External wires leave non-exit node(s) ${strayOut.join(', ')}. A subroutine can only return through its single exit node.`)
+        }
+
+        // The exit must return on a single output port
+        const exitOutbound = externalOutboundByNode.get(exitNode.id) || []
+        const exitPorts = [...new Set(exitOutbound.map(w => w.sourcePort || 0))]
+        if (exitPorts.length > 1) {
+            throw new Error(`The exit node ${exitNode.id} returns on multiple output ports (${exitPorts.join(', ')}); a subroutine returns through a single port.`)
+        }
+        const exitPort = exitPorts.length ? exitPorts[0] : 0
+        const entryInbound = externalInboundByNode.get(entryNode.id) || []
+
+        // --- build the subroutine by orchestrating this module's own validated
+        // actions (addNodes / setWires / setLinks) rather than poking RED directly,
+        // so node-type, port, same-tab, link-type and duplicate validation all apply.
+        this.RED.workspaces.show(z)
+        const gridSize = (this.RED.view.gridSize && this.RED.view.gridSize()) || 20
+        const label = (typeof name === 'string' && name.trim()) ? name.trim() : 'Subroutine'
+
+        const linkInId = this.RED.nodes.id()
+        const linkOutId = this.RED.nodes.id()
+        const linkCallId = this.RED.nodes.id()
+
+        // 1. Create the link nodes (addNodes applies node defaults + history).
+        //    The link call's target is set afterwards via setLinks.
+        this.addNodes([
+            { id: linkInId, type: 'link in', z, x: entryNode.x - gridSize * 8, y: entryNode.y, name: label, links: [] },
+            { id: linkOutId, type: 'link out', z, x: exitNode.x + gridSize * 8, y: exitNode.y, name: `${label} return`, mode: 'return', links: [] },
+            { id: linkCallId, type: 'link call', z, x: entryNode.x, y: entryNode.y + gridSize * 6, name: `Call ${label}`, linkType: 'static', links: [] }
+        ])
+
+        // 2. Redirect the caller: upstream now feeds the link call, and the link
+        //    call's return feeds whatever was downstream of the exit.
+        for (const w of entryInbound) {
+            this.setWires({ mode: 'remove', source: w.source.id, output: w.sourcePort, target: entryNode.id })
+            this.setWires({ mode: 'add', source: w.source.id, output: w.sourcePort, target: linkCallId })
+        }
+        for (const w of exitOutbound) {
+            this.setWires({ mode: 'remove', source: exitNode.id, output: w.sourcePort, target: w.target.id })
+            this.setWires({ mode: 'add', source: linkCallId, output: 0, target: w.target.id })
+        }
+
+        // 3. Wire the body (link in -> entry, exit -> link out) and point the
+        //    link call at the link in.
+        this.setWires({ mode: 'add', source: linkInId, output: 0, target: entryNode.id })
+        this.setWires({ mode: 'add', source: exitNode.id, output: exitPort, target: linkOutId })
+        this.setLinks({ mode: 'add', source: linkCallId, target: linkInId })
+
+        // 4. Optionally relocate the body to another tab; the link call stays
+        //    inline with the caller and reaches the body via the cross-tab link.
+        if (targetTabId && targetTabId !== z) {
+            for (const id of [linkInId, ...uniqueIds, linkOutId]) {
+                const node = this.RED.nodes.node(id)
+                if (node) this.RED.nodes.moveNodeToTab(node, targetTabId)
+            }
+        }
+
+        this.RED.nodes.dirty(true)
+        this.RED.view.redraw(true)
+
+        return { linkInId, linkOutId, linkCallId, entryId: entryNode.id, exitId: exitNode.id }
+    }
+
     get supportedActions () {
         return this.actions
     }
@@ -1755,6 +1938,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
         case SET_LINKS:
             this.setLinks(params)
             result.data = { mode: params.mode, source: params.source, target: params.target }
+            result.success = true
+            break
+
+        case CREATE_SUBROUTINE:
+            result.data = this.createSubroutine(params)
             result.success = true
             break
 

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1567,11 +1567,21 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (uniqueIds.length === 0) {
             throw new Error('createSubroutine found no nodes to wrap; the selected group(s) are empty')
         }
-        const selection = uniqueIds.map(id => {
+        const resolved = uniqueIds.map(id => {
             const n = this.RED.nodes.node(id)
             if (!n) throw new Error(`Node ${id} not found`)
             return n
         })
+
+        // Config nodes in the selection are ignored, not wrapped. A config node is
+        // global (it has no x/y and no tab) and belongs to whichever node references
+        // it: the owner node is what moves into the body, while the config node stays
+        // put. Drop them so they don't break the same-tab check or land in the body
+        // group. (Group containers never reach here — they are expanded above.)
+        const selection = resolved.filter(n => !this.isConfigNode(n.id))
+        if (selection.length === 0) {
+            throw new Error('createSubroutine found no nodes to wrap; the selection contains only config nodes')
+        }
 
         // All body nodes must be regular nodes on the same tab
         const tabIds = [...new Set(selection.map(n => n.z))]
@@ -1581,19 +1591,15 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const z = tabIds[0]
         this._assertWorkspaceIsEditable(z)
 
-        // Config and link nodes cannot be wrapped. Config nodes are global (no x/y) so
-        // they have no place in a flow-anchored body; link nodes are the subroutine's own
-        // plumbing. (Group containers never reach here — they are expanded above.)
+        // Link nodes cannot be wrapped: they are the subroutine's own plumbing.
         for (const n of selection) {
-            if (this.isConfigNode(n.id)) {
-                throw new Error(`Node ${n.id} is a "${n.type}" config node and cannot be placed inside a subroutine`)
-            }
             if (LINK_NODE_TYPES.includes(n.type)) {
                 throw new Error(`Node ${n.id} is a "${n.type}" node and cannot be placed inside a subroutine`)
             }
         }
 
-        const idSet = new Set(uniqueIds)
+        const bodyNodeIds = selection.map(n => n.id)
+        const idSet = new Set(bodyNodeIds)
 
         // Classify the wires at the boundary of the selection (PORT_TYPE_INPUT = 1, PORT_TYPE_OUTPUT = 0)
         const externalInboundByNode = new Map()
@@ -1722,7 +1728,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         //    named group so the subroutine reads as one unit; the catch's group scope
         //    binds to this group. This action only creates the subroutine on its tab;
         //    relocating, renaming or deleting it afterwards is done with the group/node tools.
-        const bodyIds = [linkInId, ...uniqueIds, linkOutId, catchId]
+        const bodyIds = [linkInId, ...bodyNodeIds, linkOutId, catchId]
         this.createGroup(bodyIds, label)
 
         this.RED.nodes.dirty(true)

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -345,9 +345,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
                         type: 'array',
                         items: { type: 'string' },
                         minItems: 1,
-                        description: 'IDs of the existing node(s) to move into the subroutine body. A group ID is accepted and expanded to its member nodes (nested groups recurse). The resulting nodes must form a single-entry, single-exit subgraph: a single node, or connected nodes with one way in and one way out (a branch that reconverges is fine, not only a straight chain).'
+                        description: 'Create a link-call subroutine from existing nodes. IDs of the existing node(s) to move into the subroutine body. A group ID is accepted and expanded to its member nodes (nested groups recurse). The resulting nodes must form a single-entry, single-exit subgraph: a single node, or connected nodes with one way in and one way out (a branch that reconverges is fine, not only a straight chain).'
                     },
-                    name: { type: 'string', description: 'Name for the subroutine, used to label the created link nodes and the group. Defaults to "Subroutine".' },
+                    name: { type: 'string', description: 'Name for the subroutine. Used to label the generated nodes — the "link in" (named after it), the "link out" ("<name> return"), the "link call" ("Call <name>") and the error debug ("<name> error") — and to name the group that wraps the body. Defaults to "Subroutine".' },
                     timeout: { type: 'number', description: 'Link call timeout in seconds. Defaults to 5.', default: 5 }
                 },
                 required: ['ids']
@@ -1767,7 +1767,41 @@ export class ExpertAutomations extends ExpertActionsInterface {
             this.setWires({ mode: 'add', source: catchId, output: 0, target: linkOutId })
             this.setLinks({ mode: 'add', source: linkCallId, target: linkInId })
 
-            // 4. Wrap the body (link in, the selected nodes, link out and the catch) in a
+            // 4. Free the body nodes from any group they already belong to before re-grouping.
+            //    Node-RED's group-selection refuses to group a set of nodes unless they all
+            //    share the same parent group; our freshly-created scaffolding (link in/out,
+            //    catch) is ungrouped, so any selected node still carrying its original group
+            //    (e.g. when a whole group was expanded into the selection) would make the group
+            //    call bail and the whole build roll back. Detach the body nodes from their
+            //    group(s), walking out of nested groups too, so they are free to join the
+            //    subroutine group. This goes through the validated updateGroup(remove) path, so
+            //    it is history-tracked and reverts with the rest of the build on failure.
+            const touchedGroupIds = new Set()
+            let stillGrouped = selection.filter(n => n.g)
+            while (stillGrouped.length) {
+                const idsByGroup = new Map()
+                for (const n of stillGrouped) {
+                    if (!idsByGroup.has(n.g)) idsByGroup.set(n.g, [])
+                    idsByGroup.get(n.g).push(n.id)
+                }
+                for (const [groupId, nodeIds] of idsByGroup) {
+                    touchedGroupIds.add(groupId)
+                    this.updateGroup(groupId, { nodeIds, remove: true })
+                }
+                stillGrouped = selection.filter(n => n.g)
+            }
+
+            // Drop any original group the detach emptied (the common case: a whole group was
+            // wrapped, so its members all moved into the subroutine) so no empty husk is left
+            // on the canvas. A group that still holds other, unselected members is left intact.
+            for (const groupId of touchedGroupIds) {
+                const g = this.RED.nodes.group(groupId)
+                if (g && (!g.nodes || g.nodes.length === 0)) {
+                    this.deleteGroup(groupId)
+                }
+            }
+
+            // 5. Wrap the body (link in, the selected nodes, link out and the catch) in a
             //    named group so the subroutine reads as one unit; the catch's group scope
             //    binds to this group. This action only creates the subroutine on its tab;
             //    relocating, renaming or deleting it afterwards is done with the group/node tools.

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -916,12 +916,27 @@ describeMain('expertAutomations', () => {
                 linkCall.timeout.should.equal('30')
             })
 
-            it('rejects a config node in the selection (config nodes are global, with no x/y)', () => {
-                // A config node is scoped to a flow but has no canvas position, so it can't
-                // be wrapped into a flow-anchored subroutine body.
-                const cfg = { id: 'cfg', type: 'mqtt-broker', z: 'tab1', _def: { category: 'config' } }
+            it('ignores config nodes in the selection, wrapping only the regular nodes', () => {
+                // A config node has no canvas position and belongs to whichever node
+                // references it; the owner node moves into the body while the config node
+                // stays put, so it is dropped from the selection rather than rejected.
+                setupSingleNode()
+                const cfg = { id: 'cfg', type: 'mqtt-broker', _def: { category: 'config' } }
+                mockRED.nodes.node.withArgs('cfg').returns(cfg)
+
+                const data = expertAutomations.createSubroutine({ ids: ['f1', 'cfg'], name: 'My Sub' })
+
+                data.entryId.should.equal('f1')
+                data.exitId.should.equal('f1')
+                // the config node is not wrapped into the body group
+                const [groupIds] = expertAutomations.createGroup.firstCall.args
+                groupIds.should.deepEqual([data.linkInId, 'f1', data.linkOutId, data.catchId])
+            })
+
+            it('rejects a selection of only config nodes', () => {
+                const cfg = { id: 'cfg', type: 'mqtt-broker', _def: { category: 'config' } }
                 mockRED.nodes.node.withArgs('cfg').returns(cfg);
-                (() => expertAutomations.createSubroutine({ ids: ['cfg'] })).should.throw(/config node and cannot be placed inside a subroutine/)
+                (() => expertAutomations.createSubroutine({ ids: ['cfg'] })).should.throw(/only config nodes/)
             })
 
             it('anchors the link nodes off 50/50 if the entry node has non-finite coords', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -836,6 +836,9 @@ describeMain('expertAutomations', () => {
                 mockRED.view.redraw = sinon.stub()
                 idc = 0
                 mockRED.nodes.id = sinon.stub().callsFake(() => `gen-${++idc}`)
+                // isConfigNode falls back to getType when a node has no _def; plain test
+                // nodes resolve to no def (treated as regular, non-config).
+                mockRED.nodes.getType = sinon.stub().returns(undefined)
                 // Orchestration is tested here; addNodes/setWires/setLinks have their own tests.
                 sinon.stub(expertAutomations, 'addNodes')
                 sinon.stub(expertAutomations, 'setWires')
@@ -883,6 +886,32 @@ describeMain('expertAutomations', () => {
 
                 // 3. virtual link call -> link in via setLinks
                 expertAutomations.setLinks.calledWithMatch({ mode: 'add', source: data.linkCallId, target: data.linkInId }).should.be.true()
+            })
+
+            it('rejects a config node in the selection (config nodes are global, with no x/y)', () => {
+                // A config node is scoped to a flow but has no canvas position, so it can't
+                // be wrapped into a flow-anchored subroutine body.
+                const cfg = { id: 'cfg', type: 'mqtt-broker', z: 'tab1', _def: { category: 'config' } }
+                mockRED.nodes.node.withArgs('cfg').returns(cfg);
+                (() => expertAutomations.createSubroutine({ ids: ['cfg'] })).should.throw(/config node and cannot be placed inside a subroutine/)
+            })
+
+            it('anchors the link nodes off 50/50 if the entry node has non-finite coords', () => {
+                const inject = { id: 'inj', type: 'inject', z: 'tab1' }
+                const fn = { id: 'f1', type: 'function', z: 'tab1', x: null, y: null }
+                const dbg = { id: 'dbg', type: 'debug', z: 'tab1' }
+                mockRED.nodes.node.withArgs('f1').returns(fn)
+                mockRED.nodes.getNodeLinks = sinon.stub()
+                mockRED.nodes.getNodeLinks.withArgs('f1', 1).returns([{ source: inject, sourcePort: 0, target: fn }])
+                mockRED.nodes.getNodeLinks.withArgs('f1', 0).returns([{ source: fn, sourcePort: 0, target: dbg }])
+
+                expertAutomations.createSubroutine({ ids: ['f1'] })
+
+                const createdNodes = expertAutomations.addNodes.firstCall.args[0]
+                createdNodes.forEach((n) => {
+                    Number.isFinite(n.x).should.be.true(`${n.type}.x should be finite, got ${n.x}`)
+                    Number.isFinite(n.y).should.be.true(`${n.type}.y should be finite, got ${n.y}`)
+                })
             })
 
             it('wraps a linear chain, leaving the internal wire intact', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -870,18 +870,21 @@ describeMain('expertAutomations', () => {
                 // 1. link nodes, the error switch and the group catch created via addNodes in one call
                 expertAutomations.addNodes.calledOnce.should.be.true()
                 const createdNodes = expertAutomations.addNodes.firstCall.args[0]
-                createdNodes.map(n => n.type).should.deepEqual(['link in', 'link out', 'link call', 'switch', 'catch'])
+                createdNodes.map(n => n.type).should.deepEqual(['link in', 'link out', 'link call', 'switch', 'debug', 'catch'])
                 const linkOut = createdNodes.find(n => n.type === 'link out')
                 const linkCall = createdNodes.find(n => n.type === 'link call')
                 const errSwitch = createdNodes.find(n => n.type === 'switch')
                 const errCatch = createdNodes.find(n => n.type === 'catch')
+                const errDebug = createdNodes.find(n => n.type === 'debug')
                 linkOut.mode.should.equal('return')
                 linkCall.linkType.should.equal('static')
                 linkCall.timeout.should.equal('5')
                 errSwitch.property.should.equal('error')
                 errSwitch.propertyType.should.equal('msg')
                 errSwitch.outputs.should.equal(2)
+                errSwitch.outputLabels.should.deepEqual(['Error', 'Success'])
                 errCatch.scope.should.equal('group')
+                errDebug.id.should.equal(data.debugId)
 
                 // 2. wiring via setWires: remove inject->f1 / f1->dbg, then route through
                 //    the link call, the error switch and the group catch
@@ -890,6 +893,7 @@ describeMain('expertAutomations', () => {
                 wireCalls.should.matchAny(w => w.mode === 'remove' && w.source === 'f1' && w.target === 'dbg')
                 wireCalls.should.matchAny(w => w.mode === 'add' && w.source === 'inj' && w.target === data.linkCallId)
                 wireCalls.should.matchAny(w => w.mode === 'add' && w.source === data.linkCallId && w.target === data.switchId)
+                wireCalls.should.matchAny(w => w.mode === 'add' && w.source === data.switchId && w.output === 0 && w.target === data.debugId)
                 wireCalls.should.matchAny(w => w.mode === 'add' && w.source === data.switchId && w.output === 1 && w.target === 'dbg')
                 wireCalls.should.matchAny(w => w.mode === 'add' && w.source === data.linkInId && w.target === 'f1')
                 wireCalls.should.matchAny(w => w.mode === 'add' && w.source === 'f1' && w.target === data.linkOutId)
@@ -961,21 +965,35 @@ describeMain('expertAutomations', () => {
                 removes.should.matchAny(w => w.source === 'n2' && w.target === 'down')
             })
 
-            it('moves the body to another tab when targetTabId is given (link call stays inline)', () => {
-                const { fn } = setupSingleNode()
-                mockRED.nodes.moveNodeToTab = sinon.stub()
-                const linkIn = { id: 'gen-1', type: 'link in', z: 'tab1' }
-                const linkOut = { id: 'gen-2', type: 'link out', z: 'tab1' }
-                const errCatch = { id: 'gen-5', type: 'catch', z: 'tab1' }
-                mockRED.nodes.node.withArgs('gen-1').returns(linkIn)
-                mockRED.nodes.node.withArgs('gen-2').returns(linkOut)
-                mockRED.nodes.node.withArgs('gen-5').returns(errCatch)
-                expertAutomations.createSubroutine({ ids: ['f1'], targetTabId: 'tab2' })
-                // link in, the function node, link out and the catch move; the link call (gen-3) and switch (gen-4) do not
-                mockRED.nodes.moveNodeToTab.callCount.should.equal(4)
-                mockRED.nodes.moveNodeToTab.getCalls().some(c => c.args[0] === fn && c.args[1] === 'tab2').should.be.true()
-                mockRED.nodes.moveNodeToTab.getCalls().some(c => c.args[0] === linkIn).should.be.true()
-                mockRED.nodes.moveNodeToTab.getCalls().some(c => c.args[0] === errCatch).should.be.true()
+            it('expands a selected group into its member nodes', () => {
+                const up = { id: 'up', type: 'inject', z: 'tab1' }
+                const n1 = { id: 'n1', type: 'function', z: 'tab1', x: 200, y: 100, g: 'grp' }
+                const n2 = { id: 'n2', type: 'function', z: 'tab1', x: 400, y: 100, g: 'grp' }
+                const down = { id: 'down', type: 'debug', z: 'tab1' }
+                const grp = { id: 'grp', type: 'group', z: 'tab1', nodes: ['n1', 'n2'] }
+                mockRED.nodes.group = sinon.stub()
+                mockRED.nodes.group.withArgs('grp').returns(grp)
+                mockRED.nodes.node.withArgs('n1').returns(n1)
+                mockRED.nodes.node.withArgs('n2').returns(n2)
+                mockRED.nodes.getNodeLinks = sinon.stub()
+                mockRED.nodes.getNodeLinks.withArgs('n1', 1).returns([{ source: up, sourcePort: 0, target: n1 }])
+                mockRED.nodes.getNodeLinks.withArgs('n1', 0).returns([{ source: n1, sourcePort: 0, target: n2 }])
+                mockRED.nodes.getNodeLinks.withArgs('n2', 1).returns([{ source: n1, sourcePort: 0, target: n2 }])
+                mockRED.nodes.getNodeLinks.withArgs('n2', 0).returns([{ source: n2, sourcePort: 0, target: down }])
+
+                const data = expertAutomations.createSubroutine({ ids: ['grp'] })
+                data.entryId.should.equal('n1')
+                data.exitId.should.equal('n2')
+                // the body group is built from the expanded members, not the original group id
+                const [groupIds] = expertAutomations.createGroup.firstCall.args
+                groupIds.should.deepEqual([data.linkInId, 'n1', 'n2', data.linkOutId, data.catchId])
+            })
+
+            it('throws when the selection expands to no nodes (empty group)', () => {
+                const grp = { id: 'empty', type: 'group', z: 'tab1', nodes: [] }
+                mockRED.nodes.group = sinon.stub()
+                mockRED.nodes.group.withArgs('empty').returns(grp);
+                (() => expertAutomations.createSubroutine({ ids: ['empty'] })).should.throw(/no nodes to wrap/)
             })
 
             it('rejects a selection with multiple exit points', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -839,6 +839,10 @@ describeMain('expertAutomations', () => {
                 // isConfigNode falls back to getType when a node has no _def; plain test
                 // nodes resolve to no def (treated as regular, non-config).
                 mockRED.nodes.getType = sinon.stub().returns(undefined)
+                // The build phase is transactional: it snapshots history.depth() up front,
+                // pushes a 'move' event for the body, and pops back to the snapshot on
+                // failure. Stub all three so the orchestration tests run.
+                mockRED.history = { depth: sinon.stub().returns(0), pop: sinon.stub(), push: sinon.stub() }
                 // Orchestration is tested here; addNodes/setWires/setLinks have their own tests.
                 sinon.stub(expertAutomations, 'addNodes')
                 sinon.stub(expertAutomations, 'setWires')
@@ -850,7 +854,7 @@ describeMain('expertAutomations', () => {
             // inject -> function 1 -> debug, wrapping function 1 only
             function setupSingleNode () {
                 const inject = { id: 'inj', type: 'inject', z: 'tab1' }
-                const fn = { id: 'f1', type: 'function', z: 'tab1', x: 300, y: 100 }
+                const fn = { id: 'f1', type: 'function', z: 'tab1', x: 300, y: 100, outputs: 1 }
                 const dbg = { id: 'dbg', type: 'debug', z: 'tab1' }
                 mockRED.nodes.node.withArgs('f1').returns(fn)
                 mockRED.nodes.getNodeLinks = sinon.stub()
@@ -941,7 +945,7 @@ describeMain('expertAutomations', () => {
 
             it('anchors the link nodes off 50/50 if the entry node has non-finite coords', () => {
                 const inject = { id: 'inj', type: 'inject', z: 'tab1' }
-                const fn = { id: 'f1', type: 'function', z: 'tab1', x: null, y: null }
+                const fn = { id: 'f1', type: 'function', z: 'tab1', x: null, y: null, outputs: 1 }
                 const dbg = { id: 'dbg', type: 'debug', z: 'tab1' }
                 mockRED.nodes.node.withArgs('f1').returns(fn)
                 mockRED.nodes.getNodeLinks = sinon.stub()
@@ -960,7 +964,7 @@ describeMain('expertAutomations', () => {
             it('wraps a linear chain, leaving the internal wire intact', () => {
                 const up = { id: 'up', type: 'inject', z: 'tab1' }
                 const n1 = { id: 'n1', type: 'function', z: 'tab1', x: 200, y: 100 }
-                const n2 = { id: 'n2', type: 'function', z: 'tab1', x: 400, y: 100 }
+                const n2 = { id: 'n2', type: 'function', z: 'tab1', x: 400, y: 100, outputs: 1 }
                 const down = { id: 'down', type: 'debug', z: 'tab1' }
                 mockRED.nodes.node.withArgs('n1').returns(n1)
                 mockRED.nodes.node.withArgs('n2').returns(n2)
@@ -983,7 +987,7 @@ describeMain('expertAutomations', () => {
             it('expands a selected group into its member nodes', () => {
                 const up = { id: 'up', type: 'inject', z: 'tab1' }
                 const n1 = { id: 'n1', type: 'function', z: 'tab1', x: 200, y: 100, g: 'grp' }
-                const n2 = { id: 'n2', type: 'function', z: 'tab1', x: 400, y: 100, g: 'grp' }
+                const n2 = { id: 'n2', type: 'function', z: 'tab1', x: 400, y: 100, g: 'grp', outputs: 1 }
                 const down = { id: 'down', type: 'debug', z: 'tab1' }
                 const grp = { id: 'grp', type: 'group', z: 'tab1', nodes: ['n1', 'n2'] }
                 mockRED.nodes.group = sinon.stub()
@@ -1062,6 +1066,62 @@ describeMain('expertAutomations', () => {
 
             it('throws when ids is empty', () => {
                 (() => expertAutomations.createSubroutine({ ids: [] })).should.throw(/non-empty/)
+            })
+
+            it('rejects an exit node with no output port before mutating anything', () => {
+                // f1 -> dbg, wrapping both: the exit (debug) has no output to return through,
+                // so it must be rejected up front, leaving the flow untouched.
+                const inject = { id: 'inj', type: 'inject', z: 'tab1' }
+                const f1 = { id: 'f1', type: 'function', z: 'tab1', x: 200, y: 100, outputs: 1 }
+                const dbg = { id: 'dbg', type: 'debug', z: 'tab1', x: 400, y: 100, outputs: 0 }
+                mockRED.nodes.node.withArgs('f1').returns(f1)
+                mockRED.nodes.node.withArgs('dbg').returns(dbg)
+                mockRED.nodes.getNodeLinks = sinon.stub()
+                mockRED.nodes.getNodeLinks.withArgs('f1', 1).returns([{ source: inject, sourcePort: 0, target: f1 }])
+                mockRED.nodes.getNodeLinks.withArgs('f1', 0).returns([{ source: f1, sourcePort: 0, target: dbg }])
+                mockRED.nodes.getNodeLinks.withArgs('dbg', 1).returns([{ source: f1, sourcePort: 0, target: dbg }])
+                mockRED.nodes.getNodeLinks.withArgs('dbg', 0).returns([]);
+
+                (() => expertAutomations.createSubroutine({ ids: ['f1', 'dbg'] })).should.throw(/no output port/)
+                expertAutomations.addNodes.called.should.be.false()
+                mockRED.history.push.called.should.be.false()
+            })
+
+            it('rejects an entry node that does not accept inputs before mutating anything', () => {
+                // inj -> f1, wrapping both: the entry (inject) cannot be called into, so the
+                // subroutine cannot be built. getType reports inject as inputs: 0.
+                const inj = { id: 'inj', type: 'inject', z: 'tab1', x: 200, y: 100 }
+                const f1 = { id: 'f1', type: 'function', z: 'tab1', x: 400, y: 100, outputs: 1 }
+                const down = { id: 'down', type: 'debug', z: 'tab1' }
+                mockRED.nodes.node.withArgs('inj').returns(inj)
+                mockRED.nodes.node.withArgs('f1').returns(f1)
+                mockRED.nodes.getType.withArgs('inject').returns({ inputs: 0 })
+                mockRED.nodes.getNodeLinks = sinon.stub()
+                mockRED.nodes.getNodeLinks.withArgs('inj', 1).returns([])
+                mockRED.nodes.getNodeLinks.withArgs('inj', 0).returns([{ source: inj, sourcePort: 0, target: f1 }])
+                mockRED.nodes.getNodeLinks.withArgs('f1', 1).returns([{ source: inj, sourcePort: 0, target: f1 }])
+                mockRED.nodes.getNodeLinks.withArgs('f1', 0).returns([{ source: f1, sourcePort: 0, target: down }]);
+
+                (() => expertAutomations.createSubroutine({ ids: ['inj', 'f1'] })).should.throw(/does not accept inputs/)
+                expertAutomations.addNodes.called.should.be.false()
+            })
+
+            it('rolls back every recorded history event when a build step throws', () => {
+                setupSingleNode()
+                // Simulate a failure partway through the build, after some history events
+                // have been recorded. depth() reports the snapshot (0), then a stack that
+                // unwinds back down to it as pop() is called.
+                const depth = sinon.stub()
+                depth.onCall(0).returns(0) // snapshot taken before the build
+                depth.onCall(1).returns(2)
+                depth.onCall(2).returns(1)
+                depth.onCall(3).returns(0)
+                mockRED.history = { depth, pop: sinon.stub(), push: sinon.stub() }
+                expertAutomations.setLinks.throws(new Error('boom'));
+
+                (() => expertAutomations.createSubroutine({ ids: ['f1'] })).should.throw(/boom/)
+                // rewound back to the snapshot depth, and the partial group was never left behind
+                mockRED.history.pop.calledTwice.should.be.true()
             })
         })
         describe('addNodes action', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -843,6 +843,7 @@ describeMain('expertAutomations', () => {
                 sinon.stub(expertAutomations, 'addNodes')
                 sinon.stub(expertAutomations, 'setWires')
                 sinon.stub(expertAutomations, 'setLinks')
+                sinon.stub(expertAutomations, 'createGroup')
                 mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().returns(false), show: sinon.stub() }
             })
 
@@ -858,34 +859,57 @@ describeMain('expertAutomations', () => {
                 return { inject, fn, dbg }
             }
 
-            it('wraps a single node, reusing addNodes/setWires/setLinks', () => {
+            it('wraps a single node, reusing addNodes/setWires/setLinks/createGroup', () => {
                 setupSingleNode()
                 const data = expertAutomations.createSubroutine({ ids: ['f1'], name: 'My Sub' })
 
                 data.entryId.should.equal('f1')
                 data.exitId.should.equal('f1')
-                data.should.have.properties(['linkInId', 'linkOutId', 'linkCallId'])
+                data.should.have.properties(['linkInId', 'linkOutId', 'linkCallId', 'switchId', 'catchId'])
 
-                // 1. three link nodes created via addNodes in one call
+                // 1. link nodes, the error switch and the group catch created via addNodes in one call
                 expertAutomations.addNodes.calledOnce.should.be.true()
                 const createdNodes = expertAutomations.addNodes.firstCall.args[0]
-                createdNodes.map(n => n.type).should.deepEqual(['link in', 'link out', 'link call'])
+                createdNodes.map(n => n.type).should.deepEqual(['link in', 'link out', 'link call', 'switch', 'catch'])
                 const linkOut = createdNodes.find(n => n.type === 'link out')
                 const linkCall = createdNodes.find(n => n.type === 'link call')
+                const errSwitch = createdNodes.find(n => n.type === 'switch')
+                const errCatch = createdNodes.find(n => n.type === 'catch')
                 linkOut.mode.should.equal('return')
                 linkCall.linkType.should.equal('static')
+                linkCall.timeout.should.equal('5')
+                errSwitch.property.should.equal('error')
+                errSwitch.propertyType.should.equal('msg')
+                errSwitch.outputs.should.equal(2)
+                errCatch.scope.should.equal('group')
 
-                // 2. wiring via setWires: remove inject->f1 / f1->dbg, add the 4 new wires
+                // 2. wiring via setWires: remove inject->f1 / f1->dbg, then route through
+                //    the link call, the error switch and the group catch
                 const wireCalls = expertAutomations.setWires.getCalls().map(c => c.args[0])
                 wireCalls.should.matchAny(w => w.mode === 'remove' && w.source === 'inj' && w.target === 'f1')
                 wireCalls.should.matchAny(w => w.mode === 'remove' && w.source === 'f1' && w.target === 'dbg')
                 wireCalls.should.matchAny(w => w.mode === 'add' && w.source === 'inj' && w.target === data.linkCallId)
-                wireCalls.should.matchAny(w => w.mode === 'add' && w.source === data.linkCallId && w.target === 'dbg')
+                wireCalls.should.matchAny(w => w.mode === 'add' && w.source === data.linkCallId && w.target === data.switchId)
+                wireCalls.should.matchAny(w => w.mode === 'add' && w.source === data.switchId && w.output === 1 && w.target === 'dbg')
                 wireCalls.should.matchAny(w => w.mode === 'add' && w.source === data.linkInId && w.target === 'f1')
                 wireCalls.should.matchAny(w => w.mode === 'add' && w.source === 'f1' && w.target === data.linkOutId)
+                wireCalls.should.matchAny(w => w.mode === 'add' && w.source === data.catchId && w.target === data.linkOutId)
 
                 // 3. virtual link call -> link in via setLinks
                 expertAutomations.setLinks.calledWithMatch({ mode: 'add', source: data.linkCallId, target: data.linkInId }).should.be.true()
+
+                // 4. the body (link in, node, link out, catch) is wrapped in a named group
+                expertAutomations.createGroup.calledOnce.should.be.true()
+                const [groupIds, groupName] = expertAutomations.createGroup.firstCall.args
+                groupIds.should.deepEqual([data.linkInId, 'f1', data.linkOutId, data.catchId])
+                groupName.should.equal('My Sub')
+            })
+
+            it('uses the supplied timeout for the link call', () => {
+                setupSingleNode()
+                expertAutomations.createSubroutine({ ids: ['f1'], timeout: 30 })
+                const linkCall = expertAutomations.addNodes.firstCall.args[0].find(n => n.type === 'link call')
+                linkCall.timeout.should.equal('30')
             })
 
             it('rejects a config node in the selection (config nodes are global, with no x/y)', () => {
@@ -942,13 +966,16 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.moveNodeToTab = sinon.stub()
                 const linkIn = { id: 'gen-1', type: 'link in', z: 'tab1' }
                 const linkOut = { id: 'gen-2', type: 'link out', z: 'tab1' }
+                const errCatch = { id: 'gen-5', type: 'catch', z: 'tab1' }
                 mockRED.nodes.node.withArgs('gen-1').returns(linkIn)
                 mockRED.nodes.node.withArgs('gen-2').returns(linkOut)
+                mockRED.nodes.node.withArgs('gen-5').returns(errCatch)
                 expertAutomations.createSubroutine({ ids: ['f1'], targetTabId: 'tab2' })
-                // link in, the function node and link out move; the link call (gen-3) does not
-                mockRED.nodes.moveNodeToTab.callCount.should.equal(3)
+                // link in, the function node, link out and the catch move; the link call (gen-3) and switch (gen-4) do not
+                mockRED.nodes.moveNodeToTab.callCount.should.equal(4)
                 mockRED.nodes.moveNodeToTab.getCalls().some(c => c.args[0] === fn && c.args[1] === 'tab2').should.be.true()
                 mockRED.nodes.moveNodeToTab.getCalls().some(c => c.args[0] === linkIn).should.be.true()
+                mockRED.nodes.moveNodeToTab.getCalls().some(c => c.args[0] === errCatch).should.be.true()
             })
 
             it('rejects a selection with multiple exit points', () => {
@@ -969,6 +996,30 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.getNodeLinks.withArgs('n3', 0).returns([{ source: n3, sourcePort: 0, target: ext }]);
 
                 (() => expertAutomations.createSubroutine({ ids: ['n1', 'n2', 'n3'] })).should.throw(/single exit node/)
+            })
+
+            it('rejects an external wire into a middle (non-entry) node', () => {
+                // up -> n1 -> n2 -> n3 -> down, wrapping {n1, n2, n3}, but an external
+                // node X also feeds the middle node n2. The body would then be reachable
+                // bypassing the entry, so it must be rejected.
+                const up = { id: 'up', type: 'inject', z: 'tab1' }
+                const x = { id: 'x', type: 'inject', z: 'tab1' }
+                const n1 = { id: 'n1', type: 'function', z: 'tab1', x: 200, y: 100 }
+                const n2 = { id: 'n2', type: 'function', z: 'tab1', x: 400, y: 100 }
+                const n3 = { id: 'n3', type: 'function', z: 'tab1', x: 600, y: 100 }
+                const down = { id: 'down', type: 'debug', z: 'tab1' }
+                mockRED.nodes.node.withArgs('n1').returns(n1)
+                mockRED.nodes.node.withArgs('n2').returns(n2)
+                mockRED.nodes.node.withArgs('n3').returns(n3)
+                mockRED.nodes.getNodeLinks = sinon.stub()
+                mockRED.nodes.getNodeLinks.withArgs('n1', 1).returns([{ source: up, sourcePort: 0, target: n1 }])
+                mockRED.nodes.getNodeLinks.withArgs('n1', 0).returns([{ source: n1, sourcePort: 0, target: n2 }])
+                mockRED.nodes.getNodeLinks.withArgs('n2', 1).returns([{ source: n1, sourcePort: 0, target: n2 }, { source: x, sourcePort: 0, target: n2 }])
+                mockRED.nodes.getNodeLinks.withArgs('n2', 0).returns([{ source: n2, sourcePort: 0, target: n3 }])
+                mockRED.nodes.getNodeLinks.withArgs('n3', 1).returns([{ source: n2, sourcePort: 0, target: n3 }])
+                mockRED.nodes.getNodeLinks.withArgs('n3', 0).returns([{ source: n3, sourcePort: 0, target: down }]);
+
+                (() => expertAutomations.createSubroutine({ ids: ['n1', 'n2', 'n3'] })).should.throw(/can only be entered through its single entry node/)
             })
 
             it('rejects a link node in the selection', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -100,6 +100,7 @@ describeMain('expertAutomations', () => {
                 'automation/remove-nodes',
                 'automation/set-wires',
                 'automation/set-links',
+                'automation/create-subroutine',
                 'automation/import-flow',
                 'automation/close-editor-tray',
                 'automation/get-node-types',
@@ -826,6 +827,128 @@ describeMain('expertAutomations', () => {
                 const historyArg = mockRED.history.push.firstCall.args[0]
                 historyArg.events[0].changes.links.should.deepEqual(['existing1'])
                 historyArg.events[1].changes.links.should.deepEqual(['existing2'])
+            })
+        })
+        describe('createSubroutine action', () => {
+            let idc
+            beforeEach(() => {
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.view.redraw = sinon.stub()
+                idc = 0
+                mockRED.nodes.id = sinon.stub().callsFake(() => `gen-${++idc}`)
+                // Orchestration is tested here; addNodes/setWires/setLinks have their own tests.
+                sinon.stub(expertAutomations, 'addNodes')
+                sinon.stub(expertAutomations, 'setWires')
+                sinon.stub(expertAutomations, 'setLinks')
+                mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().returns(false), show: sinon.stub() }
+            })
+
+            // inject -> function 1 -> debug, wrapping function 1 only
+            function setupSingleNode () {
+                const inject = { id: 'inj', type: 'inject', z: 'tab1' }
+                const fn = { id: 'f1', type: 'function', z: 'tab1', x: 300, y: 100 }
+                const dbg = { id: 'dbg', type: 'debug', z: 'tab1' }
+                mockRED.nodes.node.withArgs('f1').returns(fn)
+                mockRED.nodes.getNodeLinks = sinon.stub()
+                mockRED.nodes.getNodeLinks.withArgs('f1', 1).returns([{ source: inject, sourcePort: 0, target: fn }])
+                mockRED.nodes.getNodeLinks.withArgs('f1', 0).returns([{ source: fn, sourcePort: 0, target: dbg }])
+                return { inject, fn, dbg }
+            }
+
+            it('wraps a single node, reusing addNodes/setWires/setLinks', () => {
+                setupSingleNode()
+                const data = expertAutomations.createSubroutine({ ids: ['f1'], name: 'My Sub' })
+
+                data.entryId.should.equal('f1')
+                data.exitId.should.equal('f1')
+                data.should.have.properties(['linkInId', 'linkOutId', 'linkCallId'])
+
+                // 1. three link nodes created via addNodes in one call
+                expertAutomations.addNodes.calledOnce.should.be.true()
+                const createdNodes = expertAutomations.addNodes.firstCall.args[0]
+                createdNodes.map(n => n.type).should.deepEqual(['link in', 'link out', 'link call'])
+                const linkOut = createdNodes.find(n => n.type === 'link out')
+                const linkCall = createdNodes.find(n => n.type === 'link call')
+                linkOut.mode.should.equal('return')
+                linkCall.linkType.should.equal('static')
+
+                // 2. wiring via setWires: remove inject->f1 / f1->dbg, add the 4 new wires
+                const wireCalls = expertAutomations.setWires.getCalls().map(c => c.args[0])
+                wireCalls.should.matchAny(w => w.mode === 'remove' && w.source === 'inj' && w.target === 'f1')
+                wireCalls.should.matchAny(w => w.mode === 'remove' && w.source === 'f1' && w.target === 'dbg')
+                wireCalls.should.matchAny(w => w.mode === 'add' && w.source === 'inj' && w.target === data.linkCallId)
+                wireCalls.should.matchAny(w => w.mode === 'add' && w.source === data.linkCallId && w.target === 'dbg')
+                wireCalls.should.matchAny(w => w.mode === 'add' && w.source === data.linkInId && w.target === 'f1')
+                wireCalls.should.matchAny(w => w.mode === 'add' && w.source === 'f1' && w.target === data.linkOutId)
+
+                // 3. virtual link call -> link in via setLinks
+                expertAutomations.setLinks.calledWithMatch({ mode: 'add', source: data.linkCallId, target: data.linkInId }).should.be.true()
+            })
+
+            it('wraps a linear chain, leaving the internal wire intact', () => {
+                const up = { id: 'up', type: 'inject', z: 'tab1' }
+                const n1 = { id: 'n1', type: 'function', z: 'tab1', x: 200, y: 100 }
+                const n2 = { id: 'n2', type: 'function', z: 'tab1', x: 400, y: 100 }
+                const down = { id: 'down', type: 'debug', z: 'tab1' }
+                mockRED.nodes.node.withArgs('n1').returns(n1)
+                mockRED.nodes.node.withArgs('n2').returns(n2)
+                mockRED.nodes.getNodeLinks = sinon.stub()
+                mockRED.nodes.getNodeLinks.withArgs('n1', 1).returns([{ source: up, sourcePort: 0, target: n1 }])
+                mockRED.nodes.getNodeLinks.withArgs('n1', 0).returns([{ source: n1, sourcePort: 0, target: n2 }])
+                mockRED.nodes.getNodeLinks.withArgs('n2', 1).returns([{ source: n1, sourcePort: 0, target: n2 }])
+                mockRED.nodes.getNodeLinks.withArgs('n2', 0).returns([{ source: n2, sourcePort: 0, target: down }])
+
+                const data = expertAutomations.createSubroutine({ ids: ['n1', 'n2'] })
+                data.entryId.should.equal('n1')
+                data.exitId.should.equal('n2')
+                // only the two external wires are removed; the internal n1 -> n2 is untouched
+                const removes = expertAutomations.setWires.getCalls().map(c => c.args[0]).filter(w => w.mode === 'remove')
+                removes.should.have.lengthOf(2)
+                removes.should.matchAny(w => w.source === 'up' && w.target === 'n1')
+                removes.should.matchAny(w => w.source === 'n2' && w.target === 'down')
+            })
+
+            it('moves the body to another tab when targetTabId is given (link call stays inline)', () => {
+                const { fn } = setupSingleNode()
+                mockRED.nodes.moveNodeToTab = sinon.stub()
+                const linkIn = { id: 'gen-1', type: 'link in', z: 'tab1' }
+                const linkOut = { id: 'gen-2', type: 'link out', z: 'tab1' }
+                mockRED.nodes.node.withArgs('gen-1').returns(linkIn)
+                mockRED.nodes.node.withArgs('gen-2').returns(linkOut)
+                expertAutomations.createSubroutine({ ids: ['f1'], targetTabId: 'tab2' })
+                // link in, the function node and link out move; the link call (gen-3) does not
+                mockRED.nodes.moveNodeToTab.callCount.should.equal(3)
+                mockRED.nodes.moveNodeToTab.getCalls().some(c => c.args[0] === fn && c.args[1] === 'tab2').should.be.true()
+                mockRED.nodes.moveNodeToTab.getCalls().some(c => c.args[0] === linkIn).should.be.true()
+            })
+
+            it('rejects a selection with multiple exit points', () => {
+                const up = { id: 'up', type: 'inject', z: 'tab1' }
+                const n1 = { id: 'n1', type: 'function', z: 'tab1', x: 200, y: 100 }
+                const n2 = { id: 'n2', type: 'debug', z: 'tab1' }
+                const n3 = { id: 'n3', type: 'debug', z: 'tab1' }
+                const ext = { id: 'ext', type: 'debug', z: 'tab1' }
+                mockRED.nodes.node.withArgs('n1').returns(n1)
+                mockRED.nodes.node.withArgs('n2').returns(n2)
+                mockRED.nodes.node.withArgs('n3').returns(n3)
+                mockRED.nodes.getNodeLinks = sinon.stub()
+                mockRED.nodes.getNodeLinks.withArgs('n1', 1).returns([{ source: up, sourcePort: 0, target: n1 }])
+                mockRED.nodes.getNodeLinks.withArgs('n1', 0).returns([{ source: n1, sourcePort: 0, target: n2 }, { source: n1, sourcePort: 1, target: n3 }])
+                mockRED.nodes.getNodeLinks.withArgs('n2', 1).returns([{ source: n1, sourcePort: 0, target: n2 }])
+                mockRED.nodes.getNodeLinks.withArgs('n2', 0).returns([{ source: n2, sourcePort: 0, target: ext }])
+                mockRED.nodes.getNodeLinks.withArgs('n3', 1).returns([{ source: n1, sourcePort: 1, target: n3 }])
+                mockRED.nodes.getNodeLinks.withArgs('n3', 0).returns([{ source: n3, sourcePort: 0, target: ext }]);
+
+                (() => expertAutomations.createSubroutine({ ids: ['n1', 'n2', 'n3'] })).should.throw(/single exit node/)
+            })
+
+            it('rejects a link node in the selection', () => {
+                mockRED.nodes.node.withArgs('lc').returns({ id: 'lc', type: 'link call', z: 'tab1' });
+                (() => expertAutomations.createSubroutine({ ids: ['lc'] })).should.throw(/cannot be placed inside a subroutine/)
+            })
+
+            it('throws when ids is empty', () => {
+                (() => expertAutomations.createSubroutine({ ids: [] })).should.throw(/non-empty/)
             })
         })
         describe('addNodes action', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -848,6 +848,25 @@ describeMain('expertAutomations', () => {
                 sinon.stub(expertAutomations, 'setWires')
                 sinon.stub(expertAutomations, 'setLinks')
                 sinon.stub(expertAutomations, 'createGroup')
+                // Detaching a body node from its original group is exercised through updateGroup(remove);
+                // the real path invokes a core action, so the stub simulates the detach by clearing
+                // each node's `g` and splicing it out of the group's nodes array (as removeFromGroup
+                // does). Clearing `g` lets createSubroutine's detach loop converge; emptying the group
+                // lets the husk-cleanup step see it as empty.
+                sinon.stub(expertAutomations, 'updateGroup').callsFake((groupId, { nodeIds, remove } = {}) => {
+                    if (remove) {
+                        const g = mockRED.nodes.group(groupId)
+                        for (const nid of nodeIds || []) {
+                            const n = mockRED.nodes.node(nid)
+                            if (n) delete n.g
+                            if (g && Array.isArray(g.nodes)) {
+                                const i = g.nodes.indexOf(nid)
+                                if (i !== -1) g.nodes.splice(i, 1)
+                            }
+                        }
+                    }
+                })
+                sinon.stub(expertAutomations, 'deleteGroup')
                 mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().returns(false), show: sinon.stub() }
             })
 
@@ -1006,6 +1025,56 @@ describeMain('expertAutomations', () => {
                 // the body group is built from the expanded members, not the original group id
                 const [groupIds] = expertAutomations.createGroup.firstCall.args
                 groupIds.should.deepEqual([data.linkInId, 'n1', 'n2', data.linkOutId, data.catchId])
+                // wrapping the whole group empties the original, so it is removed (no husk left)
+                expertAutomations.deleteGroup.calledWith('grp').should.be.true()
+            })
+
+            it('leaves the original group in place when it still has other members', () => {
+                // Only n1/n2 are wrapped; sibling 's1' stays in 'grp', so the group is not emptied
+                // and must not be deleted.
+                const up = { id: 'up', type: 'inject', z: 'tab1' }
+                const n1 = { id: 'n1', type: 'function', z: 'tab1', x: 200, y: 100, g: 'grp' }
+                const n2 = { id: 'n2', type: 'function', z: 'tab1', x: 400, y: 100, g: 'grp', outputs: 1 }
+                const down = { id: 'down', type: 'debug', z: 'tab1' }
+                const grp = { id: 'grp', type: 'group', z: 'tab1', nodes: ['n1', 'n2', 's1'] }
+                mockRED.nodes.group = sinon.stub()
+                mockRED.nodes.group.withArgs('grp').returns(grp)
+                mockRED.nodes.node.withArgs('n1').returns(n1)
+                mockRED.nodes.node.withArgs('n2').returns(n2)
+                mockRED.nodes.getNodeLinks = sinon.stub()
+                mockRED.nodes.getNodeLinks.withArgs('n1', 1).returns([{ source: up, sourcePort: 0, target: n1 }])
+                mockRED.nodes.getNodeLinks.withArgs('n1', 0).returns([{ source: n1, sourcePort: 0, target: n2 }])
+                mockRED.nodes.getNodeLinks.withArgs('n2', 1).returns([{ source: n1, sourcePort: 0, target: n2 }])
+                mockRED.nodes.getNodeLinks.withArgs('n2', 0).returns([{ source: n2, sourcePort: 0, target: down }])
+
+                expertAutomations.createSubroutine({ ids: ['n1', 'n2'] })
+
+                expertAutomations.updateGroup.calledWithMatch('grp', { nodeIds: ['n1', 'n2'], remove: true }).should.be.true()
+                grp.nodes.should.deepEqual(['s1'])
+                expertAutomations.deleteGroup.called.should.be.false()
+            })
+
+            it('detaches body nodes from their existing group before re-grouping them', () => {
+                // A node that is already a group member still carries its `g`. Node-RED's
+                // group-selection refuses to group a mixed set (the freshly-created link
+                // nodes are ungrouped), so the body must be detached from its original group
+                // first or the build would fail and roll back. Here f1 lives in 'oldgrp'.
+                const inject = { id: 'inj', type: 'inject', z: 'tab1' }
+                const fn = { id: 'f1', type: 'function', z: 'tab1', x: 300, y: 100, outputs: 1, g: 'oldgrp' }
+                const dbg = { id: 'dbg', type: 'debug', z: 'tab1' }
+                mockRED.nodes.node.withArgs('f1').returns(fn)
+                mockRED.nodes.getNodeLinks = sinon.stub()
+                mockRED.nodes.getNodeLinks.withArgs('f1', 1).returns([{ source: inject, sourcePort: 0, target: fn }])
+                mockRED.nodes.getNodeLinks.withArgs('f1', 0).returns([{ source: fn, sourcePort: 0, target: dbg }])
+
+                const data = expertAutomations.createSubroutine({ ids: ['f1'], name: 'My Sub' })
+
+                // f1 is removed from 'oldgrp' before the body group is created...
+                expertAutomations.updateGroup.calledWithMatch('oldgrp', { nodeIds: ['f1'], remove: true }).should.be.true()
+                expertAutomations.updateGroup.calledBefore(expertAutomations.createGroup).should.be.true()
+                // ...so the body group is created cleanly from the now-ungrouped node.
+                const [groupIds] = expertAutomations.createGroup.firstCall.args
+                groupIds.should.deepEqual([data.linkInId, 'f1', data.linkOutId, data.catchId])
             })
 
             it('throws when the selection expands to no nodes (empty group)', () => {


### PR DESCRIPTION
## What

Adds a new `automation/create-subroutine` action that wraps one or more existing nodes into a callable **link-node subroutine**, replacing them inline with a single `link call`, and builds it as a self-contained, reusable unit:

```
caller:  <upstream> -> [link call] -> [switch on msg.error] --Success--> <downstream>
                                            \--Error--> [debug]
body:    [link in] -> <entry> ... <exit> -> [link out, mode: return]
         [catch (group scope)] -> [link out]
```

The link call targets the link in, so at runtime the message is routed into the body and returned to the caller by the return-mode link out. The body (link in, the selected nodes, link out and the catch) is wrapped in a named group, a group-scoped catch returns body errors through the same link out, and a switch on `msg.error` splits the returned message into a labelled **Error** branch and **Success** branch on the caller side. The caller (link call, switch, debug) stays on the original row where the selection was; the body group is placed just below it.

## Why

There is no Node-RED core action for the link-call (call/return) subroutine pattern: `core:split-wire-with-link-nodes` only produces a one-way bridge, and `core:create-subflow` produces a subflow. Unlike a subflow, which duplicates nodes for every instance, a link-call subroutine is a single shared body that any caller reuses. Building the pattern by hand takes several fragile steps (create link in/out/call, set the link out to return mode, rewire the caller, add the catch and switch, group the body, set the virtual link). This action turns it into a single, validated call.

## How

- The selection must form a **single-entry, single-exit subgraph**: a single node, or connected nodes with one way in and one way out (this includes a branch that reconverges, not only a straight chain). Multi-entry / multi-exit selections are rejected, since a `link call` has a single input and a single output. External wires that enter a non-entry node or leave a non-exit node are also rejected, so the body cannot be entered or left except through its single entry and exit.
- A **group ID is accepted and expanded** to its member nodes (recursively for nested groups), so a whole group can be wrapped in one call; the expanded nodes are then validated like any other selection. Nodes that are already group members (whether a group ID was passed, or node IDs whose nodes live in a group) are **detached from their group before being re-grouped** into the subroutine, since Node-RED's group-selection only groups nodes that share the same parent group. Any original group the detach empties is removed so no empty group is left behind, while a group that still holds other members is left intact.
- Any ordinary canvas node can be wrapped, including subflow instances and junctions. Config and link nodes are rejected (config nodes have no canvas position; link nodes are the subroutine's own plumbing).
- Internal wires between selected nodes are kept intact. External inbound is redirected to the link call; the link call's return feeds a switch on `msg.error`. The **Success** branch continues to whatever was downstream, and the **Error** branch is wired to a `debug` node by default so failures are visible (the caller can rewire it to a notification, a log, or further handling).
- A group-scoped `catch` is wired to the link out, so an error raised anywhere in the body returns through the same path and surfaces on the switch's Error branch.
- The body is wrapped in a named group (named after the subroutine) so it reads as one unit on the canvas, and is dropped below the caller row so the group does not overlap the call.
- A `timeout` option sets the link call timeout in seconds, defaulting to 5.
- The action only **creates** a subroutine on the current tab. Relocating the result to a dedicated "Subroutines" tab, renaming it or deleting it is left to the existing node and group actions (move via a node `z` update, rename/regroup via the group action, delete via remove) rather than being bolted onto this action.
- Rather than poking `RED` primitives directly, it orchestrates the module's own validated actions (`addNodes` / `setWires` / `setLinks` / `createGroup`), so node-type, port, same-tab, link-type and duplicate-wire validation all apply.

## Tests

Adds unit coverage for the single-node case (including the group, catch, error switch, the `Error`/`Success` labels and the default Error-branch debug wiring), the supplied-timeout option, linear chains (internal wire left intact), group expansion, the empty-group rejection, and the multi-exit / external-wire-into-a-middle-node / link-node / config-node / empty-input rejections. Full suite: 437 passing.

