### PR TITLE
feat: add move-to-tab for groups via manage-groups

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -428,12 +428,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
                             properties: {
                                 op: {
                                     type: 'string',
-                                    enum: ['create', 'update', 'manage-members', 'delete'],
+                                    enum: ['create', 'update', 'manage-members', 'move', 'delete'],
                                     description: 'Operation to perform'
                                 },
                                 id: {
                                     type: 'string',
-                                    description: 'Group ID (required for update, manage-members, and delete)'
+                                    description: 'Group ID (required for update, manage-members, move, and delete)'
+                                },
+                                z: {
+                                    type: 'string',
+                                    description: 'move only — destination tab ID. Moves the group and all its contents (member nodes and nested groups) to that tab, keeping it intact.'
                                 },
                                 nodeIds: {
                                     type: 'array',
@@ -1859,6 +1863,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     results.push({ op: 'manage-members', mode, ...this._summarizeGroup(group) })
                     break
                 }
+                case 'move': {
+                    if (!entry.id) throw new Error('id is required for move')
+                    if (!entry.z) throw new Error('z (target tab id) is required for move')
+                    const group = this.moveGroupToTab(entry.id, entry.z)
+                    results.push({ op: 'move', ...this._summarizeGroup(group) })
+                    break
+                }
                 case 'delete': {
                     if (!entry.id) throw new Error('id is required for delete')
                     this.deleteGroup(entry.id)
@@ -2157,6 +2168,65 @@ export class ExpertAutomations extends ExpertActionsInterface {
         this.RED.actions.invoke('core:ungroup-selection')
         this.RED.nodes.dirty(true)
         this.RED.view.redraw()
+    }
+
+    /**
+     * Move a group and everything it contains to another tab, preserving membership.
+     * Member nodes, junctions and nested groups (recursively) all move together, so the
+     * group stays intact; wires between co-moving members are kept, and any wire to a node
+     * left behind is bridged with link nodes (via _moveNodeToTab). A virtual link (e.g. a
+     * subroutine's link call -> link in) keeps working across tabs, which is what makes
+     * relocating a subroutine body to its own tab safe.
+     * @param {string} id - group ID to move
+     * @param {string} targetTabId - destination tab ID
+     * @returns {object} the moved group
+     */
+    moveGroupToTab (id, targetTabId) {
+        const group = this.RED.nodes.group(id)
+        if (!group) throw new Error(`Group ${id} not found`)
+        if (!targetTabId) throw new Error('targetTabId is required to move a group')
+        this._assertWorkspaceIsEditable(group.z)
+        this._assertWorkspaceIsEditable(targetTabId)
+        if (group.z === targetTabId) return group
+
+        // Collect the group and all its descendants: nested group containers (moved
+        // directly, they carry no wires) and member nodes (moved with wire handling).
+        // Every member co-moves, so wires between members survive without splitting.
+        const groupContainers = []
+        const memberNodes = []
+        const seen = new Set()
+        const descend = (g) => {
+            if (seen.has(g.id)) return
+            seen.add(g.id)
+            groupContainers.push(g)
+            for (const member of (g.nodes || [])) {
+                const memberId = typeof member === 'object' ? member.id : member
+                const childGroup = this.RED.nodes.group(memberId)
+                if (childGroup) {
+                    descend(childGroup)
+                    continue
+                }
+                const node = this.RED.nodes.node(memberId)
+                if (node) memberNodes.push(node)
+            }
+        }
+        descend(group)
+
+        const coMovingIds = new Set(memberNodes.map(n => n.id))
+        this.RED.workspaces.show(group.z)
+        for (const node of memberNodes) {
+            this._moveNodeToTab(node.id, targetTabId, coMovingIds)
+        }
+        // Move the group containers themselves; moveNodeToTab routes group nodes to the
+        // core moveGroupToTab, and each member node's g (membership) is left untouched.
+        for (const g of groupContainers) {
+            this.RED.nodes.moveNodeToTab(g, targetTabId)
+        }
+
+        this.RED.nodes.dirty(true)
+        this.RED.view.redraw(true)
+        this.RED.workspaces.show(targetTabId)
+        return group
     }
 
     /**

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -3114,6 +3114,88 @@ describeMain('expertAutomations', () => {
                 result.data[1].should.have.property('op', 'update')
                 existingGroup.name.should.equal('Renamed')
             })
+
+            function setupMoveMocks () {
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.view.redraw = sinon.stub()
+                mockRED.view.select = sinon.stub()
+                mockRED.history = { push: sinon.stub() }
+                mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().returns(false), show: sinon.stub() }
+                mockRED.nodes.moveNodeToTab = sinon.stub()
+                mockRED.nodes.getNodeLinks = sinon.stub().returns([])
+            }
+
+            it('should move a group and all its members to the target tab', async () => {
+                setupMoveMocks()
+                const linkIn = { id: 'li', type: 'link in', z: 'tab1', g: 'grp' }
+                const fn = { id: 'fn', type: 'function', z: 'tab1', g: 'grp' }
+                const linkOut = { id: 'lo', type: 'link out', z: 'tab1', g: 'grp' }
+                const grp = { id: 'grp', type: 'group', z: 'tab1', nodes: ['li', 'fn', 'lo'] }
+                mockRED.nodes.group = sinon.stub().callsFake(id => (id === 'grp' ? grp : null))
+                mockRED.nodes.node = sinon.stub().callsFake(id => ({ li: linkIn, fn, lo: linkOut }[id] || null))
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'move', id: 'grp', z: 'tab2' }] }
+                }, result)
+                result.should.have.property('success', true)
+                result.data[0].should.have.property('op', 'move')
+                // the three members and the group container all move to tab2
+                const moved = mockRED.nodes.moveNodeToTab.args.map(a => ({ id: a[0].id, z: a[1] }))
+                moved.map(m => m.id).should.containEql('li')
+                moved.map(m => m.id).should.containEql('fn')
+                moved.map(m => m.id).should.containEql('lo')
+                moved.map(m => m.id).should.containEql('grp')
+                moved.every(m => m.z === 'tab2').should.be.true()
+            })
+
+            it('should move nested groups recursively', async () => {
+                setupMoveMocks()
+                const fn = { id: 'fn', type: 'function', z: 'tab1', g: 'inner' }
+                const inner = { id: 'inner', type: 'group', z: 'tab1', g: 'outer', nodes: ['fn'] }
+                const outer = { id: 'outer', type: 'group', z: 'tab1', nodes: ['inner'] }
+                mockRED.nodes.group = sinon.stub().callsFake(id => ({ outer, inner }[id] || null))
+                mockRED.nodes.node = sinon.stub().callsFake(id => ({ fn }[id] || null))
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'move', id: 'outer', z: 'tab2' }] }
+                }, result)
+                result.should.have.property('success', true)
+                const movedIds = mockRED.nodes.moveNodeToTab.args.map(a => a[0].id)
+                movedIds.should.containEql('fn') // member node
+                movedIds.should.containEql('inner') // nested group container
+                movedIds.should.containEql('outer') // outer group container
+            })
+
+            it('is a no-op when the group is already on the target tab', async () => {
+                setupMoveMocks()
+                const grp = { id: 'grp', type: 'group', z: 'tab1', nodes: [] }
+                mockRED.nodes.group = sinon.stub().callsFake(id => (id === 'grp' ? grp : null))
+                const result = {}
+                await expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'move', id: 'grp', z: 'tab1' }] }
+                }, result)
+                result.should.have.property('success', true)
+                mockRED.nodes.moveNodeToTab.called.should.be.false()
+            })
+
+            it('should throw if group not found for move', async () => {
+                setupMoveMocks()
+                mockRED.nodes.group = sinon.stub().returns(null)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'move', id: 'nope', z: 'tab2' }] }
+                }, result)).rejectedWith(/Group nope not found/)
+            })
+
+            it('should throw if z is missing for move', async () => {
+                setupMoveMocks()
+                const grp = { id: 'grp', type: 'group', z: 'tab1', nodes: [] }
+                mockRED.nodes.group = sinon.stub().callsFake(id => (id === 'grp' ? grp : null))
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/manage-groups', {
+                    params: { operations: [{ op: 'move', id: 'grp' }] }
+                }, result)).rejectedWith(/z \(target tab id\) is required/)
+            })
         })
         describe('arrangeNodes action', () => {
             beforeEach(() => {


### PR DESCRIPTION
## What

Adds a **move** operation to the `manage-groups` action that relocates a group, and everything it contains, to another tab.

## How

- Adds `moveGroupToTab`, which moves a group along with all of its contents (member nodes and nested groups, recursively) to a target tab, preserving group membership.
- Wires between members that move together are kept intact.
- Wires that cross the boundary (to nodes left behind on the original tab) are bridged with link nodes, so the flow keeps working across tabs.
- A virtual link (for example a link call to its link in) continues to resolve across tabs after the move.
- Exposed as a new `move` op on the `manage-groups` action, taking the group `id` and the target tab `z`.

## Tests

Adds unit coverage for the move operation. Full suite: 280 passing.

## Note

This work was previously merged into the `feat/create-subroutine` branch by mistake (PR #372 had the wrong base). It has been rebased onto `main` and re-opened here so it can land independently.