### PR TITLE
feat: add update-tab and remove-subflow automation actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowfuse/nr-assistant",
-    "version": "0.18.0",
+    "version": "0.17.0",
     "description": "FlowFuse Node-RED Expert plugin",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowfuse/nr-assistant",
-    "version": "0.17.0",
+    "version": "0.18.0",
     "description": "FlowFuse Node-RED Expert plugin",
     "main": "index.js",
     "scripts": {

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -17,6 +17,7 @@ const ADD_TAB = 'automation/add-tab'
 const REMOVE_TAB = 'automation/remove-tab'
 const ADD_NODES = 'automation/add-nodes'
 const REMOVE_NODES = 'automation/remove-nodes'
+const REMOVE_SUBFLOW = 'automation/remove-subflow'
 const SET_WIRES = 'automation/set-wires'
 const SET_LINKS = 'automation/set-links'
 const CREATE_SUBROUTINE = 'automation/create-subroutine'
@@ -60,6 +61,7 @@ const LINK_NODE_TYPES = ['link in', 'link out', 'link call']
  *   |REMOVE_TAB
  *   |ADD_NODES
  *   |REMOVE_NODES
+ *   |REMOVE_SUBFLOW
  *   |SET_WIRES
  *   |SET_LINKS
  *   |CREATE_SUBROUTINE
@@ -312,6 +314,15 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 },
                 required: ['ids']
+            }
+        },
+        [REMOVE_SUBFLOW]: {
+            params: {
+                type: 'object',
+                properties: {
+                    id: { type: 'string', description: 'ID of the subflow definition to remove. This removes the definition, its internal nodes, and every placed instance.' }
+                },
+                required: ['id']
             }
         },
         [SET_WIRES]: {
@@ -862,6 +873,21 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const node = this.RED.nodes.node(id)
         if (!node) throw new Error(`Node ${id} not found`)
 
+        // Skipped when defaults are unknown (e.g. some subflow instances): the valid property set can't be determined.
+        const declaredDefaults = node._def?.defaults
+        if (declaredDefaults) {
+            const allowedKeys = new Set([
+                'id', 'type', 'z', 'x', 'y', 'wires', 'g', 'name', 'info', 'd', 'l', 'icon', 'inputLabels', 'outputLabels', 'credentials',
+                ...Object.keys(declaredDefaults)
+            ])
+            const updatedKeys = [...Object.keys(properties), ...patches.map(patch => patch.property)]
+            const unknownKeys = [...new Set(updatedKeys.filter(key => !allowedKeys.has(key)))]
+            if (unknownKeys.length > 0) {
+                const noun = unknownKeys.length > 1 ? 'properties' : 'property'
+                throw new Error(`Unknown ${noun} [${unknownKeys.join(', ')}] for node type "${node.type}" — not a valid property for this node. Use describe_node_type to confirm the exact property name.`)
+            }
+        }
+
         this._assertWorkspaceIsEditable(node.z)
 
         const changes = {}
@@ -1320,24 +1346,63 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {string[]} ids - node IDs to remove
      * @param {object} [options]
      * @param {boolean} [options.reconnectWires=false] - reconnect wires around removed nodes
+     * @returns {{removed: string[], notFound: string[]}} IDs that were removed and IDs that did not resolve to a node
      */
     removeNodes (ids, { reconnectWires = false } = {}) {
-        // Resolve all nodes once and check for missing
-        const nodes = ids.map(id => {
+        // Partition into found nodes and missing IDs so a partial batch still removes what it can.
+        const nodes = []
+        const notFound = []
+        for (const id of ids) {
             const node = this.RED.nodes.node(id)
-            if (!node) throw new Error(`Node ${id} not found`)
-            return node
-        })
-        // Check if any node's workspace is locked
-        for (const node of nodes) {
-            this._assertWorkspaceIsEditable(node.z)
+            if (node) {
+                nodes.push(node)
+            } else {
+                notFound.push(id)
+            }
         }
-        this.RED.view.select({ nodes })
-        this._verifySelection(nodes)
-        if (reconnectWires) {
-            this.RED.actions.invoke('core:delete-selection-and-reconnect')
-        } else {
-            this.RED.actions.invoke('core:delete-selection')
+        const removed = nodes.map(node => node.id)
+        if (nodes.length > 0) {
+            for (const node of nodes) {
+                this._assertWorkspaceIsEditable(node.z)
+            }
+            this.RED.view.select({ nodes })
+            this._verifySelection(nodes)
+            if (reconnectWires) {
+                this.RED.actions.invoke('core:delete-selection-and-reconnect')
+            } else {
+                this.RED.actions.invoke('core:delete-selection')
+            }
+        }
+        return { removed, notFound }
+    }
+
+    /**
+     * Remove a subflow definition from the live NR4 canvas by ID.
+     * Delegates to RED.subflow.removeSubflow, which removes the definition together with
+     * its internal nodes, its placed instances, and its groups, junctions and tab. The
+     * returned removal is recorded on the editor history so it can be undone.
+     * @param {string} id - subflow ID to remove
+     * @returns {{removed: string, instances: string[]}} the removed subflow ID and the IDs of its removed instances
+     */
+    removeSubflow (id) {
+        const subflow = this.RED.nodes.subflow(id)
+        if (!subflow) throw new Error(`Subflow ${id} not found`)
+        this._assertWritePermission()
+        // A subflow cannot be removed while one of its instances sits on a locked flow.
+        const instances = subflow.instances || []
+        for (const instance of instances) {
+            if (instance.z && this.RED.workspaces.isLocked(instance.z)) {
+                throw new Error(`Subflow ${id} cannot be deleted while an instance is on locked workspace ${instance.z}`)
+            }
+        }
+        const wasDirty = this.RED.nodes.dirty()
+        const historyEvent = this.RED.subflow.removeSubflow(id)
+        historyEvent.t = 'delete'
+        historyEvent.dirty = wasDirty
+        this.RED.history.push(historyEvent)
+        return {
+            removed: id,
+            instances: instances.map(instance => instance.id)
         }
     }
 
@@ -2078,8 +2143,15 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 result.success = false
                 break
             }
-            this.removeNodes(params.ids, { reconnectWires: params.reconnectWires ?? false })
-            result.data = { removed: params.ids }
+            const removal = this.removeNodes(params.ids, { reconnectWires: params.reconnectWires ?? false })
+            result.data = { removed: removal.removed, notFound: removal.notFound }
+            result.success = true
+        }
+            break
+
+        case REMOVE_SUBFLOW: {
+            const removal = this.removeSubflow(params.id)
+            result.data = { removed: removal.removed, instances: removal.instances }
             result.success = true
         }
             break

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -14,6 +14,7 @@ const CLOSE_SEARCH = 'automation/close-search'
 const CLOSE_TYPE_SEARCH = 'automation/close-type-search'
 const CLOSE_ACTION_LIST = 'automation/close-action-list'
 const ADD_TAB = 'automation/add-tab'
+const UPDATE_TAB = 'automation/update-tab'
 const REMOVE_TAB = 'automation/remove-tab'
 const ADD_NODES = 'automation/add-nodes'
 const REMOVE_NODES = 'automation/remove-nodes'
@@ -58,6 +59,7 @@ const LINK_NODE_TYPES = ['link in', 'link out', 'link call']
  *   |CLOSE_TYPE_SEARCH
  *   |CLOSE_ACTION_LIST
  *   |ADD_TAB
+ *   |UPDATE_TAB
  *   |REMOVE_TAB
  *   |ADD_NODES
  *   |REMOVE_NODES
@@ -263,6 +265,41 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     }
                 },
                 required: ['label']
