### PR TITLE
feat: add get-debug-messages automation action

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -34,6 +34,7 @@ const EXPORT_FLOW = 'automation/export-flow'
 const SET_DEPLOY_MODE = 'automation/set-deploy-mode'
 const SHOW_SIDEBAR_PANEL = 'automation/show-sidebar-panel'
 const TOGGLE_SIDEBAR = 'automation/toggle-sidebar'
+const GET_DEBUG_MESSAGES = 'automation/get-debug-messages'
 
 const ALIGNMENT_DIRECTIONS = ['grid', 'left', 'right', 'top', 'bottom', 'middle', 'center']
 const DISTRIBUTE_DIRECTIONS = ['horizontally', 'vertically']
@@ -615,6 +616,34 @@ export class ExpertAutomations extends ExpertActionsInterface {
                 },
                 required: ['side']
             }
+        },
+        [GET_DEBUG_MESSAGES]: {
+            params: {
+                type: 'object',
+                properties: {
+                    count: {
+                        type: 'number',
+                        default: 20,
+                        description: 'Maximum number of debug messages to return. Defaults to 20. The Node-RED debug sidebar itself only ever retains the last 100 messages, so this is capped at 100 regardless of the value provided.'
+                    },
+                    nodeIds: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'Optional. Only include messages sourced from one of these node ids, or from a node nested within one of these ids (e.g. a node inside a subflow instance listed here).'
+                    },
+                    fatal: { type: 'boolean', default: true, description: 'Include "fatal" level messages. Defaults to true.' },
+                    error: { type: 'boolean', default: true, description: 'Include "error" level messages. Defaults to true.' },
+                    warn: { type: 'boolean', default: true, description: 'Include "warn" level messages. Defaults to true.' },
+                    info: { type: 'boolean', default: true, description: 'Include "info" level messages. Defaults to true.' },
+                    debug: { type: 'boolean', default: true, description: 'Include "debug" level messages. Defaults to true.' },
+                    trace: { type: 'boolean', default: true, description: 'Include "trace" level messages. Defaults to true.' },
+                    select: {
+                        type: 'boolean',
+                        default: false,
+                        description: 'If true, also select the source nodes of the returned messages on the canvas. Defaults to false.'
+                    }
+                }
+            }
         }
 
     })
@@ -665,6 +694,68 @@ export class ExpertAutomations extends ExpertActionsInterface {
             this.RED.view.select({ nodes })
         }
         return nodes
