### PR TITLE
feat(automations): apply set-wires as a batch with partial success

### DIFF
--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -367,12 +367,22 @@ export class ExpertAutomations extends ExpertActionsInterface {
             params: {
                 type: 'object',
                 properties: {
-                    mode: { type: 'string', enum: ['add', 'remove'], description: 'Whether to add or remove a wire' },
-                    source: { type: 'string', description: 'Source node ID' },
-                    output: { type: 'number', description: 'Source output port index (0-based)' },
-                    target: { type: 'string', description: 'Target node ID' }
+                    mode: { type: 'string', enum: ['add', 'remove'], description: 'Whether to add or remove every wire in the batch' },
+                    wires: {
+                        type: 'array',
+                        description: 'The wires to add or remove, applied in order',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                source: { type: 'string', description: 'Source node ID' },
+                                output: { type: 'number', description: 'Source output port index (0-based, defaults to 0)' },
+                                target: { type: 'string', description: 'Target node ID' }
+                            },
+                            required: ['source', 'target']
+                        }
+                    }
                 },
-                required: ['mode', 'source', 'target']
+                required: ['mode', 'wires']
             }
         },
         [SET_LINKS]: {
@@ -1559,14 +1569,16 @@ export class ExpertAutomations extends ExpertActionsInterface {
     }
 
     /**
-     * Add or remove a single wire between two nodes.
-     * @param {object} params
-     * @param {'add'|'remove'} params.mode
-     * @param {string} params.source - Source node ID
-     * @param {number} [params.output] - Source output port index (0-based, defaults to 0)
-     * @param {string} params.target - Target node ID
+     * Add or remove a single wire between two nodes. Throws on any validation failure.
+     * Records the change on the editor history but does not repaint — the caller repaints
+     * once after a batch (see setWires).
+     * @param {object} wire
+     * @param {'add'|'remove'} wire.mode
+     * @param {string} wire.source - Source node ID
+     * @param {number} [wire.output] - Source output port index (0-based, defaults to 0)
+     * @param {string} wire.target - Target node ID
      */
-    setWires ({ mode, source, output, target }) {
+    _applyWire ({ mode, source, output, target }) {
         if (source === target) throw new Error('Cannot wire a node to itself')
         const sourceNode = this._resolveNode(source)
         if (!sourceNode) throw new Error(`Source node ${source} not found`)
@@ -1621,8 +1633,44 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
         sourceNode.dirty = true
         this.RED.nodes.dirty(true)
-        this.RED.view.updateActive()
-        this.RED.view.redraw()
+    }
+
+    /**
+     * Add or remove one or more wires in a single call, all with the same mode. Each wire is
+     * applied independently: one that fails validation is reported in `failed` and does not
+     * stop the rest (partial success, mirroring removeNodes). The canvas is repainted once,
+     * after the batch.
+     * @param {object} params
+     * @param {'add'|'remove'} params.mode - whether to add or remove every wire in the batch
+     * @param {Array<{source: string, output?: number, target: string}>} [params.wires] - the wires to apply
+     * @param {string} [params.source] - single-wire form (used only when `wires` is absent)
+     * @param {number} [params.output] - single-wire form: source output port index (0-based)
+     * @param {string} [params.target] - single-wire form: target node ID
+     * @returns {{mode: string, applied: Array<object>, failed: Array<object>}}
+     */
+    setWires ({ mode, wires, source, output, target }) {
+        // Write permission is an action-level gate (a denial fails every wire identically), so
+        // check it once up front and reject the whole call rather than reporting it per wire.
+        this._assertWritePermission()
+        // Accept either a `wires` array or the legacy single-wire fields.
+        const batch = Array.isArray(wires) ? wires : [{ source, output, target }]
+        if (batch.length === 0) throw new Error('wires array must not be empty')
+        const applied = []
+        const failed = []
+        for (const wire of batch) {
+            const summary = { source: wire.source, output: wire.output ?? 0, target: wire.target }
+            try {
+                this._applyWire({ mode, source: wire.source, output: wire.output, target: wire.target })
+                applied.push(summary)
+            } catch (err) {
+                failed.push({ ...summary, error: err.message })
+            }
+        }
+        if (applied.length > 0) {
+            this.RED.view.updateActive()
+            this.RED.view.redraw()
+        }
+        return { mode, applied, failed }
     }
 
     /**
@@ -1967,21 +2015,21 @@ export class ExpertAutomations extends ExpertActionsInterface {
             //    so failures are visible by default (the caller can rewire it to a notification,
             //    a log, or further handling).
             for (const w of entryInbound) {
-                this.setWires({ mode: 'remove', source: w.source.id, output: w.sourcePort, target: entryNode.id })
-                this.setWires({ mode: 'add', source: w.source.id, output: w.sourcePort, target: linkCallId })
+                this._applyWire({ mode: 'remove', source: w.source.id, output: w.sourcePort, target: entryNode.id })
+                this._applyWire({ mode: 'add', source: w.source.id, output: w.sourcePort, target: linkCallId })
             }
-            this.setWires({ mode: 'add', source: linkCallId, output: 0, target: switchId })
-            this.setWires({ mode: 'add', source: switchId, output: 0, target: debugId })
+            this._applyWire({ mode: 'add', source: linkCallId, output: 0, target: switchId })
+            this._applyWire({ mode: 'add', source: switchId, output: 0, target: debugId })
             for (const w of exitOutbound) {
-                this.setWires({ mode: 'remove', source: exitNode.id, output: w.sourcePort, target: w.target.id })
-                this.setWires({ mode: 'add', source: switchId, output: 1, target: w.target.id })
+                this._applyWire({ mode: 'remove', source: exitNode.id, output: w.sourcePort, target: w.target.id })
+                this._applyWire({ mode: 'add', source: switchId, output: 1, target: w.target.id })
             }
 
             // 3. Wire the body (link in -> entry, exit -> link out), route caught body
             //    errors back through the link out, and point the link call at the link in.
-            this.setWires({ mode: 'add', source: linkInId, output: 0, target: entryNode.id })
-            this.setWires({ mode: 'add', source: exitNode.id, output: exitPort, target: linkOutId })
-            this.setWires({ mode: 'add', source: catchId, output: 0, target: linkOutId })
+            this._applyWire({ mode: 'add', source: linkInId, output: 0, target: entryNode.id })
+            this._applyWire({ mode: 'add', source: exitNode.id, output: exitPort, target: linkOutId })
+            this._applyWire({ mode: 'add', source: catchId, output: 0, target: linkOutId })
             this.setLinks({ mode: 'add', source: linkCallId, target: linkInId })
 
             // 4. Free the body nodes from any group they already belong to before re-grouping.
@@ -2315,11 +2363,11 @@ export class ExpertAutomations extends ExpertActionsInterface {
         }
             break
 
-        case SET_WIRES:
-            this.setWires(params)
-            result.data = { mode: params.mode, source: params.source, output: params.output, target: params.target }
+        case SET_WIRES: {
+            result.data = this.setWires(params)
             result.success = true
             break
+        }
 
         case SET_LINKS:
             this.setLinks(params)

--- a/resources/expertAutomations.js
+++ b/resources/expertAutomations.js
@@ -375,7 +375,7 @@ export class ExpertAutomations extends ExpertActionsInterface {
                             type: 'object',
                             properties: {
                                 source: { type: 'string', description: 'Source node ID' },
-                                output: { type: 'number', description: 'Source output port index (0-based, defaults to 0)' },
+                                output: { type: 'number', default: 0, description: 'Source output port index (0-based, defaults to 0)' },
                                 target: { type: 'string', description: 'Target node ID' }
                             },
                             required: ['source', 'target']

--- a/test/unit/resources/expertAutomations.test.js
+++ b/test/unit/resources/expertAutomations.test.js
@@ -647,6 +647,20 @@ describeMain('expertAutomations', () => {
                     isLocked: sinon.stub().returns(false)
                 }
             })
+            // A wire that fails validation is reported in `failed` rather than thrown: the batch
+            // still succeeds with partial results, mirroring removeNodes. Nothing is applied and
+            // the canvas is not repainted when the single wire fails.
+            const expectWireFailure = async (params, errorRegex) => {
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-wires', { params }, result)
+                result.should.have.property('success', true)
+                result.data.applied.should.be.empty()
+                result.data.failed.should.have.lengthOf(1)
+                result.data.failed[0].error.should.match(errorRegex)
+                mockRED.nodes.addLink.called.should.be.false()
+                mockRED.view.redraw.called.should.be.false()
+                return result
+            }
             it('should add a wire between two nodes with history', async () => {
                 const source = { id: 'n1', z: 'tab1', outputs: 1, dirty: false, changed: false }
                 const target = { id: 'n2', z: 'tab1', type: 'debug' }
@@ -654,7 +668,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('n2').returns(target)
                 const result = {}
                 await expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', source: 'n1', target: 'n2' }
+                    params: { mode: 'add', wires: [{ source: 'n1', target: 'n2' }] }
                 }, result)
                 mockRED.nodes.addLink.calledOnce.should.be.true()
                 mockRED.history.push.calledOnce.should.be.true()
@@ -667,7 +681,67 @@ describeMain('expertAutomations', () => {
                 mockRED.view.updateActive.calledOnce.should.be.true()
                 mockRED.view.redraw.calledOnce.should.be.true()
                 result.should.have.property('success', true)
-                result.should.have.property('data').which.deepEqual({ mode: 'add', source: 'n1', output: undefined, target: 'n2' })
+                result.should.have.property('data').which.deepEqual({ mode: 'add', applied: [{ source: 'n1', output: 0, target: 'n2' }], failed: [] })
+            })
+            it('should accept the legacy single-wire shape (no wires array)', async () => {
+                const source = { id: 'n1', z: 'tab1', outputs: 1, dirty: false, changed: false }
+                const target = { id: 'n2', z: 'tab1', type: 'debug' }
+                mockRED.nodes.node.withArgs('n1').returns(source)
+                mockRED.nodes.node.withArgs('n2').returns(target)
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-wires', {
+                    params: { mode: 'add', source: 'n1', target: 'n2' }
+                }, result)
+                mockRED.nodes.addLink.calledOnce.should.be.true()
+                result.should.have.property('success', true)
+                result.data.applied.should.deepEqual([{ source: 'n1', output: 0, target: 'n2' }])
+            })
+            it('should add multiple wires in one batch, repainting once', async () => {
+                const source = { id: 'n1', z: 'tab1', outputs: 2, dirty: false, changed: false }
+                const t1 = { id: 'n2', z: 'tab1', type: 'debug' }
+                const t2 = { id: 'n3', z: 'tab1', type: 'debug' }
+                mockRED.nodes.node.withArgs('n1').returns(source)
+                mockRED.nodes.node.withArgs('n2').returns(t1)
+                mockRED.nodes.node.withArgs('n3').returns(t2)
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-wires', {
+                    params: {
+                        mode: 'add',
+                        wires: [
+                            { source: 'n1', output: 0, target: 'n2' },
+                            { source: 'n1', output: 1, target: 'n3' }
+                        ]
+                    }
+                }, result)
+                mockRED.nodes.addLink.calledTwice.should.be.true()
+                mockRED.view.redraw.calledOnce.should.be.true('the canvas repaints once per batch, not once per wire')
+                result.data.applied.should.have.lengthOf(2)
+                result.data.failed.should.be.empty()
+                result.should.have.property('success', true)
+            })
+            it('should apply the valid wires and report the bad ones in a mixed batch', async () => {
+                const source = { id: 'n1', z: 'tab1', outputs: 1, dirty: false, changed: false }
+                const good = { id: 'n2', z: 'tab1', type: 'debug' }
+                mockRED.nodes.node.withArgs('n1').returns(source)
+                mockRED.nodes.node.withArgs('n2').returns(good)
+                mockRED.nodes.node.withArgs('missing').returns(null)
+                const result = {}
+                await expertAutomations.invokeAction('automation/set-wires', {
+                    params: {
+                        mode: 'add',
+                        wires: [
+                            { source: 'n1', target: 'n2' },
+                            { source: 'n1', target: 'missing' }
+                        ]
+                    }
+                }, result)
+                mockRED.nodes.addLink.calledOnce.should.be.true('only the valid wire is added')
+                mockRED.view.redraw.calledOnce.should.be.true()
+                result.should.have.property('success', true)
+                result.data.applied.should.deepEqual([{ source: 'n1', output: 0, target: 'n2' }])
+                result.data.failed.should.have.lengthOf(1)
+                result.data.failed[0].should.have.property('target', 'missing')
+                result.data.failed[0].error.should.match(/Target node missing not found/)
             })
             it('should remove a wire with history', async () => {
                 const source = { id: 'n1', z: 'tab1', outputs: 1, dirty: false, changed: false }
@@ -678,7 +752,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.getNodeLinks.returns([existingLink])
                 const result = {}
                 await expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'remove', source: 'n1', target: 'n2' }
+                    params: { mode: 'remove', wires: [{ source: 'n1', target: 'n2' }] }
                 }, result)
                 mockRED.nodes.removeLink.calledWith(existingLink).should.be.true()
                 mockRED.history.push.calledOnce.should.be.true()
@@ -687,6 +761,7 @@ describeMain('expertAutomations', () => {
                 historyArg.should.have.property('links').which.is.an.Array().with.lengthOf(1)
                 source.changed.should.be.false('wiring should not set node.changed (per NR convention)')
                 result.should.have.property('success', true)
+                result.data.applied.should.deepEqual([{ source: 'n1', output: 0, target: 'n2' }])
             })
             it('should use non-zero output port', async () => {
                 const source = { id: 'n1', z: 'tab1', outputs: 3, dirty: false, changed: false }
@@ -695,7 +770,7 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.node.withArgs('n2').returns(target)
                 const result = {}
                 await expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', source: 'n1', output: 2, target: 'n2' }
+                    params: { mode: 'add', wires: [{ source: 'n1', output: 2, target: 'n2' }] }
                 }, result)
                 const linkArg = mockRED.nodes.addLink.firstCall.args[0]
                 linkArg.should.have.property('sourcePort', 2)
@@ -709,76 +784,52 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.junction = sinon.stub().withArgs('j1').returns(junction)
                 const result = {}
                 await expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', source: 'j1', target: 'n2' }
+                    params: { mode: 'add', wires: [{ source: 'j1', target: 'n2' }] }
                 }, result)
                 mockRED.nodes.addLink.calledOnce.should.be.true()
                 result.should.have.property('success', true)
             })
-            it('should throw if source node not found', async () => {
+            it('reports a failure if source node not found', async () => {
                 mockRED.nodes.node.returns(null)
-                const result = {}
-                await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', source: 'missing', target: 'n2' }
-                }, result)).rejectedWith(/Source node missing not found/)
+                await expectWireFailure({ mode: 'add', wires: [{ source: 'missing', target: 'n2' }] }, /Source node missing not found/)
             })
-            it('should throw if target node not found', async () => {
+            it('reports a failure if target node not found', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1', outputs: 1 })
                 mockRED.nodes.node.withArgs('n2').returns(null)
-                const result = {}
-                await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', source: 'n1', target: 'n2' }
-                }, result)).rejectedWith(/Target node n2 not found/)
+                await expectWireFailure({ mode: 'add', wires: [{ source: 'n1', target: 'n2' }] }, /Target node n2 not found/)
             })
-            it('should throw if wiring a node to itself', async () => {
+            it('reports a failure if wiring a node to itself', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1', outputs: 1 })
-                const result = {}
-                await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', source: 'n1', target: 'n1' }
-                }, result)).rejectedWith(/Cannot wire a node to itself/)
+                await expectWireFailure({ mode: 'add', wires: [{ source: 'n1', target: 'n1' }] }, /Cannot wire a node to itself/)
             })
-            it('should throw if source and target are on different tabs', async () => {
+            it('reports a failure if source and target are on different tabs', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1', outputs: 1 })
                 mockRED.nodes.node.withArgs('n2').returns({ id: 'n2', z: 'tab2', type: 'debug' })
-                const result = {}
-                await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', source: 'n1', target: 'n2' }
-                }, result)).rejectedWith(/Source and target nodes must be on the same tab/)
+                await expectWireFailure({ mode: 'add', wires: [{ source: 'n1', target: 'n2' }] }, /Source and target nodes must be on the same tab/)
             })
-            it('should throw if workspace is locked', async () => {
+            it('reports a failure if workspace is locked', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1', outputs: 1 })
                 mockRED.nodes.node.withArgs('n2').returns({ id: 'n2', z: 'tab1', type: 'debug' })
                 mockRED.workspaces.isLocked.withArgs('tab1').returns(true)
-                const result = {}
-                await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', source: 'n1', target: 'n2' }
-                }, result)).rejectedWith(/Workspace tab1 is locked/)
+                await expectWireFailure({ mode: 'add', wires: [{ source: 'n1', target: 'n2' }] }, /Workspace tab1 is locked/)
             })
-            it('should throw if source output port does not exist', async () => {
+            it('reports a failure if source output port does not exist', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1', outputs: 1 })
                 mockRED.nodes.node.withArgs('n2').returns({ id: 'n2', z: 'tab1', type: 'debug' })
-                const result = {}
-                await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', source: 'n1', output: 5, target: 'n2' }
-                }, result)).rejectedWith(/does not have output port 5/)
+                await expectWireFailure({ mode: 'add', wires: [{ source: 'n1', output: 5, target: 'n2' }] }, /does not have output port 5/)
             })
-            it('should throw if source node has no outputs', async () => {
+            it('reports a failure if source node has no outputs', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1', outputs: 0 })
                 mockRED.nodes.node.withArgs('n2').returns({ id: 'n2', z: 'tab1', type: 'debug' })
-                const result = {}
-                await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', source: 'n1', target: 'n2' }
-                }, result)).rejectedWith(/does not have output port 0/)
+                await expectWireFailure({ mode: 'add', wires: [{ source: 'n1', target: 'n2' }] }, /does not have output port 0/)
             })
-            it('should throw if target node does not accept inputs', async () => {
+            it('reports a failure if target node does not accept inputs', async () => {
                 mockRED.nodes.node.withArgs('n1').returns({ id: 'n1', z: 'tab1', outputs: 1 })
                 mockRED.nodes.node.withArgs('n2').returns({ id: 'n2', z: 'tab1', type: 'inject' })
                 mockRED.nodes.getType.withArgs('inject').returns({ inputs: 0, outputs: 1 })
-                const result = {}
-                await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', source: 'n1', target: 'n2' }
-                }, result)).rejectedWith(/does not accept inputs/)
+                await expectWireFailure({ mode: 'add', wires: [{ source: 'n1', target: 'n2' }] }, /does not accept inputs/)
             })
-            it('should throw if adding a wire that already exists', async () => {
+            it('reports a failure if adding a wire that already exists', async () => {
                 const source = { id: 'n1', z: 'tab1', outputs: 1 }
                 const target = { id: 'n2', z: 'tab1', type: 'debug' }
                 mockRED.nodes.node.withArgs('n1').returns(source)
@@ -786,21 +837,15 @@ describeMain('expertAutomations', () => {
                 mockRED.nodes.getNodeLinks.returns([
                     { source: { id: 'n1' }, sourcePort: 0, target: { id: 'n2' } }
                 ])
-                const result = {}
-                await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'add', source: 'n1', target: 'n2' }
-                }, result)).rejectedWith(/Wire already exists from n1 port 0 to n2/)
+                await expectWireFailure({ mode: 'add', wires: [{ source: 'n1', target: 'n2' }] }, /Wire already exists from n1 port 0 to n2/)
             })
-            it('should throw if removing a wire that does not exist', async () => {
+            it('reports a failure if removing a wire that does not exist', async () => {
                 const source = { id: 'n1', z: 'tab1', outputs: 1 }
                 const target = { id: 'n2', z: 'tab1', type: 'debug' }
                 mockRED.nodes.node.withArgs('n1').returns(source)
                 mockRED.nodes.node.withArgs('n2').returns(target)
                 mockRED.nodes.getNodeLinks.returns([])
-                const result = {}
-                await should(expertAutomations.invokeAction('automation/set-wires', {
-                    params: { mode: 'remove', source: 'n1', output: 0, target: 'n2' }
-                }, result)).rejectedWith(/Wire not found from n1 port 0 to n2/)
+                await expectWireFailure({ mode: 'remove', wires: [{ source: 'n1', output: 0, target: 'n2' }] }, /Wire not found from n1 port 0 to n2/)
             })
         })
         describe('setLinks action', () => {
@@ -1033,9 +1078,9 @@ describeMain('expertAutomations', () => {
                 // pushes a 'move' event for the body, and pops back to the snapshot on
                 // failure. Stub all three so the orchestration tests run.
                 mockRED.history = { depth: sinon.stub().returns(0), pop: sinon.stub(), push: sinon.stub() }
-                // Orchestration is tested here; addNodes/setWires/setLinks have their own tests.
+                // Orchestration is tested here; addNodes/_applyWire/setLinks have their own tests.
                 sinon.stub(expertAutomations, 'addNodes')
-                sinon.stub(expertAutomations, 'setWires')
+                sinon.stub(expertAutomations, '_applyWire')
                 sinon.stub(expertAutomations, 'setLinks')
                 sinon.stub(expertAutomations, 'createGroup')
                 // Detaching a body node from its original group is exercised through updateGroup(remove);
@@ -1072,7 +1117,7 @@ describeMain('expertAutomations', () => {
                 return { inject, fn, dbg }
             }
 
-            it('wraps a single node, reusing addNodes/setWires/setLinks/createGroup', () => {
+            it('wraps a single node, reusing addNodes/_applyWire/setLinks/createGroup', () => {
                 setupSingleNode()
                 const data = expertAutomations.createSubroutine({ ids: ['f1'], name: 'My Sub' })
 
@@ -1099,9 +1144,9 @@ describeMain('expertAutomations', () => {
                 errCatch.scope.should.equal('group')
                 errDebug.id.should.equal(data.debugId)
 
-                // 2. wiring via setWires: remove inject->f1 / f1->dbg, then route through
+                // 2. wiring via _applyWire: remove inject->f1 / f1->dbg, then route through
                 //    the link call, the error switch and the group catch
-                const wireCalls = expertAutomations.setWires.getCalls().map(c => c.args[0])
+                const wireCalls = expertAutomations._applyWire.getCalls().map(c => c.args[0])
                 wireCalls.should.matchAny(w => w.mode === 'remove' && w.source === 'inj' && w.target === 'f1')
                 wireCalls.should.matchAny(w => w.mode === 'remove' && w.source === 'f1' && w.target === 'dbg')
                 wireCalls.should.matchAny(w => w.mode === 'add' && w.source === 'inj' && w.target === data.linkCallId)
@@ -1187,7 +1232,7 @@ describeMain('expertAutomations', () => {
                 data.entryId.should.equal('n1')
                 data.exitId.should.equal('n2')
                 // only the two external wires are removed; the internal n1 -> n2 is untouched
-                const removes = expertAutomations.setWires.getCalls().map(c => c.args[0]).filter(w => w.mode === 'remove')
+                const removes = expertAutomations._applyWire.getCalls().map(c => c.args[0]).filter(w => w.mode === 'remove')
                 removes.should.have.lengthOf(2)
                 removes.should.matchAny(w => w.source === 'up' && w.target === 'n1')
                 removes.should.matchAny(w => w.source === 'n2' && w.target === 'down')


### PR DESCRIPTION
## Summary

The `automation/set-wires` action now accepts a batch of wires in a single call and applies each connection independently, instead of connecting one wire per call. This removes the round-trip-per-wire cost when wiring up a flow.

## What changed

The action payload gains a `wires` array, each entry being `{ source, output?, target }`, with a single top-level `mode` (`add` or `remove`) shared by every wire in the batch. The single-wire payload shape is still accepted, so existing callers keep working.

Each wire is applied on its own: a wire that fails validation is recorded rather than aborting the batch. The result reports `{ mode, applied, failed }`, where `failed` entries carry the wire summary plus the error message. Write permission is checked once up front, so a permission failure still rejects the whole call.

Internally the per-wire validation and mutation moved into an apply that throws on failure. The batch loop turns those throws into `failed` entries, and the subroutine builder reuses the same apply so its rollback-on-throw behaviour is unchanged. The canvas is repainted once after the batch rather than per wire.

## Testing

`npm test` (475 passing). Added coverage for batches, mixed valid/invalid batches, the legacy single-wire shape, empty input, and the up-front permission check. Validated end to end against a running instance: a five-wire add applied all five with an empty `failed` list.