+            }
+        },
+        [UPDATE_TAB]: {
+            params: {
+                type: 'object',
+                properties: {
+                    id: { type: 'string', description: 'ID of the tab to update' },
+                    properties: {
+                        type: 'object',
+                        description: 'Tab properties to update',
+                        properties: {
+                            label: { type: 'string', description: 'New label' },
+                            disabled: { type: 'boolean', description: 'Enable/disable tab' },
+                            info: { type: 'string', description: 'Tab notes' },
+                            env: {
+                                type: 'array',
+                                items: {
+                                    type: 'object',
+                                    properties: {
+                                        name: { type: 'string', description: 'Environment variable name' },
+                                        value: { type: 'string', description: 'Environment variable value' },
+                                        type: {
+                                            type: 'string',
+                                            enum: ['str', 'num', 'bool', 'json', 'env', 'cred', 'jsonata'],
+                                            description: 'Environment variable type'
+                                        }
+                                    },
+                                    required: ['name', 'value', 'type']
+                                },
+                                description: 'Environment variables'
+                            }
+                        }
+                    }
+                },
+                required: ['id', 'properties']
             }
         },
         [REMOVE_TAB]: {
@@ -1270,6 +1307,37 @@ export class ExpertAutomations extends ExpertActionsInterface {
     }
 
     /**
+     * Update label, disabled state, info, or env of an existing flow tab.
+     * Mirrors the editor's own flow-properties save behaviour (redraw only needed
+     * when disabling/enabling, since that is the only change affecting node rendering).
+     * @param {string} id - tab ID to update
+     * @param {Object} properties - subset of {label, disabled, info, env}
+     */
+    updateTab (id, properties = {}) {
+        const ws = this.RED.nodes.workspace(id)
+        if (!ws) throw new Error(`Workspace ${id} not found`)
+        this._assertWorkspaceIsEditable(id)
+        const changes = {}
+        for (const key of Object.keys(properties)) {
+            changes[key] = ws[key]
+            ws[key] = properties[key]
+        }
+        ws.changed = true
+        this.RED.history.push({ t: 'edit', changes, node: ws, dirty: this.RED.nodes.dirty() })
+        this.RED.nodes.dirty(true)
+        if (Object.prototype.hasOwnProperty.call(changes, 'disabled')) {
+            this.RED.nodes.eachNode(n => {
+                if (n.z === ws.id) n.dirty = true
+            })
+            this.RED.view.redraw()
+        }
+        this.RED.workspaces.refresh()
+        this.RED.sidebar.config.refresh()
+        this.RED.events.emit('flows:change', ws)
+        return ws
+    }
+
+    /**
      * Remove an existing flow tab from the NR4 editor.
      * @param {string} z - tab ID to remove
      */
@@ -1278,6 +1346,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (!ws) throw new Error(`Workspace ${z} not found`)
         this._assertWorkspaceIsEditable(z)
         this.RED.workspaces.delete(ws)
+        this.RED.view.redraw()
     }
 
     /**
@@ -1388,8 +1457,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const subflow = this.RED.nodes.subflow(id)
         if (!subflow) throw new Error(`Subflow ${id} not found`)
         this._assertWritePermission()
-        // A subflow cannot be removed while one of its instances sits on a locked flow.
-        const instances = subflow.instances || []
+        // Scan the live canvas rather than trusting subflow.instances, which is not
+        // guaranteed to be kept in sync with every instance placed across all workspaces.
+        const instances = this.RED.nodes.filterNodes({ type: `subflow:${id}` })
         for (const instance of instances) {
             if (instance.z && this.RED.workspaces.isLocked(instance.z)) {
                 throw new Error(`Subflow ${id} cannot be deleted while an instance is on locked workspace ${instance.z}`)
@@ -2075,6 +2145,13 @@ export class ExpertAutomations extends ExpertActionsInterface {
         case ADD_TAB: {
             const newTab = this.addTab(params)
             result.data = this._summarizeNode(newTab)
+            result.success = true
+        }
+            break
+
+        case UPDATE_TAB: {
+            const ws = this.updateTab(params.id, params.properties)
+            result.data = this._summarizeWorkspace(ws)
             result.success = true
         }
             break

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -778,7 +778,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
      *   wires between co-moving nodes are kept intact (no splitting).
      */
     _moveNodeToTab (id, targetTabId, coMovingIds = new Set()) {
-        const node = this.RED.nodes.node(id)
+        const node = this._resolveNode(id)
         if (!node) throw new Error(`Node ${id} not found`)
 
         this._assertWorkspaceIsEditable(targetTabId)
@@ -907,7 +907,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         if (!hasProperties && !hasPatches) {
             throw new Error('At least one of "properties" or "patches" must be provided')
         }
-        const node = this.RED.nodes.node(id)
+        const node = this._resolveNode(id)
         if (!node) throw new Error(`Node ${id} not found`)
 
         // Skipped when defaults are unknown (e.g. some subflow instances): the valid property set can't be determined.
@@ -1254,11 +1254,20 @@ export class ExpertAutomations extends ExpertActionsInterface {
     }
 
     isConfigNode (id) {
-        const node = this.RED.nodes.node(id)
+        const node = this._resolveNode(id)
         if (!node) { throw new Error(`Node ${id} not found`) }
         const def = node._def || this.RED.nodes.getType(node.type)
         if (!def) { return false }
         return def.category === 'config'
+    }
+
+    /**
+     * Look up a node by ID. Junctions live in their own registry (RED.nodes.junction),
+     * separate from the main node map, so a plain RED.nodes.node(id) lookup misses them.
+     * @param {string} id - node or junction ID
+     */
+    _resolveNode (id) {
+        return this.RED.nodes.node(id) || this.RED.nodes.junction(id)
     }
 
     closeSearch () { this.RED.search.hide() }
@@ -1363,9 +1372,12 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const prepared = nodes.map(rawNode => {
             if (!rawNode.id) throw new Error('Node is missing required property: id')
             if (!rawNode.type) throw new Error('Node is missing required property: type')
-            const def = this.RED.nodes.getType(rawNode.type)
-            if (!def) throw new Error(`Unknown node type: ${rawNode.type}`)
-            const isConfigNode = def.category === 'config'
+            // Junctions have no palette definition (RED.nodes.getType returns nothing for
+            // them), so they're recognised by type name rather than a registry lookup.
+            const isJunction = rawNode.type === 'junction'
+            const def = isJunction ? null : this.RED.nodes.getType(rawNode.type)
+            if (!isJunction && !def) throw new Error(`Unknown node type: ${rawNode.type}`)
+            const isConfigNode = !isJunction && def.category === 'config'
             if (!isConfigNode && !rawNode.z) throw new Error('Node is missing required property: z')
             return { ...rawNode }
         })
@@ -1381,7 +1393,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
         // Pre-import: reject if any node ID already exists on the canvas
         if (!generateIds) {
-            const existing = prepared.filter(n => this.RED.nodes.node(n.id))
+            const existing = prepared.filter(n => this._resolveNode(n.id))
             if (existing.length > 0) {
                 throw new Error(`Node ID(s) already exist: ${existing.map(n => n.id).join(', ')} — use generateIds: true to auto-assign new IDs`)
             }
@@ -1422,7 +1434,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         const nodes = []
         const notFound = []
         for (const id of ids) {
-            const node = this.RED.nodes.node(id)
+            const node = this._resolveNode(id)
             if (node) {
                 nodes.push(node)
             } else {
@@ -1490,9 +1502,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
      */
     setWires ({ mode, source, output, target }) {
         if (source === target) throw new Error('Cannot wire a node to itself')
-        const sourceNode = this.RED.nodes.node(source)
+        const sourceNode = this._resolveNode(source)
         if (!sourceNode) throw new Error(`Source node ${source} not found`)
-        const targetNode = this.RED.nodes.node(target)
+        const targetNode = this._resolveNode(target)
         if (!targetNode) throw new Error(`Target node ${target} not found`)
         // wires can only be set on workspace nodes (not config nodes)
         if (this.isConfigNode(source)) {
@@ -2199,7 +2211,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 break
             }
             this.addNodes(params.nodes, { generateIds: params.generateIds ?? false })
-            const addedNodes = params.nodes.map(n => this.RED.nodes.node(n.id)).filter(Boolean)
+            const addedNodes = params.nodes.map(n => this._resolveNode(n.id)).filter(Boolean)
             if (this.RED.editor?.validateNode) {
                 addedNodes.forEach(n => this.RED.editor.validateNode(n))
             }

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -1470,6 +1470,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
         historyEvent.t = 'delete'
         historyEvent.dirty = wasDirty
         this.RED.history.push(historyEvent)
+        // Force a synchronous repaint from a freshly refreshed node cache: redraw()'s
+        // default deferred paint can be starved while the tab is unfocused, and without
+        // updateActive it repaints the stale pre-deletion node list either way.
+        this.RED.view.redraw(true, true)
         return {
             removed: id,
             instances: instances.map(instance => instance.id)

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -39,7 +39,15 @@ describeMain('expertAutomations', () => {
                 createExportableNodeSet: sinon.stub().callsFake((nodes) => nodes || []),
                 dirty: sinon.stub(),
                 workspace: sinon.stub().returns({ id: 'default-tab', type: 'tab' }),
-                updateConfigNodeUsers: sinon.stub()
+                updateConfigNodeUsers: sinon.stub(),
+                filterNodes: sinon.stub().returns([]),
+                eachNode: sinon.stub()
+            },
+            sidebar: {
+                config: { refresh: sinon.stub() }
+            },
+            events: {
+                emit: sinon.stub()
             },
             settings: {
                 version: '4.1.4'
@@ -95,6 +103,7 @@ describeMain('expertAutomations', () => {
                 'automation/close-type-search',
                 'automation/close-action-list',
                 'automation/add-tab',
+                'automation/update-tab',
                 'automation/remove-tab',
                 'automation/add-nodes',
                 'automation/remove-nodes',
@@ -466,12 +475,14 @@ describeMain('expertAutomations', () => {
             beforeEach(() => {
                 mockRED.nodes.dirty = sinon.stub().returns(false)
                 mockRED.nodes.subflow = sinon.stub()
+                mockRED.nodes.filterNodes = sinon.stub().returns([])
                 mockRED.subflow = { removeSubflow: sinon.stub().returns({ subflows: [] }) }
                 mockRED.history = { push: sinon.stub() }
                 mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().returns(false) }
             })
             it('should remove a subflow and push an undoable delete history event', async () => {
-                mockRED.nodes.subflow.withArgs('sf1').returns({ id: 'sf1', instances: [{ id: 'i1', z: 'tab1' }] })
+                mockRED.nodes.subflow.withArgs('sf1').returns({ id: 'sf1' })
+                mockRED.nodes.filterNodes.withArgs({ type: 'subflow:sf1' }).returns([{ id: 'i1', z: 'tab1' }])
                 const removalResult = { subflows: [{ id: 'sf1' }] }
                 mockRED.subflow.removeSubflow.withArgs('sf1').returns(removalResult)
                 const result = {}
@@ -487,6 +498,16 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('handled', true)
                 result.should.have.property('data').which.deepEqual({ removed: 'sf1', instances: ['i1'] })
             })
+            it('should scan all workspaces for instances rather than trust a stale subflow.instances', async () => {
+                // subflow.instances deliberately omitted/stale — the scan must not depend on it.
+                mockRED.nodes.subflow.withArgs('sf1').returns({ id: 'sf1', instances: [] })
+                mockRED.nodes.filterNodes.withArgs({ type: 'subflow:sf1' }).returns([{ id: 'i1', z: 'tab1' }, { id: 'i2', z: 'tab2' }])
+                const result = {}
+                await expertAutomations.invokeAction('automation/remove-subflow', {
+                    params: { id: 'sf1' }
+                }, result)
+                result.should.have.property('data').which.deepEqual({ removed: 'sf1', instances: ['i1', 'i2'] })
+            })
             it('should throw if the subflow does not exist', async () => {
                 mockRED.nodes.subflow.returns(null)
                 const result = {}
@@ -497,7 +518,8 @@ describeMain('expertAutomations', () => {
                 mockRED.history.push.called.should.be.false()
             })
             it('should throw if an instance sits on a locked workspace', async () => {
-                mockRED.nodes.subflow.withArgs('sf1').returns({ id: 'sf1', instances: [{ id: 'i1', z: 'locked-tab' }] })
+                mockRED.nodes.subflow.withArgs('sf1').returns({ id: 'sf1' })
+                mockRED.nodes.filterNodes.withArgs({ type: 'subflow:sf1' }).returns([{ id: 'i1', z: 'locked-tab' }])
                 mockRED.workspaces.isLocked = sinon.stub().withArgs('locked-tab').returns(true)
                 const result = {}
                 await should(expertAutomations.invokeAction('automation/remove-subflow', {
@@ -1523,6 +1545,7 @@ describeMain('expertAutomations', () => {
                     params: { id: 'tab1' }
                 }, result)
                 mockRED.workspaces.delete.calledWith(mockWs).should.be.true()
+                mockRED.view.redraw.calledOnce.should.be.true()
                 result.should.have.property('success', true)
                 result.should.have.property('data')
                 result.data.should.have.property('removed', 'tab1')
@@ -1549,6 +1572,64 @@ describeMain('expertAutomations', () => {
                     params: { id: 'locked-tab' }
                 }, {})).rejectedWith(/Workspace locked-tab is locked/)
                 mockRED.workspaces.delete.called.should.be.false()
+            })
+        })
+        describe('updateTab action', () => {
+            let mockWs
+            beforeEach(() => {
+                mockWs = { id: 'tab1', type: 'tab', label: 'Old Label', locked: false, disabled: false }
+                mockRED.nodes.workspace = sinon.stub().withArgs('tab1').returns(mockWs)
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.history = { push: sinon.stub() }
+                mockRED.workspaces = { ...mockRED.workspaces, refresh: sinon.stub() }
+                mockRED.sidebar = { config: { refresh: sinon.stub() } }
+                mockRED.events = { emit: sinon.stub() }
+            })
+            it('should rename a tab without redrawing the canvas', async () => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/update-tab', {
+                    params: { id: 'tab1', properties: { label: 'New Label' } }
+                }, result)
+                mockWs.label.should.equal('New Label')
+                mockRED.history.push.calledOnce.should.be.true()
+                const historyArg = mockRED.history.push.firstCall.args[0]
+                historyArg.should.have.property('t', 'edit')
+                historyArg.changes.should.have.property('label', 'Old Label')
+                mockRED.nodes.dirty.calledWith(true).should.be.true()
+                mockRED.workspaces.refresh.calledOnce.should.be.true()
+                mockRED.sidebar.config.refresh.calledOnce.should.be.true()
+                mockRED.events.emit.calledWith('flows:change', mockWs).should.be.true()
+                mockRED.view.redraw.called.should.be.false()
+                result.should.have.property('success', true)
+                result.data.should.have.property('label', 'New Label')
+            })
+            it('should redraw and mark member nodes dirty when disabling a tab', async () => {
+                const memberNode = { id: 'n1', z: 'tab1', dirty: false }
+                const otherNode = { id: 'n2', z: 'tab2', dirty: false }
+                mockRED.nodes.eachNode = sinon.stub().callsFake(fn => { fn(memberNode); fn(otherNode) })
+                const result = {}
+                await expertAutomations.invokeAction('automation/update-tab', {
+                    params: { id: 'tab1', properties: { disabled: true } }
+                }, result)
+                mockWs.disabled.should.be.true()
+                memberNode.dirty.should.be.true()
+                otherNode.dirty.should.be.false()
+                mockRED.view.redraw.calledOnce.should.be.true()
+                result.should.have.property('success', true)
+            })
+            it('should throw if tab not found', async () => {
+                mockRED.nodes.workspace = sinon.stub().returns(null)
+                await should(expertAutomations.invokeAction('automation/update-tab', {
+                    params: { id: 'does-not-exist', properties: { label: 'New Label' } }
+                }, {})).rejectedWith(/Workspace does-not-exist not found/)
+            })
+            it('should throw if tab is locked', async () => {
+                mockRED.nodes.workspace = sinon.stub().withArgs('locked-tab').returns({ id: 'locked-tab', type: 'tab', locked: true })
+                mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().withArgs('locked-tab').returns(true) }
+                await should(expertAutomations.invokeAction('automation/update-tab', {
+                    params: { id: 'locked-tab', properties: { label: 'New Label' } }
+                }, {})).rejectedWith(/Workspace locked-tab is locked/)
+                mockRED.history.push.called.should.be.false()
             })
         })
         describe('addTab action', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -98,6 +98,7 @@ describeMain('expertAutomations', () => {
                 'automation/remove-tab',
                 'automation/add-nodes',
                 'automation/remove-nodes',
+                'automation/remove-subflow',
                 'automation/set-wires',
                 'automation/set-links',
                 'automation/create-subroutine',
@@ -393,7 +394,7 @@ describeMain('expertAutomations', () => {
                 mockRED.actions.invoke.calledWith('core:delete-selection').should.be.true()
                 result.should.have.property('success', true)
                 result.should.have.property('handled', true)
-                result.should.have.property('data').which.deepEqual({ removed: ['n1'] })
+                result.should.have.property('data').which.deepEqual({ removed: ['n1'], notFound: [] })
             })
             it('should use core:delete-selection-and-reconnect when reconnectWires is true', async () => {
                 const mockNode = { id: 'n1' }
@@ -405,22 +406,28 @@ describeMain('expertAutomations', () => {
                 mockRED.actions.invoke.calledWith('core:delete-selection-and-reconnect').should.be.true()
                 result.should.have.property('success', true)
             })
-            it('should throw if any node ID does not exist', async () => {
+            it('should report all IDs as notFound and remove nothing when none exist', async () => {
                 mockRED.nodes.node.returns(null)
                 const result = {}
-                await should(expertAutomations.invokeAction('automation/remove-nodes', {
+                await expertAutomations.invokeAction('automation/remove-nodes', {
                     params: { ids: ['nonexistent'] }
-                }, result)).rejectedWith(/Node nonexistent not found/)
+                }, result)
+                result.should.have.property('success', true)
+                result.should.have.property('data').which.deepEqual({ removed: [], notFound: ['nonexistent'] })
                 mockRED.actions.invoke.called.should.be.false()
             })
-            it('should throw without removing anything if mix of valid and invalid IDs', async () => {
-                mockRED.nodes.node.withArgs('n1').returns({ id: 'n1' })
+            it('should remove existing IDs and report missing ones when given a mix', async () => {
+                const mockNode = { id: 'n1' }
+                mockRED.nodes.node.withArgs('n1').returns(mockNode)
                 mockRED.nodes.node.withArgs('bad').returns(null)
                 const result = {}
-                await should(expertAutomations.invokeAction('automation/remove-nodes', {
+                await expertAutomations.invokeAction('automation/remove-nodes', {
                     params: { ids: ['n1', 'bad'] }
-                }, result)).rejectedWith(/Node bad not found/)
-                mockRED.actions.invoke.called.should.be.false()
+                }, result)
+                mockRED.view.select.calledWith({ nodes: [mockNode] }).should.be.true()
+                mockRED.actions.invoke.calledWith('core:delete-selection').should.be.true()
+                result.should.have.property('success', true)
+                result.should.have.property('data').which.deepEqual({ removed: ['n1'], notFound: ['bad'] })
             })
             it('should throw if node workspace is locked', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'locked-tab' })
@@ -453,6 +460,51 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('errorCode', 'FORBIDDEN_PROPERTY')
                 result.should.have.property('error').which.match(/member of a group/)
                 mockRED.actions.invoke.called.should.be.false()
+            })
+        })
+        describe('removeSubflow action', () => {
+            beforeEach(() => {
+                mockRED.nodes.dirty = sinon.stub().returns(false)
+                mockRED.nodes.subflow = sinon.stub()
+                mockRED.subflow = { removeSubflow: sinon.stub().returns({ subflows: [] }) }
+                mockRED.history = { push: sinon.stub() }
+                mockRED.workspaces = { ...mockRED.workspaces, isLocked: sinon.stub().returns(false) }
+            })
+            it('should remove a subflow and push an undoable delete history event', async () => {
+                mockRED.nodes.subflow.withArgs('sf1').returns({ id: 'sf1', instances: [{ id: 'i1', z: 'tab1' }] })
+                const removalResult = { subflows: [{ id: 'sf1' }] }
+                mockRED.subflow.removeSubflow.withArgs('sf1').returns(removalResult)
+                const result = {}
+                await expertAutomations.invokeAction('automation/remove-subflow', {
+                    params: { id: 'sf1' }
+                }, result)
+                mockRED.subflow.removeSubflow.calledWith('sf1').should.be.true()
+                mockRED.history.push.calledOnce.should.be.true()
+                const historyArg = mockRED.history.push.firstCall.args[0]
+                historyArg.should.have.property('t', 'delete')
+                historyArg.should.have.property('dirty', false)
+                result.should.have.property('success', true)
+                result.should.have.property('handled', true)
+                result.should.have.property('data').which.deepEqual({ removed: 'sf1', instances: ['i1'] })
+            })
+            it('should throw if the subflow does not exist', async () => {
+                mockRED.nodes.subflow.returns(null)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/remove-subflow', {
+                    params: { id: 'missing' }
+                }, result)).rejectedWith(/Subflow missing not found/)
+                mockRED.subflow.removeSubflow.called.should.be.false()
+                mockRED.history.push.called.should.be.false()
+            })
+            it('should throw if an instance sits on a locked workspace', async () => {
+                mockRED.nodes.subflow.withArgs('sf1').returns({ id: 'sf1', instances: [{ id: 'i1', z: 'locked-tab' }] })
+                mockRED.workspaces.isLocked = sinon.stub().withArgs('locked-tab').returns(true)
+                const result = {}
+                await should(expertAutomations.invokeAction('automation/remove-subflow', {
+                    params: { id: 'sf1' }
+                }, result)).rejectedWith(/cannot be deleted while an instance is on locked workspace locked-tab/)
+                mockRED.subflow.removeSubflow.called.should.be.false()
+                mockRED.history.push.called.should.be.false()
             })
         })
         describe('setWires action', () => {
@@ -1769,6 +1821,74 @@ describeMain('expertAutomations', () => {
                 await should(expertAutomations.invokeAction('automation/update-nodes', {
                     params: { nodes: [{ id: 'missing', updates: [{ property: 'name', op: 'replace', content: 'x' }] }] }
                 }, result)).rejectedWith(/Node missing not found/)
+            })
+            describe('property name validation', () => {
+                it('should reject an unknown property and not mutate the node', async () => {
+                    const mockNode = { id: 'n1', readOnlyHint: false, changed: false, _def: { defaults: { readOnlyHint: {} } } }
+                    mockRED.nodes.node.withArgs('n1').returns(mockNode)
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.history = { push: sinon.stub() }
+                    const result = {}
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', updates: [{ property: 'readonly', op: 'replace', content: true }] }] }
+                    }, result)).rejectedWith(/Unknown property \[readonly\] for node type "[^"]*" — not a valid property/)
+                    mockNode.should.not.have.property('readonly')
+                    mockRED.history.push.called.should.be.false()
+                })
+                it('should reject an unknown patch property and not mutate the node', async () => {
+                    const mockNode = { id: 'n1', func: 'a\nb', changed: false, _def: { defaults: { func: {} } } }
+                    mockRED.nodes.node.withArgs('n1').returns(mockNode)
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.history = { push: sinon.stub() }
+                    const result = {}
+                    await should(expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', updates: [{ property: 'fnc', op: 'replace', start: 1, end: 1, content: 'X' }] }] }
+                    }, result)).rejectedWith(/Unknown property \[fnc\]/)
+                    mockNode.func.should.equal('a\nb')
+                    mockRED.history.push.called.should.be.false()
+                })
+                it('should accept a valid declared property', async () => {
+                    const mockNode = { id: 'n1', readOnlyHint: false, changed: false, _def: { defaults: { readOnlyHint: {} } } }
+                    mockRED.nodes.node.withArgs('n1').returns(mockNode)
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.history = { push: sinon.stub() }
+                    mockRED.editor = { validateNode: sinon.stub() }
+                    mockRED.view.redraw = sinon.stub()
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', updates: [{ property: 'readOnlyHint', op: 'replace', content: true }] }] }
+                    }, result)
+                    mockNode.readOnlyHint.should.equal(true)
+                    result.should.have.property('success', true)
+                })
+                it('should accept a structural meta property not declared in defaults', async () => {
+                    const mockNode = { id: 'n1', info: 'old', changed: false, _def: { defaults: { readOnlyHint: {} } } }
+                    mockRED.nodes.node.withArgs('n1').returns(mockNode)
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.history = { push: sinon.stub() }
+                    mockRED.editor = { validateNode: sinon.stub() }
+                    mockRED.view.redraw = sinon.stub()
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', updates: [{ property: 'info', op: 'replace', content: 'new' }] }] }
+                    }, result)
+                    mockNode.info.should.equal('new')
+                    result.should.have.property('success', true)
+                })
+                it('should pass through unvalidated when the node type has no declared defaults', async () => {
+                    const mockNode = { id: 'n1', anything: 'old', changed: false, _def: {} }
+                    mockRED.nodes.node.withArgs('n1').returns(mockNode)
+                    mockRED.nodes.dirty = sinon.stub()
+                    mockRED.history = { push: sinon.stub() }
+                    mockRED.editor = { validateNode: sinon.stub() }
+                    mockRED.view.redraw = sinon.stub()
+                    const result = {}
+                    await expertAutomations.invokeAction('automation/update-nodes', {
+                        params: { nodes: [{ id: 'n1', updates: [{ property: 'anything', op: 'replace', content: 'new' }] }] }
+                    }, result)
+                    mockNode.anything.should.equal('new')
+                    result.should.have.property('success', true)
+                })
             })
             describe('patches', () => {
                 function setupPatchNode (overrides = {}) {
@@ -3778,6 +3898,14 @@ describeMain('expertAutomations', () => {
                     params: { ids: ['n1'] }
                 }, {})).rejectedWith(/Permission denied.*write permission/)
                 mockRED.actions.invoke.called.should.be.false()
+            })
+            it('should reject remove-subflow', async () => {
+                mockRED.nodes.subflow = sinon.stub().withArgs('sf1').returns({ id: 'sf1', instances: [] })
+                mockRED.subflow = { removeSubflow: sinon.stub() }
+                await should(expertAutomations.invokeAction('automation/remove-subflow', {
+                    params: { id: 'sf1' }
+                }, {})).rejectedWith(/Permission denied.*write permission/)
+                mockRED.subflow.removeSubflow.called.should.be.false()
             })
             it('should reject update-nodes', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1', type: 'inject', name: 'old' })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -35,6 +35,7 @@ describeMain('expertAutomations', () => {
             nodes: {
                 node: sinon.stub(),
                 group: sinon.stub().returns(null),
+                junction: sinon.stub().returns(null),
                 getAllFlowNodes: sinon.stub(),
                 createExportableNodeSet: sinon.stub().callsFake((nodes) => nodes || []),
                 dirty: sinon.stub(),
@@ -470,6 +471,19 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('error').which.match(/member of a group/)
                 mockRED.actions.invoke.called.should.be.false()
             })
+            it('should remove a junction, which is only resolvable via RED.nodes.junction', async () => {
+                const mockJunction = { id: 'j1', type: 'junction', z: 'tab1' }
+                mockRED.nodes.node.withArgs('j1').returns(null)
+                mockRED.nodes.junction = sinon.stub().withArgs('j1').returns(mockJunction)
+                const result = {}
+                await expertAutomations.invokeAction('automation/remove-nodes', {
+                    params: { ids: ['j1'] }
+                }, result)
+                mockRED.view.select.calledWith({ nodes: [mockJunction] }).should.be.true()
+                mockRED.actions.invoke.calledWith('core:delete-selection').should.be.true()
+                result.should.have.property('success', true)
+                result.should.have.property('data').which.deepEqual({ removed: ['j1'], notFound: [] })
+            })
         })
         describe('removeSubflow action', () => {
             beforeEach(() => {
@@ -605,6 +619,19 @@ describeMain('expertAutomations', () => {
                 }, result)
                 const linkArg = mockRED.nodes.addLink.firstCall.args[0]
                 linkArg.should.have.property('sourcePort', 2)
+                result.should.have.property('success', true)
+            })
+            it('should wire a junction, which is only resolvable via RED.nodes.junction', async () => {
+                const junction = { id: 'j1', z: 'tab1', type: 'junction', outputs: 1, dirty: false, changed: false }
+                const target = { id: 'n2', z: 'tab1', type: 'debug' }
+                mockRED.nodes.node.withArgs('j1').returns(null)
+                mockRED.nodes.node.withArgs('n2').returns(target)
+                mockRED.nodes.junction = sinon.stub().withArgs('j1').returns(junction)
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-wires', {
+                    params: { mode: 'add', source: 'j1', target: 'n2' }
+                }, result)
+                mockRED.nodes.addLink.calledOnce.should.be.true()
                 result.should.have.property('success', true)
             })
             it('should throw if source node not found', async () => {
@@ -1338,6 +1365,27 @@ describeMain('expertAutomations', () => {
                 await should(expertAutomations.invokeAction('automation/add-nodes', {
                     params: { nodes: [{ id: 'n1', type: 'unknown', z: 'tab1' }] }
                 }, result)).rejectedWith(/Unknown node type/)
+            })
+            it('should accept a junction node, which has no registered node type definition', async () => {
+                const junctionNode = { id: 'j1', type: 'junction', z: 'tab1', x: 100, y: 200 }
+                mockRED.nodes.getType = sinon.stub().returns(null)
+                mockRED.nodes.workspace = sinon.stub().returns({ id: 'tab1', type: 'tab' })
+                mockRED.nodes.node = sinon.stub().returns(null)
+                mockRED.nodes.junction = sinon.stub()
+                mockRED.nodes.junction.withArgs('j1').onFirstCall().returns(null) // pre-import existence check
+                mockRED.nodes.junction.withArgs('j1').returns(junctionNode) // post-import lookup
+                mockRED.view.importNodes = sinon.stub()
+                mockRED.nodes.dirty = sinon.stub()
+                mockRED.editor = { validateNode: sinon.stub().callsFake(n => { n.valid = true }) }
+                const nodes = [{ id: 'j1', type: 'junction', z: 'tab1', x: 100, y: 200 }]
+                const result = {}
+                await expertAutomations.invokeAction('automation/add-nodes', {
+                    params: { nodes }
+                }, result)
+                mockRED.view.importNodes.calledOnce.should.be.true()
+                result.should.have.property('success', true)
+                result.data[0].should.have.property('id', 'j1')
+                result.data[0].should.have.property('type', 'junction')
             })
             // it('should switch to target tab when nodes target a different workspace', async () => {
             //     mockRED.nodes.getType = sinon.stub().returns({ inputs: 1, outputs: 1, defaults: {} })

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -498,6 +498,15 @@ describeMain('expertAutomations', () => {
                 result.should.have.property('handled', true)
                 result.should.have.property('data').which.deepEqual({ removed: 'sf1', instances: ['i1'] })
             })
+            it('should force an immediate, synchronous repaint rather than a deferred one', async () => {
+                mockRED.nodes.subflow.withArgs('sf1').returns({ id: 'sf1' })
+                mockRED.nodes.filterNodes.withArgs({ type: 'subflow:sf1' }).returns([{ id: 'i1', z: 'tab1' }])
+                const result = {}
+                await expertAutomations.invokeAction('automation/remove-subflow', {
+                    params: { id: 'sf1' }
+                }, result)
+                mockRED.view.redraw.calledWith(true, true).should.be.true()
+            })
             it('should scan all workspaces for instances rather than trust a stale subflow.instances', async () => {
                 // subflow.instances deliberately omitted/stale — the scan must not depend on it.
                 mockRED.nodes.subflow.withArgs('sf1').returns({ id: 'sf1', instances: [] })


### PR DESCRIPTION
## Summary
- Add an `automation/update-tab` action and `updateTab(id, properties)` method to rename a tab or change its enabled/disabled state, info, or env.
- Add an `automation/remove-subflow` action and `removeSubflow(id)` method that deletes a subflow definition together with its internal nodes and every placed instance, delegating to Node-RED's own subflow removal and pushing an undoable history event; blocked when an instance sits on a locked workspace.
- Fix `removeTab` to redraw the canvas after deleting a tab.
- Make `removeNodes` partial: existing nodes are removed and missing ids are reported, instead of failing the whole batch when one id is absent.
- Reject unknown property names on node updates, validated against the node type's declared defaults.
- Force a synchronous, cache-refreshed repaint after subflow removal, so a removed instance doesn't stay visible until an unrelated interaction (e.g. switching tabs) forces a redraw.
- Recognise junction nodes across `addNodes`, `isConfigNode`, `setWires`, `removeNodes`, `updateNode` and `_moveNodeToTab`. Junctions have no registered palette definition, so they live in `RED.nodes.junction` rather than the main node registry; `addNodes` was rejecting them outright with "Unknown node type: junction", and every other lookup would have failed the same way. Added a `_resolveNode` helper that falls back to `RED.nodes.junction`.

## Test plan
- [x] Full unit suite passing (`npm test`)
- [x] Live-validated against a running instance: add subflow, remove subflow, confirm both the definition and its placed instance are gone with no stale canvas state

Closes FlowFuse/engineering#176
Closes FlowFuse/engineering#174
Closes FlowFuse/engineering#177
Closes #378