+    }
+
+    /**
+     * Get the most recent messages from the Node-RED debug sidebar, optionally filtered by source node id(s) and/or level.
+     * Only ever sees messages received while this editor tab has been open and connected - Node-RED's own debug comms
+     * channel keeps no server-side history, and the sidebar itself only ever retains the last 100 messages.
+     * @param {Object} [params]
+     * @param {number} [params.count] - maximum number of messages to return. Defaults to 20, capped at 100.
+     * @param {string[]} [params.nodeIds] - only include messages sourced from one of these node ids, or nested within one (e.g. inside a subflow instance)
+     * @param {boolean} [params.fatal]
+     * @param {boolean} [params.error]
+     * @param {boolean} [params.warn]
+     * @param {boolean} [params.info]
+     * @param {boolean} [params.debug]
+     * @param {boolean} [params.trace]
+     * @param {boolean} [params.select] - if true, also select the source nodes of the returned messages on the canvas
+     * @returns {Array} formatted debug message entries, oldest first (matching the order shown in the debug sidebar)
+     */
+    getDebugMessages (params) {
+        const {
+            count = 20,
+            nodeIds,
+            fatal = true,
+            error = true,
+            warn = true,
+            info = true,
+            debug = true,
+            trace = true,
+            select = false
+        } = params || {}
+
+        const wantLevels = []
+        if (fatal) wantLevels.push('fatal')
+        if (error) wantLevels.push('error')
+        if (warn) wantLevels.push('warn')
+        if (info) wantLevels.push('info')
+        if (debug) wantLevels.push('debug')
+        if (trace) wantLevels.push('trace')
+
+        const wantNodeIds = Array.isArray(nodeIds) && nodeIds.length > 0 ? new Set(nodeIds) : null
+
+        let entries = this.expertComms.collectDebugLogEntries({ visibleOnly: false })
+            .filter(entry => wantLevels.includes(entry?.level))
+
+        if (wantNodeIds) {
+            entries = entries.filter(entry => {
+                const sourceIds = [entry.source?.id, ...(entry.ancestors || []).map(a => a.id)]
+                return sourceIds.some(id => id && wantNodeIds.has(id))
+            })
+        }
+
+        const maxCount = Math.min(Math.max(Number(count) || 20, 1), 100)
+        const messages = entries.slice(-maxCount)
+
+        if (select) {
+            const sourceIds = [...new Set(messages.map(m => m.source?.id).filter(id => id && this.RED.nodes.node(id)))]
+            if (sourceIds.length > 0) {
+                this.selectNodes(sourceIds)
+            }
+        }
+
+        return messages
     }
 
     /**
@@ -2459,6 +2550,10 @@ export class ExpertAutomations extends ExpertActionsInterface {
             result.success = true
             break
         }
+        case GET_DEBUG_MESSAGES:
+            result.messages = this.getDebugMessages(params)
+            result.success = true
+            break
         default:
             result.handled = false
             result.success = false

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -725,18 +725,9 @@ export class ExpertAutomations extends ExpertActionsInterface {
             select = false
         } = params || {}
 
-        const wantLevels = []
-        if (fatal) wantLevels.push('fatal')
-        if (error) wantLevels.push('error')
-        if (warn) wantLevels.push('warn')
-        if (info) wantLevels.push('info')
-        if (debug) wantLevels.push('debug')
-        if (trace) wantLevels.push('trace')
-
         const wantNodeIds = Array.isArray(nodeIds) && nodeIds.length > 0 ? new Set(nodeIds) : null
 
-        let entries = this.expertComms.collectDebugLogEntries({ visibleOnly: false })
-            .filter(entry => wantLevels.includes(entry?.level))
+        let entries = this.expertComms.collectDebugLogEntries({ visibleOnly: false, fatal, error, warn, info, debug, trace })
 
         if (wantNodeIds) {
             entries = entries.filter(entry => {

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -636,12 +636,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                     warn: { type: 'boolean', default: true, description: 'Include "warn" level messages. Defaults to true.' },
                     info: { type: 'boolean', default: true, description: 'Include "info" level messages. Defaults to true.' },
                     debug: { type: 'boolean', default: true, description: 'Include "debug" level messages. Defaults to true.' },
-                    trace: { type: 'boolean', default: true, description: 'Include "trace" level messages. Defaults to true.' },
-                    select: {
-                        type: 'boolean',
-                        default: false,
-                        description: 'If true, also select the source nodes of the returned messages on the canvas. Defaults to false.'
-                    }
+                    trace: { type: 'boolean', default: true, description: 'Include "trace" level messages. Defaults to true.' }
                 }
             }
         }
@@ -709,7 +704,6 @@ export class ExpertAutomations extends ExpertActionsInterface {
      * @param {boolean} [params.info]
      * @param {boolean} [params.debug]
      * @param {boolean} [params.trace]
-     * @param {boolean} [params.select] - if true, also select the source nodes of the returned messages on the canvas
      * @returns {Array} formatted debug message entries, oldest first (matching the order shown in the debug sidebar)
      */
     getDebugMessages (params) {
@@ -721,8 +715,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
             warn = true,
             info = true,
             debug = true,
-            trace = true,
-            select = false
+            trace = true
         } = params || {}
 
         const wantNodeIds = Array.isArray(nodeIds) && nodeIds.length > 0 ? new Set(nodeIds) : null
@@ -737,16 +730,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
 
         const maxCount = Math.min(Math.max(Number(count) || 20, 1), 100)
-        const messages = entries.slice(-maxCount)
-
-        if (select) {
-            const sourceIds = [...new Set(messages.map(m => m.source?.id).filter(id => id && this.RED.nodes.node(id)))]
-            if (sourceIds.length > 0) {
-                this.selectNodes(sourceIds)
-            }
-        }
-
-        return messages
+        return entries.slice(-maxCount)
     }
 
     /**

--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -424,6 +424,22 @@ export class ExpertComms {
         if (debug) wantLevels.push('debug')
         if (trace) wantLevels.push('trace')
 
+        // first remove class .selected from all entries. It will be re-added once the expert responds with the list uuids it has registered.
+        $('button.ff-expert-debug-context').removeClass('selected')
+
+        const filteredEntries = this.collectDebugLogEntries({ visibleOnly }).filter(entry => wantLevels.includes(entry?.level))
+        this.postReply({ type: 'debug-log-context-add', debugLog: filteredEntries }, event)
+    }
+
+    /**
+     * Scrape and format the debug log entries currently rendered in the Node-RED debug sidebar (oldest first, matching
+     * the order they appear in the sidebar). Shared by the chat "add to context" feature and the automation/get-debug-messages
+     * action - neither mutates selection state here, that's handled by their respective callers.
+     * @param {Object} [options]
+     * @param {boolean} [options.visibleOnly] - only include entries currently visible in the viewport and not hidden by the sidebar's own tab/node filter. Defaults to false.
+     * @returns {Array} formatted debug log entries
+     */
+    collectDebugLogEntries ({ visibleOnly = false } = {}) {
         const isElementInView = (jElement) => {
             if (jElement.length === 0) {
                 return false
@@ -445,12 +461,9 @@ export class ExpertComms {
                 rect.right <= $(window).width()
             )
         }
-        // first remove class .selected from all entries. It will be re-added once the expert responds with the list uuids it has registered.
-        $('button.ff-expert-debug-context').removeClass('selected')
 
-        const filteredEntries = []
+        const entries = []
         // get buttons `.red-ui-debug-content-list button.ff-expert-debug-context` in the debug sidebar
-        // but dont include any with `.hide` on the parent `.red-ui-debug-msg` element, as those are not visible
         $('.red-ui-debug-content-list button.ff-expert-debug-context').each((i, el) => {
             const expertToolButtonEl = $(el)
             const parent = expertToolButtonEl.closest('div.red-ui-debug-msg')
@@ -458,19 +471,13 @@ export class ExpertComms {
                 return // hidden or not visible in the viewport, skip this entry
             }
             const uuid = expertToolButtonEl.attr('data-ff-expert-debug-uuid')
-            if (uuid) {
-                const data = expertToolButtonEl.data('ff-expert-debug-data')
-                if (!data) return
-                const { message, payload } = data
-                const entry = this.formatDebugMessage(uuid, message, payload)
-                const level = entry?.level
-                if (!wantLevels.includes(level)) {
-                    return // not a level we want to include, skip this entry
-                }
-                filteredEntries.push(entry)
-            }
+            if (!uuid) return
+            const data = expertToolButtonEl.data('ff-expert-debug-data')
+            if (!data) return
+            const { message, payload } = data
+            entries.push(this.formatDebugMessage(uuid, message, payload))
         })
-        this.postReply({ type: 'debug-log-context-add', debugLog: filteredEntries }, event)
+        return entries
     }
 
     setNodeRedEventListeners () {

--- a/resources/expertComms.js
+++ b/resources/expertComms.js
@@ -416,6 +416,37 @@ export class ExpertComms {
      */
     handleDebugLogContextGetEntries ({ event, params }) {
         const { visibleOnly = true, fatal = true, error = true, warn = true, info = true, debug = true, trace = true } = params || {}
+
+        // first remove class .selected from all entries. It will be re-added once the expert responds with the list uuids it has registered.
+        $('button.ff-expert-debug-context').removeClass('selected')
+
+        const filteredEntries = this.collectDebugLogEntries({ visibleOnly, fatal, error, warn, info, debug, trace })
+        this.postReply({ type: 'debug-log-context-add', debugLog: filteredEntries }, event)
+    }
+
+    /**
+     * Scrape and format the debug log entries currently rendered in the Node-RED debug sidebar (oldest first, matching
+     * the order they appear in the sidebar), filtered by level. Shared by the chat "add to context" feature and the
+     * automation/get-debug-messages action - neither mutates selection state here, that's handled by their respective callers.
+     * @param {Object} [options]
+     * @param {boolean} [options.visibleOnly] - only include entries currently visible in the viewport and not hidden by the sidebar's own tab/node filter. Defaults to false.
+     * @param {boolean} [options.fatal]
+     * @param {boolean} [options.error]
+     * @param {boolean} [options.warn]
+     * @param {boolean} [options.info]
+     * @param {boolean} [options.debug]
+     * @param {boolean} [options.trace]
+     * @returns {Array} formatted debug log entries, filtered to the requested levels
+     */
+    collectDebugLogEntries ({
+        visibleOnly = false,
+        fatal = true,
+        error = true,
+        warn = true,
+        info = true,
+        debug = true,
+        trace = true
+    } = {}) {
         const wantLevels = []
         if (fatal) wantLevels.push('fatal')
         if (error) wantLevels.push('error')
@@ -424,22 +455,6 @@ export class ExpertComms {
         if (debug) wantLevels.push('debug')
         if (trace) wantLevels.push('trace')
 
-        // first remove class .selected from all entries. It will be re-added once the expert responds with the list uuids it has registered.
-        $('button.ff-expert-debug-context').removeClass('selected')
-
-        const filteredEntries = this.collectDebugLogEntries({ visibleOnly }).filter(entry => wantLevels.includes(entry?.level))
-        this.postReply({ type: 'debug-log-context-add', debugLog: filteredEntries }, event)
-    }
-
-    /**
-     * Scrape and format the debug log entries currently rendered in the Node-RED debug sidebar (oldest first, matching
-     * the order they appear in the sidebar). Shared by the chat "add to context" feature and the automation/get-debug-messages
-     * action - neither mutates selection state here, that's handled by their respective callers.
-     * @param {Object} [options]
-     * @param {boolean} [options.visibleOnly] - only include entries currently visible in the viewport and not hidden by the sidebar's own tab/node filter. Defaults to false.
-     * @returns {Array} formatted debug log entries
-     */
-    collectDebugLogEntries ({ visibleOnly = false } = {}) {
         const isElementInView = (jElement) => {
             if (jElement.length === 0) {
                 return false
@@ -475,7 +490,10 @@ export class ExpertComms {
             const data = expertToolButtonEl.data('ff-expert-debug-data')
             if (!data) return
             const { message, payload } = data
-            entries.push(this.formatDebugMessage(uuid, message, payload))
+            const formatted = this.formatDebugMessage(uuid, message, payload)
+            if (wantLevels.includes(formatted?.level)) {
+                entries.push(formatted)
+            }
         })
         return entries
     }

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -210,7 +210,15 @@ describeMain('expertAutomations', () => {
                     makeEntry('c', 'debug', 'node3')
                 ])
                 const result = expertAutomations.getDebugMessages({ count: 2 })
-                mockExpertComms.collectDebugLogEntries.calledWith({ visibleOnly: false }).should.be.true()
+                mockExpertComms.collectDebugLogEntries.calledWith({
+                    visibleOnly: false,
+                    fatal: true,
+                    error: true,
+                    warn: true,
+                    info: true,
+                    debug: true,
+                    trace: true
+                }).should.be.true()
                 result.map(e => e.uuid).should.deepEqual(['b', 'c'])
             })
             it('should default count to 20 and cap at 100', () => {
@@ -221,13 +229,18 @@ describeMain('expertAutomations', () => {
                 const resultCapped = expertAutomations.getDebugMessages({ count: 500 })
                 resultCapped.length.should.equal(100)
             })
-            it('should filter by level', () => {
-                mockExpertComms.collectDebugLogEntries = sinon.stub().returns([
-                    makeEntry('a', 'error', 'node1'),
-                    makeEntry('b', 'debug', 'node2')
-                ])
-                const result = expertAutomations.getDebugMessages({ error: false })
-                result.map(e => e.uuid).should.deepEqual(['b'])
+            it('should forward level flags to collectDebugLogEntries', () => {
+                mockExpertComms.collectDebugLogEntries = sinon.stub().returns([])
+                expertAutomations.getDebugMessages({ error: false, trace: false })
+                mockExpertComms.collectDebugLogEntries.calledWith({
+                    visibleOnly: false,
+                    fatal: true,
+                    error: false,
+                    warn: true,
+                    info: true,
+                    debug: true,
+                    trace: false
+                }).should.be.true()
             })
             it('should filter by nodeIds, matching source or ancestors', () => {
                 mockExpertComms.collectDebugLogEntries = sinon.stub().returns([

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -123,7 +123,8 @@ describeMain('expertAutomations', () => {
                 'automation/export-flow',
                 'automation/set-deploy-mode',
                 'automation/show-sidebar-panel',
-                'automation/toggle-sidebar'
+                'automation/toggle-sidebar',
+                'automation/get-debug-messages'
             ]
             supportedActions.should.only.have.keys(...expectedKeys)
         })
@@ -191,6 +192,70 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.returns(null)
                 const result = expertAutomations.getNodes('node1', null)
                 should(result).equal(null)
+            })
+        })
+        describe('getDebugMessages', () => {
+            const makeEntry = (uuid, level, sourceId, ancestorIds = []) => ({
+                uuid,
+                level,
+                data: `payload-${uuid}`,
+                source: { id: sourceId },
+                ancestors: ancestorIds.map(id => ({ id }))
+            })
+
+            it('should return entries from expertComms, capped to count', () => {
+                mockExpertComms.collectDebugLogEntries = sinon.stub().returns([
+                    makeEntry('a', 'debug', 'node1'),
+                    makeEntry('b', 'debug', 'node2'),
+                    makeEntry('c', 'debug', 'node3')
+                ])
+                const result = expertAutomations.getDebugMessages({ count: 2 })
+                mockExpertComms.collectDebugLogEntries.calledWith({ visibleOnly: false }).should.be.true()
+                result.map(e => e.uuid).should.deepEqual(['b', 'c'])
+            })
+            it('should default count to 20 and cap at 100', () => {
+                const entries = Array.from({ length: 150 }, (_, i) => makeEntry(`id${i}`, 'debug', 'node1'))
+                mockExpertComms.collectDebugLogEntries = sinon.stub().returns(entries)
+                const resultDefault = expertAutomations.getDebugMessages()
+                resultDefault.length.should.equal(20)
+                const resultCapped = expertAutomations.getDebugMessages({ count: 500 })
+                resultCapped.length.should.equal(100)
+            })
+            it('should filter by level', () => {
+                mockExpertComms.collectDebugLogEntries = sinon.stub().returns([
+                    makeEntry('a', 'error', 'node1'),
+                    makeEntry('b', 'debug', 'node2')
+                ])
+                const result = expertAutomations.getDebugMessages({ error: false })
+                result.map(e => e.uuid).should.deepEqual(['b'])
+            })
+            it('should filter by nodeIds, matching source or ancestors', () => {
+                mockExpertComms.collectDebugLogEntries = sinon.stub().returns([
+                    makeEntry('a', 'debug', 'node1'),
+                    makeEntry('b', 'debug', 'inner-node', ['subflow1']),
+                    makeEntry('c', 'debug', 'node3')
+                ])
+                const result = expertAutomations.getDebugMessages({ nodeIds: ['subflow1'] })
+                result.map(e => e.uuid).should.deepEqual(['b'])
+            })
+            it('should select source nodes when select is true', () => {
+                const mockNode1 = { id: 'node1' }
+                mockRED.nodes.node.withArgs('node1').returns(mockNode1)
+                mockExpertComms.collectDebugLogEntries = sinon.stub().returns([
+                    makeEntry('a', 'debug', 'node1')
+                ])
+                sinon.spy(expertAutomations, 'selectNodes')
+                expertAutomations.getDebugMessages({ select: true })
+                expertAutomations.selectNodes.calledWith(['node1']).should.be.true()
+            })
+            it('should not select when no source nodes resolve', () => {
+                mockRED.nodes.node.returns(null)
+                mockExpertComms.collectDebugLogEntries = sinon.stub().returns([
+                    makeEntry('a', 'debug', 'node1')
+                ])
+                sinon.spy(expertAutomations, 'selectNodes')
+                expertAutomations.getDebugMessages({ select: true })
+                expertAutomations.selectNodes.called.should.be.false()
             })
         })
         describe('editNode', () => {
@@ -302,6 +367,27 @@ describeMain('expertAutomations', () => {
                 await expertAutomations.invokeAction('automation/get-nodes', { params: { id: 'node1' } }, result)
                 result.should.have.property('success', false)
                 result.should.have.property('error')
+            })
+        })
+        describe('getDebugMessages action', () => {
+            it('should invoke action and return messages', async () => {
+                mockExpertComms.collectDebugLogEntries = sinon.stub().returns([
+                    { uuid: 'a', level: 'debug', source: { id: 'node1' }, ancestors: [] }
+                ])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-debug-messages', { params: { count: 5 } }, result)
+                result.should.have.property('messages').and.deepEqual([
+                    { uuid: 'a', level: 'debug', source: { id: 'node1' }, ancestors: [] }
+                ])
+                result.should.have.property('success', true)
+                result.should.have.property('handled', true)
+            })
+            it('should work with no params provided', async () => {
+                mockExpertComms.collectDebugLogEntries = sinon.stub().returns([])
+                const result = {}
+                await expertAutomations.invokeAction('automation/get-debug-messages', {}, result)
+                result.should.have.property('messages').and.deepEqual([])
+                result.should.have.property('success', true)
             })
         })
         describe('editNode action', () => {

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -251,25 +251,6 @@ describeMain('expertAutomations', () => {
                 const result = expertAutomations.getDebugMessages({ nodeIds: ['subflow1'] })
                 result.map(e => e.uuid).should.deepEqual(['b'])
             })
-            it('should select source nodes when select is true', () => {
-                const mockNode1 = { id: 'node1' }
-                mockRED.nodes.node.withArgs('node1').returns(mockNode1)
-                mockExpertComms.collectDebugLogEntries = sinon.stub().returns([
-                    makeEntry('a', 'debug', 'node1')
-                ])
-                sinon.spy(expertAutomations, 'selectNodes')
-                expertAutomations.getDebugMessages({ select: true })
-                expertAutomations.selectNodes.calledWith(['node1']).should.be.true()
-            })
-            it('should not select when no source nodes resolve', () => {
-                mockRED.nodes.node.returns(null)
-                mockExpertComms.collectDebugLogEntries = sinon.stub().returns([
-                    makeEntry('a', 'debug', 'node1')
-                ])
-                sinon.spy(expertAutomations, 'selectNodes')
-                expertAutomations.getDebugMessages({ select: true })
-                expertAutomations.selectNodes.called.should.be.false()
-            })
         })
         describe('editNode', () => {
             it('should edit a node when in default state', () => {


### PR DESCRIPTION
## What

Adds a new `automation/get-debug-messages` action that returns the most recent messages from the Node-RED debug sidebar, optionally filtered by level and by source node id(s).

## Why

The Expert has no way to read what's in the debug sidebar today. The only existing mechanism (`debug-log-context-get-entries`) is wired as a raw postMessage command for the "add to chat context" UI feature, not a schema-validated `automation/*` action.

## How

- Extracts the DOM-scraping logic already used by `handleDebugLogContextGetEntries` into a shared `collectDebugLogEntries({ visibleOnly })` method on `ExpertComms`, reused by both the existing chat-context command and the new action.
- Adds `getDebugMessages(params)` on `ExpertAutomations`: filters `collectDebugLogEntries` output by level (`fatal/error/warn/info/debug/trace`, all default true) and by `nodeIds` (matching either the message's source node or any ancestor, e.g. a subflow instance), then takes the last `count` entries (default 20, hard-capped at 100 since that's all the sidebar itself retains).
- Registers the action and its params schema in the `actions` map, and dispatches it in `invokeAction`.

## Tests

Adds unit coverage for count default/capping, level filtering, `nodeIds` filtering (direct source and ancestor match), and the dispatched action. Full suite: 472 passing.

Closes #386

